### PR TITLE
Update v4.0 schemas for a few issues found in schema linting

### DIFF
--- a/touch-adaptation-kit/schemas/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/context/v4.0/context.json
@@ -1,163 +1,163 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "AllowedStateValues": {
-      "examples": [
-        {},
-        {
-          "inventorySlotForegroundImage": [
-            "InventoryForegroundFireballSpell",
-            "InventoryForegroundLightningBoltSpell"
-          ],
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          }
-        }
-      ],
-      "title": "Touch Bundle Allowed State Values",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/StateType"
-              }
-            },
-            {
-              "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
-            }
-          ]
-        }
-      },
-      "description": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
-      "type": "object",
-      "markdownDescription": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
-      "additionalProperties": false
-    },
-    "State": {
-      "examples": [
-        {},
-        {
-          "inventorySlotBackgroundImage": "InventoryBackground",
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground"
-        }
-      ],
-      "title": "Touch Bundle State",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "description": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
-      "type": "object",
-      "markdownDescription": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
-      "additionalProperties": false
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/$defs/joystickAssetName"
-                  }
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Touch Adaptation Bundle Context Schema",
+    "description": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+    "markdownDescription": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "Touch Bundle Allowed State Values",
+            "description": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
+            "markdownDescription": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
                 }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "Definable Types",
+            "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+            "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "Definitions",
+            "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+            "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "Touch Bundle State",
+            "description": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
+            "markdownDescription": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "Touch Bundle State Item",
+            "description": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
+            "markdownDescription": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "Styles",
+            "description": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+            "markdownDescription": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+            "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles"
         }
-      ],
-      "title": "Definitions",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/ContextDefinableType"
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
         }
-      },
-      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "type": "object",
-      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "additionalProperties": false
     },
-    "StateType": {
-      "markdownDescription": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "description": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "title": "Touch Bundle State Item"
-    },
-    "ContextDefinableType": {
-      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
-      "title": "Definable Types"
-    },
-    "ContextStyles": {
-      "markdownDescription": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
-      "description": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "title": "Styles"
-    }
-  },
-  "description": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
-  "properties": {
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    },
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "$schema": {
-      "type": "string"
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
-  "title": "Touch Adaptation Bundle Context Schema",
-  "markdownDescription": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases."
+    "additionalProperties": false
 }

--- a/touch-adaptation-kit/schemas/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/context/v4.0/context.json
@@ -1,116 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    }
-  },
-  "title": "Touch Adaptation Bundle Context Schema",
-  "description": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
-  "markdownDescription": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "type": "object",
   "$defs": {
-    "State": {
-      "markdownDescription": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
-      "additionalProperties": false,
-      "description": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
-      "title": "Touch Bundle State",
-      "examples": [
-        {},
-        {
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground",
-          "inventorySlotBackgroundImage": "InventoryBackground"
-        }
-      ],
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "type": "object"
-    },
-    "StateType": {
-      "description": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "title": "Touch Bundle State Item",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "markdownDescription": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically."
-    },
-    "ContextStyles": {
-      "description": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
-      "title": "Styles",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "markdownDescription": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file."
-    },
-    "ContextDefinableType": {
-      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "title": "Definable Types",
-      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information"
-    },
     "AllowedStateValues": {
-      "markdownDescription": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
-      "additionalProperties": false,
-      "description": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
-      "title": "Touch Bundle Allowed State Values",
       "examples": [
         {},
         {
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          },
           "inventorySlotForegroundImage": [
             "InventoryForegroundFireballSpell",
             "InventoryForegroundLightningBoltSpell"
-          ]
+          ],
+          "inventorySlotBackgroundImage": {
+            "$ref": "#/definitions/AllowedBackgroundImages"
+          }
         }
       ],
+      "title": "Touch Bundle Allowed State Values",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "anyOf": [
@@ -126,13 +31,32 @@
           ]
         }
       },
-      "type": "object"
+      "description": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
+      "type": "object",
+      "markdownDescription": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
+      "additionalProperties": false
+    },
+    "State": {
+      "examples": [
+        {},
+        {
+          "inventorySlotBackgroundImage": "InventoryBackground",
+          "inventorySlotEnabled": true,
+          "inventorySlotForegroundImage": "InventoryForeground"
+        }
+      ],
+      "title": "Touch Bundle State",
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/StateType"
+        }
+      },
+      "description": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
+      "type": "object",
+      "markdownDescription": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
+      "additionalProperties": false
     },
     "Definitions": {
-      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "additionalProperties": false,
-      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "title": "Definitions",
       "examples": [
         {},
         {
@@ -151,13 +75,89 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "Definitions",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/ContextDefinableType"
         }
       },
-      "type": "object"
+      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "type": "object",
+      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "additionalProperties": false
+    },
+    "StateType": {
+      "markdownDescription": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ],
+      "description": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
+      "examples": [
+        "customAssetName",
+        false,
+        true,
+        1,
+        0
+      ],
+      "title": "Touch Bundle State Item"
+    },
+    "ContextDefinableType": {
+      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "anyOf": [
+        {
+          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+        },
+        {
+          "$ref": "#/$defs/StateType"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StateType"
+          }
+        }
+      ],
+      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "title": "Definable Types"
+    },
+    "ContextStyles": {
+      "markdownDescription": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "description": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
+      "title": "Styles"
     }
   },
-  "type": "object"
+  "description": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+  "properties": {
+    "state": {
+      "$ref": "#/$defs/State"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/ContextStyles"
+    },
+    "allowedStateValues": {
+      "$ref": "#/$defs/AllowedStateValues"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "title": "Touch Adaptation Bundle Context Schema",
+  "markdownDescription": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases."
 }

--- a/touch-adaptation-kit/schemas/ja-JP/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/ja-JP/context/v4.0/context.json
@@ -1,116 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    }
-  },
-  "title": "タッチ適応バンドルのコンテキスト スキーマ",
-  "description": "タッチ適用バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
-  "markdownDescription": "タッチ適用バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "type": "object",
   "$defs": {
-    "State": {
-      "markdownDescription": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
-      "additionalProperties": false,
-      "description": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
-      "title": "タッチ バンドルの状態",
-      "examples": [
-        {},
-        {
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground",
-          "inventorySlotBackgroundImage": "InventoryBackground"
-        }
-      ],
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "type": "object"
-    },
-    "StateType": {
-      "description": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "title": "タッチ バンドルの状態アイテム",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "markdownDescription": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。"
-    },
-    "ContextStyles": {
-      "description": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
-      "title": "スタイル",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "markdownDescription": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。"
-    },
-    "ContextDefinableType": {
-      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "title": "定義可能な型",
-      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください"
-    },
     "AllowedStateValues": {
-      "markdownDescription": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
-      "additionalProperties": false,
-      "description": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
-      "title": "タッチ バンドルの許可状態値",
       "examples": [
         {},
         {
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          },
           "inventorySlotForegroundImage": [
             "InventoryForegroundFireballSpell",
             "InventoryForegroundLightningBoltSpell"
-          ]
+          ],
+          "inventorySlotBackgroundImage": {
+            "$ref": "#/definitions/AllowedBackgroundImages"
+          }
         }
       ],
+      "title": "タッチ バンドルの許可状態値",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "anyOf": [
@@ -126,13 +31,32 @@
           ]
         }
       },
-      "type": "object"
+      "description": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
+      "type": "object",
+      "markdownDescription": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
+      "additionalProperties": false
+    },
+    "State": {
+      "examples": [
+        {},
+        {
+          "inventorySlotBackgroundImage": "InventoryBackground",
+          "inventorySlotEnabled": true,
+          "inventorySlotForegroundImage": "InventoryForeground"
+        }
+      ],
+      "title": "タッチ バンドルの状態",
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/StateType"
+        }
+      },
+      "description": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
+      "type": "object",
+      "markdownDescription": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
+      "additionalProperties": false
     },
     "Definitions": {
-      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "additionalProperties": false,
-      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "title": "定義",
       "examples": [
         {},
         {
@@ -151,13 +75,89 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "定義",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/ContextDefinableType"
         }
       },
-      "type": "object"
+      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "type": "object",
+      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "additionalProperties": false
+    },
+    "StateType": {
+      "markdownDescription": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ],
+      "description": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
+      "examples": [
+        "customAssetName",
+        false,
+        true,
+        1,
+        0
+      ],
+      "title": "タッチ バンドルの状態アイテム"
+    },
+    "ContextDefinableType": {
+      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+      "anyOf": [
+        {
+          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+        },
+        {
+          "$ref": "#/$defs/StateType"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StateType"
+          }
+        }
+      ],
+      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+      "title": "定義可能な型"
+    },
+    "ContextStyles": {
+      "markdownDescription": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "description": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
+      "title": "スタイル"
     }
   },
-  "type": "object"
+  "description": "タッチ適応バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+  "properties": {
+    "state": {
+      "$ref": "#/$defs/State"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/ContextStyles"
+    },
+    "allowedStateValues": {
+      "$ref": "#/$defs/AllowedStateValues"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "title": "タッチ適応バンドルのコンテキスト スキーマ",
+  "markdownDescription": "タッチ適応バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。"
 }

--- a/touch-adaptation-kit/schemas/ja-JP/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/ja-JP/context/v4.0/context.json
@@ -1,163 +1,163 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "AllowedStateValues": {
-      "examples": [
-        {},
-        {
-          "inventorySlotForegroundImage": [
-            "InventoryForegroundFireballSpell",
-            "InventoryForegroundLightningBoltSpell"
-          ],
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          }
-        }
-      ],
-      "title": "タッチ バンドルの許可状態値",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/StateType"
-              }
-            },
-            {
-              "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
-            }
-          ]
-        }
-      },
-      "description": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
-      "type": "object",
-      "markdownDescription": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
-      "additionalProperties": false
-    },
-    "State": {
-      "examples": [
-        {},
-        {
-          "inventorySlotBackgroundImage": "InventoryBackground",
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground"
-        }
-      ],
-      "title": "タッチ バンドルの状態",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "description": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
-      "type": "object",
-      "markdownDescription": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
-      "additionalProperties": false
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/$defs/joystickAssetName"
-                  }
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "タッチ適応バンドルのコンテキスト スキーマ",
+    "description": "タッチ適応バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+    "markdownDescription": "タッチ適応バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "タッチ バンドルの許可状態値",
+            "description": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
+            "markdownDescription": "このプロパティは、動的状態を使用する場合に、さまざまな資産ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、資産などの追加のバンドル ファイルが欠落したり使用されたりしないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
                 }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "定義可能な型",
+            "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+            "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "定義",
+            "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+            "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "タッチ バンドルの状態",
+            "description": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
+            "markdownDescription": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "タッチ バンドルの状態アイテム",
+            "description": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
+            "markdownDescription": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "スタイル",
+            "description": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+            "markdownDescription": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+            "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles"
         }
-      ],
-      "title": "定義",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/ContextDefinableType"
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
         }
-      },
-      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "type": "object",
-      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "additionalProperties": false
     },
-    "StateType": {
-      "markdownDescription": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "description": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "title": "タッチ バンドルの状態アイテム"
-    },
-    "ContextDefinableType": {
-      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
-      "title": "定義可能な型"
-    },
-    "ContextStyles": {
-      "markdownDescription": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
-      "description": "このプロパティは、スタイル設定を目的として、このタッチ適応バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "title": "スタイル"
-    }
-  },
-  "description": "タッチ適応バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
-  "properties": {
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    },
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "$schema": {
-      "type": "string"
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
-  "title": "タッチ適応バンドルのコンテキスト スキーマ",
-  "markdownDescription": "タッチ適応バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。"
+    "additionalProperties": false
 }

--- a/touch-adaptation-kit/schemas/ja-JP/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/ja-JP/layout/v4.0/layout.json
@@ -1,4069 +1,15 @@
 {
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "additionalProperties": false,
-  "type": "object",
+  "title": "タッチ適応バンドルのレイアウト スキーマ",
+  "description": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+  "markdownDescription": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
   "$defs": {
-    "_StrokeBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "solid",
-              "markdownDescription": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
-              "type": "string",
-              "description": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ]
-    },
-    "_SystemColorContentPrimary": {
-      "markdownDescription": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
-      "description": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "コンテンツのプライマリ システムの色のオーバーライド"
-    },
-    "_ControlTypeDirectionalPad": {
-      "const": "directionalPad",
-      "markdownDescription": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
-      "type": "string",
-      "description": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
-      "title": "方向パッド コントロールの種類"
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "JoystickDirectionIndicator": {
-      "markdownDescription": "対話の方向を示す視覚的なスタイル設定",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
-              "type": "string",
-              "description": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "対話の方向を示す視覚的なスタイル設定",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "title": "方向インジケーターのスタイル設定コンポーネント"
-    },
-    "LayerSensorContent": {
-      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
-        }
-      ],
-      "title": "センサー レイヤーのコンテンツ"
-    },
-    "Background": {
-      "markdownDescription": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
-      "title": "背景スタイル設定コンポーネント"
-    },
-    "_Accelerometer": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "accelerometer",
-          "markdownDescription": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
-          "type": "string",
-          "description": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
-          "title": "加速度計コントロールの種類"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "SensorControl": {
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "センサー コントロール",
-      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_Null": {
-      "markdownDescription": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
-      "type": "null",
-      "description": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
-      "examples": [
-        null
-      ],
-      "title": "Null"
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "markdownDescription": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
-      "type": "string",
-      "description": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "ゲームパッドのアナログ ジョイスティック出力"
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "PullIndicator": {
-      "markdownDescription": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "title": "pull インジケーターのスタイル設定コンポーネント"
-    },
-    "_SystemColorAccentPrimary": {
-      "markdownDescription": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
-      "description": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "アクセントのプライマリ システム カラーのオーバーライド"
-    },
-    "Scale": {
-      "markdownDescription": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "maximum": 2,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "title": "スケール"
-    },
-    "JoystickIdleStyle": {
-      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "コントロールのアイドルのスタイル"
-    },
-    "_AxisMapping2DItem": {
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "2 次元軸マッピング アイテム"
-    },
-    "TouchpadStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ]
-    },
-    "ButtonIdleStyle": {
-      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "コントロールのアイドルのスタイル"
-    },
-    "_LayoutStyles": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "colors": {
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ]
-    },
-    "DeadzoneDirectionalPad": {
-      "markdownDescription": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
-      "anyOf": [
-        {
-          "exclusiveMaximum": 1,
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "title": "方向パッドのデッドゾーン"
-    },
-    "Sticky": {
-      "markdownDescription": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "title": "付箋"
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayoutContent": {
-      "markdownDescription": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
-      "examples": [
-        {},
-        {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "output": "leftJoystick",
-                  "input": "axisXY"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "title": "レイアウト コンテンツ"
-    },
-    "Reference": {
-      "type": "object",
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-          "format": "uri-reference",
-          "markdownDescription": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
-          "type": "string",
-          "description": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
-          "examples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerControlWheel": {
-      "markdownDescription": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
-      "examples": [
-        {
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ],
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー コントロール ホイール"
-    },
-    "_SystemColorAccentSecondary": {
-      "markdownDescription": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
-      "description": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "アクセントのセカンダリ システムの色のオーバーライド"
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonToggledStyle": {
-      "markdownDescription": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "コントロールの切り替えスタイル"
-    },
-    "LayoutLowerArrayContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "title": "下位レイアウト配列のコンテンツ"
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          },
-          "type": "array"
-        }
-      ],
-      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "2 次元軸マッピング"
-    },
-    "ThrottleAxisOutput": {
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
-      "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
-        {
-          "$ref": "#/definitions/commonThrottleAxis"
-        }
-      ],
-      "title": "スロットル軸"
-    },
-    "ColorPaletteDefaultVariant": {
-      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
-      "description": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "既定の色"
-    },
-    "Deadzone1D": {
-      "markdownDescription": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "1 次元のデッドゾーン"
-    },
-    "JoystickOutlineWithIndicator": {
-      "markdownDescription": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
-      "examples": [
-        {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "title": "アウトライン スタイル設定コンポーネント"
-    },
-    "_ControllerButtonOutputType": {
-      "markdownDescription": "ゲームパッド ボタンの押下を出力します。",
-      "type": "string",
-      "description": "ゲームパッド ボタンの押下を出力します。",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "ゲームパッド ボタンの出力"
-    },
-    "ButtonActivatedStyle": {
-      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "コントロールがアクティブ化されたスタイル"
-    },
-    "JoystickStyles": {
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "examples": [
-        {},
-        {
-          "default": {
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyles"
-        }
-      ],
-      "title": "コントロールのスタイル"
-    },
-    "ButtonDisabledStyle": {
-      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "コントロールの無効なスタイル"
-    },
-    "LayoutActionTarget": {
-      "markdownDescription": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "title": "レイアウト アクション ターゲット"
-    },
-    "_ControlTypeButton": {
-      "const": "button",
-      "markdownDescription": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
-      "type": "string",
-      "description": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
-      "title": "ボタン コントロールの種類"
-    },
-    "_ControllerAnalog1DOutputType": {
-      "markdownDescription": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
-      "type": "string",
-      "description": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "ゲームパッドのアナログ ジョイスティック出力"
-    },
-    "_LayoutAction": {
-      "type": "object",
-      "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "const": "layer",
-          "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-          "type": "string",
-          "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-          "title": "レイアウト アクション"
-        }
-      },
-      "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "title": "レイアウト アクション",
-      "required": [
-        "type",
-        "target"
-      ],
-      "additionalProperties": false
-    },
-    "InnerLayoutControlWheel": {
-      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "output": "leftJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "title": "内側​​"
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "_ControllerTriggerOutputType": {
-      "markdownDescription": "指定されたゲームパッド トリガーにマップされる値を出力します。",
-      "type": "string",
-      "description": "指定されたゲームパッド トリガーにマップされる値を出力します。",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "ゲームパッドのアナログ トリガー出力"
-    },
-    "DirectionalPadStyles": {
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "コントロールのアイドルのスタイル"
-            },
-            "disabled": {
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "コントロールがアクティブ化されたスタイル"
-            },
-            "activated": {
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "コントロールがアクティブ化されたスタイル"
-            },
-            "default": {
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "コントロールの既定のスタイル"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "title": "コントロールのスタイル"
-    },
-    "Indicator": {
-      "markdownDescription": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
-      "description": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "インジケーターのスタイル設定コンポーネント"
-    },
-    "Stroke": {
-      "markdownDescription": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
-      "description": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "ストローク スタイル設定コンポーネント"
-    },
-    "Gradient": {
-      "markdownDescription": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
-      "examples": [
-        {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
-        }
-      ],
-      "title": "グラデーション"
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "markdownDescription": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "title": "ゲームパッド アクション"
-    },
-    "_DirectionalPad": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_TurboAction": {
-      "title": "ターボ アクション",
-      "properties": {
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        },
-        "type": {
-          "const": "turbo",
-          "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-          "type": "string",
-          "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-          "title": "ターボ アクション"
-        },
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        }
-      },
-      "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-      "type": "object",
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-      "additionalProperties": false
-    },
-    "ControlGroup": {
-      "markdownDescription": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/ControlGroupItem"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
-          },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "title": "タッチ レイアウト コントロール グループ"
-    },
-    "_SystemColorContrastPrimary": {
-      "markdownDescription": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
-      "description": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "コントラストのプライマリ システムの色のオーバーライド"
-    },
-    "ControlGroupItem": {
-      "markdownDescription": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
-      "title": "タッチ レイアウト コントロール グループ アイテム"
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "markdownDescription": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
-      "anyOf": [
-        {
-          "type": "number",
-          "minimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
-      "examples": [
-        1,
-        1.5,
-        0,
-        {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
-        }
-      ],
-      "title": "アクションのしきい値"
-    },
-    "ArcadeButtonStyles": {
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "コントロールのアイドルのスタイル"
-            },
-            "disabled": {
-              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "コントロールの無効なスタイル"
-            },
-            "activated": {
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "コントロールがアクティブ化されたスタイル"
-            },
-            "default": {
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "コントロールの既定のスタイル"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "examples": [
-        {
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          },
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "title": "コントロールのスタイル"
-    },
-    "_BackgroundAsset": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "背景のスタイルを設定するために使用するカスタム資産です。",
-          "type": "string",
-          "description": "背景のスタイルを設定するために使用するカスタム資産です。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_FaceImageIcon": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        },
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "const": "icon",
-          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
-          "type": "string",
-          "description": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
-          "title": "顔画像アイコンのスタイル設定コンポーネント"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1D": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
-        }
-      ]
-    },
-    "_InputMappingZY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
-        }
-      ]
-    },
-    "FaceImageIconValue": {
-      "markdownDescription": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
-      "anyOf": [
-        {
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "title": "顔画像アイコン"
-    },
-    "Toggle": {
-      "markdownDescription": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "title": "トグル"
-    },
-    "ArcadeButtonStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ]
-    },
-    "_ControlTypeTouchpad": {
-      "const": "touchpad",
-      "markdownDescription": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
-      "type": "string",
-      "description": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
-      "title": "タッチパッド コントロールの種類"
-    },
-    "ThrottleStyles": {
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールの既定のスタイル"
-            },
-            "idleUp": {
-              "markdownDescription": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
-              "description": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールのアイドル アップのスタイル"
-            },
-            "activatedDown": {
-              "markdownDescription": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
-              "description": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールがアクティブ化されたダウン スタイル"
-            },
-            "disabled": {
-              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールの無効なスタイル"
-            },
-            "activatedUp": {
-              "markdownDescription": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
-              "description": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールがアクティブ化されたアップ スタイル"
-            },
-            "idle": {
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールのアイドルのスタイル"
-            },
-            "activated": {
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "コントロールがアクティブ化されたスタイル"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "axisDown": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "title": "コントロールのスタイル"
-    },
-    "SensorLayerControl": {
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "レイヤー センサー コントロール",
-      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_SystemColorActionColor": {
-      "markdownDescription": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
-      "description": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "アクション システムの色のオーバーライド"
-    },
-    "LayoutSensorContent": {
-      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "title": "センサー レイアウト コンテンツ"
-    },
-    "LayoutColors": {
-      "markdownDescription": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            },
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
-      "examples": [
-        {},
-        {
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "title": "色"
-    },
-    "LayoutUpperContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "title": "上部レイアウトのコンテンツ"
-    },
-    "_Color": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ]
-    },
-    "DirectionalPadDefaultStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "RelativeInteraction": {
-      "markdownDescription": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "title": "相対"
-    },
-    "ButtonPulledStyle": {
-      "markdownDescription": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "コントロールの pull されたスタイル"
-    },
-    "InputCurveType": {
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "title": "[非推奨] 入力応答曲線の種類",
-      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
-      "anyOf": [
-        {
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。"
-    },
-    "ThrottleAxisStyle": {
-      "markdownDescription": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
-      "examples": [
-        {
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          },
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        }
-      ],
-      "title": "スロットル軸のスタイル設定コンポーネント"
-    },
-    "ButtonDefaultStyle": {
-      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "コントロールの既定のスタイル"
-    },
-    "_InputMapping1DToGamepad1DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FillColor": {
-      "markdownDescription": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
-      "description": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
-      "$ref": "#/$defs/_Color",
-      "title": "塗りつぶし"
-    },
-    "PullIndicatorBackground": {
-      "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "title": "背景スタイル設定コンポーネント"
-    },
-    "_Button": {
-      "type": "object",
-      "required": [
-        "type",
-        "action"
-      ],
-      "examples": [
-        {
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
-            }
-          },
-          "action": "gamepadA"
-        }
-      ],
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        }
-      },
-      "additionalProperties": false
-    },
-    "DirectionalPadInteraction": {
-      "markdownDescription": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "title": "対話式操作"
-    },
-    "ButtonStyles": {
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "title": "コントロールのスタイル"
-    },
-    "_CustomColorPaletteColor": {
-      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
-      "description": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "カスタム レイアウトの色"
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "DeadzoneThreshold": {
-      "markdownDescription": "出力値を生成するために必要な正規化された入力値です。",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "出力値を生成するために必要な正規化された入力値です。",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "title": "しきい値"
-    },
-    "_SystemColorContrastSecondary": {
-      "markdownDescription": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
-      "description": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "コントラスト セカンダリ システムの色のオーバーライド"
-    },
-    "_SystemColorGamepadActionColor": {
-      "markdownDescription": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
-      "description": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "ゲームパッド アクション システムの色のオーバーライド"
-    },
-    "AssetReference": {
-      "markdownDescription": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "title": "資産参照スタイル設定コンポーネント"
-    },
-    "FaceImage": {
-      "markdownDescription": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
-        }
-      ],
-      "title": "顔画像のスタイル設定コンポーネント"
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      }
-    },
-    "JoystickActivatedStyle": {
-      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "コントロールがアクティブ化されたスタイル"
-    },
-    "LayoutLowerContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "title": "下位レイアウトのコンテンツ"
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "ControlVisibility": {
-      "markdownDescription": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "表示"
-    },
-    "LayerLowerArrayContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "title": "下位レイヤー配列のコンテンツ"
-    },
-    "OuterLayoutControlWheel": {
-      "markdownDescription": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "外側​​"
-    },
-    "ControlEnabled": {
-      "markdownDescription": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "有効"
-    },
-    "ExpandInteraction": {
-      "markdownDescription": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "title": "展開"
-    },
-    "Deadzone2D": {
-      "markdownDescription": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
-      "examples": [
-        {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "2 次元のデッドゾーン"
-    },
-    "_ColorPaletteColor": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ]
-    },
-    "_InputAxisZY": {
-      "const": "axisZY",
-      "markdownDescription": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
-      "type": "string",
-      "description": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
-      "title": "Z 軸と Y 軸の入力マッピング"
-    },
-    "DirectionalPadIdleStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/definitions/joystickAssetName"
-                  }
-                }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
-        }
-      ],
-      "title": "定義",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/LayoutDefinableType"
-        }
-      },
-      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "type": "object",
-      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "additionalProperties": false
-    },
-    "_SystemColorContentSecondary": {
-      "markdownDescription": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
-      "description": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "コンテンツ セカンダリ システムの色のオーバーライド"
-    },
-    "Color": {
-      "markdownDescription": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
-      "description": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
-      "$ref": "#/$defs/_Color",
-      "title": "色"
-    },
-    "_RelativeMouse1DOutputType": {
-      "markdownDescription": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
-      "type": "string",
-      "description": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "相対マウスの 1 次元出力"
-    },
-    "_ArcadeButtons": {
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ],
-      "examples": [
-        {
-          "type": "arcadeButtons",
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          },
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          }
-        }
-      ],
-      "properties": {
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "スペシャル パンチ ボタン"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ヘビー キック ボタン"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ライト パンチ ボタン"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ライト キック ボタン"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ミディアム キック ボタン"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "スペシャル キック ボタン"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ヘビー キック ボタン"
-        },
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ミディアム パンチ ボタン"
-        }
-      },
-      "additionalProperties": false
-    },
-    "OuterLayerControlWheel": {
-      "markdownDescription": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "外側​​"
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "const": "throttle",
-      "markdownDescription": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
-      "type": "string",
-      "description": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
-      "title": "スロットル コントロールの種類"
-    },
-    "LayoutOrientation": {
-      "title": "[非推奨] レイアウトの向き",
-      "description": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
-      "enum": [
-        "landscape-left",
-        "landscape-right",
-        "landscape",
-        "portrait-up",
-        "portrait"
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
-      "type": "string"
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputAxisXY": {
-      "const": "axisXY",
-      "markdownDescription": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
-      "type": "string",
-      "description": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
-      "title": "X 軸と Y 軸の入力マッピング"
-    },
-    "PullActionType": {
-      "markdownDescription": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
-      "description": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "pull アクションの制御"
-    },
-    "Knob": {
-      "markdownDescription": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "title": "ノブ スタイル設定コンポーネント"
-    },
-    "Control": {
-      "markdownDescription": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "title": "タッチ レイアウト コントロール"
-    },
-    "LayerUpperRightContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "title": "上位レイヤーの右側のコンテンツ"
-    },
-    "AxisCapColor": {
-      "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
-              "type": "string",
-              "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
-              "title": "軸キャップ スタイル設定コンポーネント"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "title": "軸キャップ スタイル設定コンポーネント"
-    },
-    "_Throttle": {
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
-      ],
-      "examples": [
-        {
-          "sticky": true,
-          "type": "throttle",
-          "axisDown": "leftTrigger",
-          "axisUp": "rightTrigger"
-        }
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Blank": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "properties": {
-        "type": {
-          "const": "blank",
-          "markdownDescription": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
-          "type": "string",
-          "description": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
-          "title": "空白のコントロールの種類"
-        }
-      },
-      "additionalProperties": false
-    },
-    "RenderAsButton": {
-      "markdownDescription": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "title": "[レンダリング] ボタン"
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "_InputMappingXYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "ColorPaletteHighContrastVariant": {
-      "markdownDescription": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
-      "description": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "ハイ コントラストの色のみ"
-    },
-    "LayoutStyles": {
-      "markdownDescription": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
-      "description": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
-      "$ref": "#/$defs/_LayoutStyles",
-      "title": "レイアウト スタイル"
-    },
-    "LayerControlGroup": {
-      "type": "array",
-      "markdownDescription": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
-      "minItems": 1,
-      "description": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          },
-          null
-        ]
-      ],
-      "maxItems": 4,
-      "title": "タッチ レイアウト レイヤー コントロール グループ",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      }
-    },
-    "_BackgroundColor": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/Color"
-        },
-        "type": {
-          "const": "color",
-          "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
-          "type": "string",
-          "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Gyroscope": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "output": "rightJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "gyroscope",
-          "markdownDescription": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
-          "type": "string",
-          "description": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
-          "title": "ジャイロスコープ コントロールの種類"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageIconLabel": {
-      "markdownDescription": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "action",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "title": "顔画像アイコンラベルのスタイル設定コンポーネント"
-    },
-    "TouchpadStyles": {
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "コントロールのアイドルのスタイル"
-            },
-            "disabled": {
-              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "コントロールの無効なスタイル"
-            },
-            "activated": {
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "コントロールがアクティブ化されたスタイル"
-            },
-            "moving": {
-              "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
-              "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "コントロールの移動スタイル"
-            },
-            "default": {
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "コントロールの既定のスタイル"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "title": "コントロールのスタイル"
-    },
-    "Layer": {
-      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "type": "throttle",
-                "axisDown": "leftTrigger",
-                "axisUp": "rightTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー"
-    },
-    "LayerControlGroupItem": {
-      "markdownDescription": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー コントロール グループ アイテム"
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ],
-          "type": "string"
-        }
-      ]
-    },
-    "LayoutUpperRightContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "title": "右上のレイアウト コンテンツ"
-    },
-    "JoystickDefaultStyle": {
-      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "コントロールの既定のスタイル"
-    },
-    "_ControllerAnalog2DOutputType": {
-      "markdownDescription": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
-      "type": "string",
-      "description": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "ゲームパッドのアナログ ジョイスティック出力"
-    },
-    "LayerLowerContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "examples": [
-        {
-          "center": {
-            "type": "blank"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
-        }
-      ],
-      "title": "下位レイヤーのコンテンツ"
-    },
     "LayoutDefinableType": {
+      "title": "定義可能な型",
+      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -4377,153 +323,1116 @@
         {
           "$ref": "#/$defs/TouchpadStyles"
         }
-      ],
-      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
-      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
-      "title": "定義可能な型"
+      ]
     },
-    "LayoutControlWheel": {
-      "markdownDescription": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayoutControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
+    "Definitions": {
+      "title": "定義",
+      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
       "examples": [
         {},
         {
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "output": "leftJoystick",
-                "input": "axisXY"
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
               }
             }
-          ],
-          "outer": [
-            null,
-            [
-              {
-                "type": "button",
-                "action": "gamepadX"
-              }
-            ],
-            {
-              "type": "button",
-              "action": "gamepadY"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonControlWheel"
-        }
-      ],
-      "title": "タッチ レイアウト コントロール ホイール"
-    },
-    "_RelativeMouse2DOutputType": {
-      "const": "relativeMouse",
-      "markdownDescription": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
-      "type": "string",
-      "description": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
-      "title": "相対マウスの 2 次元出力"
-    },
-    "LayerControl": {
-      "markdownDescription": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー コントロール"
-    },
-    "Sensitivity": {
-      "markdownDescription": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "title": "感度"
-    },
-    "InnerLayerControlWheel": {
-      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
           }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "title": "内側​​"
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
     },
-    "_Joystick": {
+    "Reference": {
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
+          "markdownDescription": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "Null",
+      "description": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
+      "markdownDescription": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "加速度計コントロールの種類",
+          "description": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
+          "markdownDescription": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
       "required": [
         "type",
         "axis"
       ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
       "examples": [
         {
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
           },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "ヘビー キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "ヘビー キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "ライト キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "ライト パンチ ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "ミディアム キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "ミディアム パンチ ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "スペシャル キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "スペシャル パンチ ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "2 次元軸マッピング アイテム",
+      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "3 次元軸マッピング アイテム",
+      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "背景のスタイルを設定するために使用するカスタム資産です。",
+          "markdownDescription": "背景のスタイルを設定するために使用するカスタム資産です。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+          "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "空白のコントロールの種類",
+          "description": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
+          "markdownDescription": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "ゲームパッドのアナログ ジョイスティック出力",
+      "description": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
+      "markdownDescription": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "ゲームパッドのアナログ ジョイスティック出力",
+      "description": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
+      "markdownDescription": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "ゲームパッドのアナログ ジョイスティック出力",
+      "description": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
+      "markdownDescription": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "ゲームパッド ボタンの出力",
+      "description": "ゲームパッド ボタンの押下を出力します。",
+      "markdownDescription": "ゲームパッド ボタンの押下を出力します。",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "ゲームパッドのアナログ トリガー出力",
+      "description": "指定されたゲームパッド トリガーにマップされる値を出力します。",
+      "markdownDescription": "指定されたゲームパッド トリガーにマップされる値を出力します。",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "アーケード ボタン コントロールの種類",
+      "description": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
+      "markdownDescription": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "ボタン コントロールの種類",
+      "description": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
+      "markdownDescription": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "方向パッド コントロールの種類",
+      "description": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
+      "markdownDescription": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "ジョイスティック コントロールの種類",
+      "description": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
+      "markdownDescription": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "スロットル コントロールの種類",
+      "description": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
+      "markdownDescription": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "タッチパッド コントロールの種類",
+      "description": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
+      "markdownDescription": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "カスタム レイアウトの色",
+      "description": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
+      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "顔画像資産スタイル設定コンポーネント",
+          "description": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
+          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "顔画像アイコンのスタイル設定コンポーネント",
+          "description": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
+          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "ジャイロスコープ コントロールの種類",
+          "description": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
+          "markdownDescription": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "軸のマグニチューディナル入力マッピング",
+      "description": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
+      "markdownDescription": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X 軸入力マッピング",
+          "description": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "markdownDescription": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y 軸の入力マッピング",
+          "description": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "markdownDescription": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X 軸と Y 軸の入力マッピング",
+      "description": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "markdownDescription": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z 軸と Y 軸の入力マッピング",
+      "description": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "markdownDescription": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
           "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
           "styles": {
             "default": {
               "knob": {
@@ -4536,24 +1445,22 @@
           }
         }
       ],
+      "additionalProperties": false,
       "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
+        "action": {
+          "$ref": "#/$defs/ActionType"
         },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
         },
         "axis": {
           "$ref": "#/$defs/AxisMapping2D"
         },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
         },
         "relative": {
           "$ref": "#/$defs/RelativeInteraction"
@@ -4561,361 +1468,374 @@
         "styles": {
           "$ref": "#/$defs/JoystickStyles"
         },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
         "type": {
           "$ref": "#/$defs/_ControlTypeJoystick"
         }
       },
-      "additionalProperties": false
-    },
-    "InputCurve": {
-      "examples": [
-        {
-          "type": "circular",
-          "range": [
-            0,
-            0.33
-          ]
-        },
-        {
-          "type": "circular-inverse",
-          "range": [
-            0,
-            1
-          ]
-        },
-        {
-          "$ref": "#/$defs/commonJoystickResponseCurve"
-        }
+      "required": [
+        "type",
+        "axis"
       ],
-      "title": "[非推奨] 入力応答曲線",
-      "description": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
+      "type": "object"
+    },
+    "_LayerControlBase": {
       "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/InputCurveType"
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "レイアウト アクション",
+      "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+      "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "レイアウト アクション",
+          "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+          "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
             },
-            "range": {
-              "$ref": "#/$defs/InputCurveRange"
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。"
+      ]
     },
-    "AxisMapping3D": {
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+    "_RelativeMouse1DOutputType": {
+      "title": "相対マウスの 1 次元出力",
+      "description": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
+      "markdownDescription": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "3 次元軸マッピング"
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "相対マウスの 2 次元出力",
+      "description": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
+      "markdownDescription": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
+      "const": "relativeMouse",
+      "type": "string"
     },
     "_RelativeMouseMagnitudinalOutputType": {
-      "markdownDescription": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
-      "type": "string",
+      "title": "相対マウス方向の方向出力",
       "description": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
+      "markdownDescription": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
       "enum": [
         "relativeMouseUp",
         "relativeMouseDown",
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "相対マウス方向の方向出力"
+      "type": "string"
     },
-    "_InputAxisMagnitudinal": {
-      "markdownDescription": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
-      "type": "string",
-      "description": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "軸のマグニチューディナル入力マッピング"
-    },
-    "_InputAxis1D": {
+    "_SingleControlActionAssignableTypes": {
       "anyOf": [
         {
-          "const": "axisX",
-          "markdownDescription": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
-          "type": "string",
-          "description": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
-          "title": "X 軸入力マッピング"
+          "$ref": "#/$defs/_ControllerAction"
         },
         {
-          "const": "axisY",
-          "markdownDescription": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
-          "type": "string",
-          "description": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
-          "title": "Y 軸の入力マッピング"
-        }
-      ]
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "markdownDescription": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
-      "anyOf": [
+          "$ref": "#/$defs/_LayoutAction"
+        },
         {
-          "type": "object",
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/_TurboAction"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
+      ]
+    },
+    "_StrokeBase": {
       "examples": [
         {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
         },
         {
-          "$ref": "#/definitions/commonOutlineStyling"
+          "$ref": "#/definitions/commonControlStroke"
         }
       ],
-      "title": "アウトライン スタイル設定コンポーネント"
-    },
-    "ThrottleStyleBase": {
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "type": {
+              "description": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
+              "markdownDescription": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
-            },
-            "axisUp": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "axisDown": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "type"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "examples": [
-        {
-          "axisUp": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "axisDown": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          }
-        }
       ]
     },
-    "_AxisMapping3DItem": {
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        }
-      ],
-      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+    "_SystemColorContentPrimary": {
+      "title": "コンテンツのプライマリ システムの色のオーバーライド",
+      "description": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "コンテンツ セカンダリ システムの色のオーバーライド",
+      "description": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "コントラストのプライマリ システムの色のオーバーライド",
+      "description": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
+      "markdownDescription": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "コントラスト セカンダリ システムの色のオーバーライド",
+      "description": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "アクション システムの色のオーバーライド",
+      "description": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "ゲームパッド アクション システムの色のオーバーライド",
+      "description": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "アクセントのプライマリ システム カラーのオーバーライド",
+      "description": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
+      "markdownDescription": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "アクセントのセカンダリ システムの色のオーバーライド",
+      "description": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
       "examples": [
         {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
         }
       ],
-      "title": "3 次元軸マッピング アイテム"
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "ターボ アクション",
+      "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+      "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "ターボ アクション",
+          "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+          "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "アクションのしきい値",
+      "description": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
+      "markdownDescription": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "ActionType": {
-      "markdownDescription": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "title": "コントロール アクション",
       "description": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "コントロール アクション"
-    },
-    "Layers": {
-      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
-      "anyOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "type": "throttle",
-                  "axisDown": "leftTrigger",
-                  "axisUp": "rightTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー"
-    },
-    "DeadzoneRadial": {
-      "markdownDescription": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "description": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "title": "放射状"
+      "markdownDescription": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "$ref": "#/$defs/_ActionTypeBase"
     },
     "ArcadeButton": {
-      "markdownDescription": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "enabled": {
-              "$ref": "#/$defs/ControlEnabled"
-            },
-            "visible": {
-              "$ref": "#/$defs/ControlVisibility"
-            },
-            "styles": {
-              "$ref": "#/$defs/ArcadeButtonStyles"
-            },
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
       "description": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。",
+      "markdownDescription": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。",
       "examples": [
         {
           "action": "gamepadX",
@@ -4931,64 +1851,993 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ]
-    },
-    "JoystickMovingStyle": {
-      "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+      ],
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
+            "action": {
+              "$ref": "#/$defs/ActionType"
             },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
             },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "action"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+      ]
+    },
+    "ArcadeButtonStyleBase": {
       "examples": [
-        {},
         {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
           "background": {
             "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyle"
+          "$ref": "#/definitions/commonArcadeButtonStyle"
         }
       ],
-      "title": "コントロールの移動スタイル"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "コントロールの無効なスタイル",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "資産参照スタイル設定コンポーネント",
+      "description": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
+      "markdownDescription": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "軸キャップ スタイル設定コンポーネント",
+      "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+      "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "軸キャップ スタイル設定コンポーネント",
+              "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+              "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "2 次元軸マッピング",
+      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "3 次元軸マッピング",
+      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "背景スタイル設定コンポーネント",
+      "description": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+      "markdownDescription": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "コントロールがアクティブ化されたスタイル",
+      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "コントロールの既定のスタイル",
+      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "コントロールの無効なスタイル",
+      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "コントロールのアイドルのスタイル",
+      "description": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
+      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "コントロールの切り替えスタイル",
+      "description": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
+      "markdownDescription": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "コントロールの pull されたスタイル",
+      "description": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+      "markdownDescription": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "色",
+      "description": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "markdownDescription": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "既定の色",
+      "description": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
+      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "ハイ コントラストの色のみ",
+      "description": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "markdownDescription": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "タッチ レイアウト コントロール",
+      "description": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
+      "markdownDescription": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "有効",
+      "description": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
+      "markdownDescription": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "タッチ レイアウト コントロール グループ",
+      "description": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
+      "markdownDescription": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "タッチ レイアウト コントロール グループ アイテム",
+      "description": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+      "markdownDescription": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "ゲームパッド アクション",
+      "description": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
+      "markdownDescription": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "表示",
+      "description": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+      "markdownDescription": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "1 次元のデッドゾーン",
+      "description": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
+      "markdownDescription": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "2 次元のデッドゾーン",
+      "description": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
+      "markdownDescription": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "方向パッドのデッドゾーン",
+      "description": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
+      "markdownDescription": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "しきい値",
+      "description": "出力値を生成するために必要な正規化された入力値です。",
+      "markdownDescription": "出力値を生成するために必要な正規化された入力値です。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "放射状",
+      "description": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
+      "markdownDescription": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "対話式操作",
+      "description": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
+      "markdownDescription": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "DirectionalPadInteractionActivationType": {
+      "title": "アクティブ化の種類",
+      "description": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
       "markdownDescription": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
       "anyOf": [
         {
           "type": "string",
@@ -5000,319 +2849,458 @@
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "title": "アクティブ化の種類"
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
       ]
     },
-    "_FaceImageAsset": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
-          "type": "string",
-          "description": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
-          "title": "顔画像資産スタイル設定コンポーネント"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      },
-      "type": "object",
+    "DirectionalPadStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
       "examples": [
         {},
         {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "properties": {
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "additionalProperties": false
-    },
-    "TurboActionInterval": {
-      "examples": [
-        500,
-        1000
-      ],
-      "title": "間隔",
-      "description": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
-      "exclusiveMinimum": 0,
-      "markdownDescription": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
-      "type": "number"
-    },
-    "_ControlTypeJoystick": {
-      "const": "joystick",
-      "markdownDescription": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
-      "type": "string",
-      "description": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
-      "title": "ジョイスティック コントロールの種類"
-    },
-    "JoystickDisabledStyle": {
-      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
+          "default": {
             "stroke": {
               "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
               "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "コントロールの無効なスタイル"
-    },
-    "Opacity": {
-      "markdownDescription": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "maximum": 1,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "title": "不透明度"
-    },
-    "_ControlTypeArcadeButtons": {
-      "const": "arcadeButtons",
-      "markdownDescription": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
-      "type": "string",
-      "description": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
-      "title": "アーケード ボタン コントロールの種類"
-    },
-    "_Touchpad": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "axis": [
-            {
-              "output": "relativeMouse",
-              "input": "axisXY"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
             }
           }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
         }
       ],
-      "properties": {
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerUpperContent": {
-      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "展開",
+      "description": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
+      "markdownDescription": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
       "examples": [
+        true,
+        false,
         {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
         }
       ],
-      "title": "上位レイヤーのコンテンツ"
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "顔画像のスタイル設定コンポーネント",
+      "description": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+      "markdownDescription": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "顔画像アイコンラベルのスタイル設定コンポーネント",
+      "description": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
+      "markdownDescription": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "顔画像アイコン",
+      "description": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
+      "markdownDescription": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "塗りつぶし",
+      "description": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "markdownDescription": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "グラデーション",
+      "description": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
+      "markdownDescription": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "インジケーターのスタイル設定コンポーネント",
+      "description": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
+      "markdownDescription": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "内側​​",
+      "description": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
+      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "内側​​",
+      "description": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
+      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "InputCurveRange": {
+      "deprecated": true,
+      "title": "[非推奨] 入力曲線の範囲",
+      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
       "examples": [
         [
           0,
@@ -5334,63 +3322,1480 @@
           }
         ]
       ],
-      "title": "[非推奨] 入力曲線の範囲",
-      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
       "anyOf": [
         {
           "items": {
             "anyOf": [
               {
+                "type": "number",
                 "minimum": -1,
-                "maximum": 1,
-                "type": "number"
+                "maximum": 1
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
-          "type": "array",
           "maxItems": 2,
-          "minItems": 2
+          "minItems": 2,
+          "type": "array"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。"
-    },
-    "_ActionTypeBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          },
-          "type": "array"
-        }
-      ],
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
       ]
     },
-    "_ControllerAction": {
-      "anyOf": [
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[非推奨] 入力応答曲線",
+      "description": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
+      "examples": [
         {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
         },
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[非推奨] 入力応答曲線の種類",
+      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "コントロールがアクティブ化されたスタイル",
+      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "コントロールの既定のスタイル",
+      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "方向インジケーターのスタイル設定コンポーネント",
+      "description": "対話の方向を示す視覚的なスタイル設定",
+      "markdownDescription": "対話の方向を示す視覚的なスタイル設定",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
+              "markdownDescription": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "コントロールの無効なスタイル",
+      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "コントロールのアイドルのスタイル",
+      "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "コントロールの移動スタイル",
+      "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+      "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "アウトライン スタイル設定コンポーネント",
+      "description": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+      "markdownDescription": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "アウトライン スタイル設定コンポーネント",
+      "description": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
+      "markdownDescription": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "ノブ スタイル設定コンポーネント",
+      "description": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
+      "markdownDescription": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "タッチ レイアウト レイヤー",
+      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "タッチ レイアウト レイヤー",
+      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "タッチ レイアウト レイヤー コントロール",
+      "description": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
+      "markdownDescription": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "タッチ レイアウト レイヤー コントロール グループ",
+      "description": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "markdownDescription": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "タッチ レイアウト レイヤー コントロール グループ アイテム",
+      "description": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
+      "markdownDescription": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "タッチ レイアウト レイヤー コントロール ホイール",
+      "description": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
+      "markdownDescription": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "下位レイヤー配列のコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "下位レイヤーのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "センサー レイヤーのコンテンツ",
+      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "上位レイヤーのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "上位レイヤーの右側のコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "レイアウト アクション ターゲット",
+      "description": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
+      "markdownDescription": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "色",
+      "description": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "markdownDescription": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "レイアウト コンテンツ",
+      "description": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
+      "markdownDescription": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "タッチ レイアウト コントロール ホイール",
+      "description": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
+      "markdownDescription": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[非推奨] レイアウトの向き",
+      "description": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "下位レイアウト配列のコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "下位レイアウトのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "センサー レイアウト コンテンツ",
+      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
+      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "レイアウト スタイル",
+      "description": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "markdownDescription": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "上部レイアウトのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "右上のレイアウト コンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "不透明度",
+      "description": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
+      "markdownDescription": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "外側​​",
+      "description": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
+      "markdownDescription": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "外側​​",
+      "description": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
+      "markdownDescription": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
         }
       ]
     },
@@ -5406,31 +4811,626 @@
           "$ref": "#/$defs/_Null"
         }
       ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "pull アクションの制御",
+      "description": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "markdownDescription": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "PullIndicator": {
+      "title": "pull インジケーターのスタイル設定コンポーネント",
+      "description": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
+      "markdownDescription": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "背景スタイル設定コンポーネント",
+      "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+      "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "相対",
+      "description": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
+      "markdownDescription": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "[レンダリング] ボタン",
+      "description": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
+      "markdownDescription": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "スケール",
+      "description": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
+      "markdownDescription": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "感度",
+      "description": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
+      "markdownDescription": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "センサー コントロール",
+      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
+      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "レイヤー センサー コントロール",
+      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "付箋",
+      "description": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
+      "markdownDescription": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "ストローク スタイル設定コンポーネント",
+      "description": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
+      "markdownDescription": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "スロットル軸",
+      "description": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "スロットル軸のスタイル設定コンポーネント",
+      "description": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+      "markdownDescription": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "コントロールがアクティブ化されたアップ スタイル",
+              "description": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "markdownDescription": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "コントロールがアクティブ化されたダウン スタイル",
+              "description": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "markdownDescription": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "コントロールの無効なスタイル",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "コントロールのアイドル アップのスタイル",
+              "description": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
+              "markdownDescription": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "トグル",
+      "description": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
+      "markdownDescription": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "コントロールの無効なスタイル",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "コントロールの移動スタイル",
+              "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+              "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "間隔",
+      "description": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
+      "markdownDescription": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
     }
   },
-  "description": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
   "properties": {
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
+    "$schema": {
+      "type": "string"
     },
     "content": {
       "$ref": "#/$defs/LayoutContent"
     },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
     "styles": {
       "$ref": "#/$defs/LayoutStyles"
     },
-    "$schema": {
-      "type": "string"
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
     }
   },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "required": [
     "content"
   ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
-  "title": "タッチ適応バンドルのレイアウト スキーマ",
-  "markdownDescription": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。"
+  "type": "object"
 }

--- a/touch-adaptation-kit/schemas/ja-JP/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/ja-JP/layout/v4.0/layout.json
@@ -1,32 +1,2268 @@
 {
-  "required": [
-    "content"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "styles": {
-      "$ref": "#/$defs/LayoutStyles"
-    },
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "content": {
-      "$ref": "#/$defs/LayoutContent"
-    }
-  },
-  "title": "タッチ適応バンドルのレイアウト スキーマ",
-  "description": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
-  "markdownDescription": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "type": "object",
   "$defs": {
+    "_StrokeBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "solid",
+              "markdownDescription": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
+              "type": "string",
+              "description": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "color": "#0099ff",
+          "type": "solid",
+          "opacity": 1
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "markdownDescription": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
+      "description": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "コンテンツのプライマリ システムの色のオーバーライド"
+    },
+    "_ControlTypeDirectionalPad": {
+      "const": "directionalPad",
+      "markdownDescription": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
+      "type": "string",
+      "description": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
+      "title": "方向パッド コントロールの種類"
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JoystickDirectionIndicator": {
+      "markdownDescription": "対話の方向を示す視覚的なスタイル設定",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
+              "type": "string",
+              "description": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "対話の方向を示す視覚的なスタイル設定",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "title": "方向インジケーターのスタイル設定コンポーネント"
+    },
+    "LayerSensorContent": {
+      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "title": "センサー レイヤーのコンテンツ"
+    },
+    "Background": {
+      "markdownDescription": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+      "title": "背景スタイル設定コンポーネント"
+    },
+    "_Accelerometer": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "const": "accelerometer",
+          "markdownDescription": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
+          "type": "string",
+          "description": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
+          "title": "加速度計コントロールの種類"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "SensorControl": {
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "センサー コントロール",
+      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_Null": {
+      "markdownDescription": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
+      "type": "null",
+      "description": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
+      "examples": [
+        null
+      ],
+      "title": "Null"
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "markdownDescription": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
+      "type": "string",
+      "description": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "title": "ゲームパッドのアナログ ジョイスティック出力"
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "PullIndicator": {
+      "markdownDescription": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "title": "pull インジケーターのスタイル設定コンポーネント"
+    },
+    "_SystemColorAccentPrimary": {
+      "markdownDescription": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
+      "description": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "アクセントのプライマリ システム カラーのオーバーライド"
+    },
+    "Scale": {
+      "markdownDescription": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
+      "anyOf": [
+        {
+          "minimum": 0.5,
+          "maximum": 2,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "title": "スケール"
+    },
+    "JoystickIdleStyle": {
+      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "コントロールのアイドルのスタイル"
+    },
+    "_AxisMapping2DItem": {
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "rightTrigger",
+          "input": "axisUp"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "2 次元軸マッピング アイテム"
+    },
+    "TouchpadStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "コントロールのアイドルのスタイル"
+    },
+    "_LayoutStyles": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "colors": {
+            "highContrast": {
+              "myColor": "#00ff00ff",
+              "system_contentPrimary": "#ffffffff"
+            },
+            "default": {
+              "myColor": "#ff0000ff",
+              "system_contentPrimary": "#ffffffff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "markdownDescription": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "title": "方向パッドのデッドゾーン"
+    },
+    "Sticky": {
+      "markdownDescription": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "title": "付箋"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayoutContent": {
+      "markdownDescription": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "output": "leftJoystick",
+                  "input": "axisXY"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "レイアウト コンテンツ"
+    },
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "format": "uri-reference",
+          "markdownDescription": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
+          "type": "string",
+          "description": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerControlWheel": {
+      "markdownDescription": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "title": "タッチ レイアウト レイヤー コントロール ホイール"
+    },
+    "_SystemColorAccentSecondary": {
+      "markdownDescription": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
+      "description": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "アクセントのセカンダリ システムの色のオーバーライド"
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "markdownDescription": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "コントロールの切り替えスタイル"
+    },
+    "LayoutLowerArrayContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "title": "下位レイアウト配列のコンテンツ"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "2 次元軸マッピング"
+    },
+    "ThrottleAxisOutput": {
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "title": "スロットル軸"
+    },
+    "ColorPaletteDefaultVariant": {
+      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
+      "description": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "既定の色"
+    },
+    "Deadzone1D": {
+      "markdownDescription": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "1 次元のデッドゾーン"
+    },
+    "JoystickOutlineWithIndicator": {
+      "markdownDescription": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "title": "アウトライン スタイル設定コンポーネント"
+    },
+    "_ControllerButtonOutputType": {
+      "markdownDescription": "ゲームパッド ボタンの押下を出力します。",
+      "type": "string",
+      "description": "ゲームパッド ボタンの押下を出力します。",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "title": "ゲームパッド ボタンの出力"
+    },
+    "ButtonActivatedStyle": {
+      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "コントロールがアクティブ化されたスタイル"
+    },
+    "JoystickStyles": {
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "title": "コントロールのスタイル"
+    },
+    "ButtonDisabledStyle": {
+      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "コントロールの無効なスタイル"
+    },
+    "LayoutActionTarget": {
+      "markdownDescription": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "title": "レイアウト アクション ターゲット"
+    },
+    "_ControlTypeButton": {
+      "const": "button",
+      "markdownDescription": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
+      "type": "string",
+      "description": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
+      "title": "ボタン コントロールの種類"
+    },
+    "_ControllerAnalog1DOutputType": {
+      "markdownDescription": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
+      "type": "string",
+      "description": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "title": "ゲームパッドのアナログ ジョイスティック出力"
+    },
+    "_LayoutAction": {
+      "type": "object",
+      "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "const": "layer",
+          "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+          "type": "string",
+          "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+          "title": "レイアウト アクション"
+        }
+      },
+      "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "title": "レイアウト アクション",
+      "required": [
+        "type",
+        "target"
+      ],
+      "additionalProperties": false
+    },
+    "InnerLayoutControlWheel": {
+      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "output": "leftJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "title": "内側​​"
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_ControllerTriggerOutputType": {
+      "markdownDescription": "指定されたゲームパッド トリガーにマップされる値を出力します。",
+      "type": "string",
+      "description": "指定されたゲームパッド トリガーにマップされる値を出力します。",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "title": "ゲームパッドのアナログ トリガー出力"
+    },
+    "DirectionalPadStyles": {
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "コントロールのアイドルのスタイル"
+            },
+            "disabled": {
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "コントロールがアクティブ化されたスタイル"
+            },
+            "activated": {
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "コントロールがアクティブ化されたスタイル"
+            },
+            "default": {
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "コントロールの既定のスタイル"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "gradient": {
+              "color": "#0099ffaa"
+            },
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "title": "コントロールのスタイル"
+    },
+    "Indicator": {
+      "markdownDescription": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
+      "description": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "インジケーターのスタイル設定コンポーネント"
+    },
+    "Stroke": {
+      "markdownDescription": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
+      "description": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "ストローク スタイル設定コンポーネント"
+    },
+    "Gradient": {
+      "markdownDescription": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "title": "グラデーション"
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "markdownDescription": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "title": "ゲームパッド アクション"
+    },
+    "_DirectionalPad": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_TurboAction": {
+      "title": "ターボ アクション",
+      "properties": {
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "const": "turbo",
+          "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+          "type": "string",
+          "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+          "title": "ターボ アクション"
+        },
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        }
+      },
+      "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+      "type": "object",
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+      "additionalProperties": false
+    },
+    "ControlGroup": {
+      "markdownDescription": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "title": "タッチ レイアウト コントロール グループ"
+    },
+    "_SystemColorContrastPrimary": {
+      "markdownDescription": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
+      "description": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "コントラストのプライマリ システムの色のオーバーライド"
+    },
+    "ControlGroupItem": {
+      "markdownDescription": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+      "title": "タッチ レイアウト コントロール グループ アイテム"
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionThreshold": {
+      "markdownDescription": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "title": "アクションのしきい値"
+    },
+    "ArcadeButtonStyles": {
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "コントロールのアイドルのスタイル"
+            },
+            "disabled": {
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "コントロールの無効なスタイル"
+            },
+            "activated": {
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "コントロールがアクティブ化されたスタイル"
+            },
+            "default": {
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "コントロールの既定のスタイル"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "activated": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            }
+          },
+          "default": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "title": "コントロールのスタイル"
+    },
+    "_BackgroundAsset": {
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "背景のスタイルを設定するために使用するカスタム資産です。",
+          "type": "string",
+          "description": "背景のスタイルを設定するために使用するカスタム資産です。"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_FaceImageIcon": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        "type": {
+          "const": "icon",
+          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
+          "type": "string",
+          "description": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
+          "title": "顔画像アイコンのスタイル設定コンポーネント"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "markdownDescription": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "title": "顔画像アイコン"
+    },
+    "Toggle": {
+      "markdownDescription": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "title": "トグル"
+    },
+    "ArcadeButtonStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ]
+    },
+    "_ControlTypeTouchpad": {
+      "const": "touchpad",
+      "markdownDescription": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
+      "type": "string",
+      "description": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
+      "title": "タッチパッド コントロールの種類"
+    },
+    "ThrottleStyles": {
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールの既定のスタイル"
+            },
+            "idleUp": {
+              "markdownDescription": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
+              "description": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールのアイドル アップのスタイル"
+            },
+            "activatedDown": {
+              "markdownDescription": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "description": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールがアクティブ化されたダウン スタイル"
+            },
+            "disabled": {
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールの無効なスタイル"
+            },
+            "activatedUp": {
+              "markdownDescription": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "description": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールがアクティブ化されたアップ スタイル"
+            },
+            "idle": {
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールのアイドルのスタイル"
+            },
+            "activated": {
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "コントロールがアクティブ化されたスタイル"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "axisDown": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "title": "コントロールのスタイル"
+    },
+    "SensorLayerControl": {
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "レイヤー センサー コントロール",
+      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_SystemColorActionColor": {
+      "markdownDescription": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "description": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "アクション システムの色のオーバーライド"
+    },
+    "LayoutSensorContent": {
+      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "title": "センサー レイアウト コンテンツ"
+    },
+    "LayoutColors": {
+      "markdownDescription": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            },
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "examples": [
+        {},
+        {
+          "highContrast": {
+            "myColor": "#00ff00ff",
+            "system_contentPrimary": "#ffffffff"
+          },
+          "default": {
+            "myColor": "#ff0000ff",
+            "system_contentPrimary": "#ffffffff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "title": "色"
+    },
+    "LayoutUpperContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "title": "上部レイアウトのコンテンツ"
+    },
+    "_Color": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ]
+    },
     "DirectionalPadDefaultStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
       "examples": [
         {},
         {
@@ -42,39 +2278,855 @@
         {
           "$ref": "#/definitions/commonDPadStyle"
         }
-      ],
+      ]
+    },
+    "RelativeInteraction": {
+      "markdownDescription": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "type": "boolean"
         },
         {
           "$ref": "#/$defs/Reference"
         }
+      ],
+      "description": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "title": "相対"
+    },
+    "ButtonPulledStyle": {
+      "markdownDescription": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "コントロールの pull されたスタイル"
+    },
+    "InputCurveType": {
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "title": "[非推奨] 入力応答曲線の種類",
+      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。"
+    },
+    "ThrottleAxisStyle": {
+      "markdownDescription": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+      "examples": [
+        {
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          },
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        }
+      ],
+      "title": "スロットル軸のスタイル設定コンポーネント"
+    },
+    "ButtonDefaultStyle": {
+      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "コントロールの既定のスタイル"
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FillColor": {
+      "markdownDescription": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "description": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "$ref": "#/$defs/_Color",
+      "title": "塗りつぶし"
+    },
+    "PullIndicatorBackground": {
+      "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "title": "背景スタイル設定コンポーネント"
+    },
+    "_Button": {
+      "type": "object",
+      "required": [
+        "type",
+        "action"
+      ],
+      "examples": [
+        {
+          "type": "button",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          },
+          "action": "gamepadA"
+        }
+      ],
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DirectionalPadInteraction": {
+      "markdownDescription": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "title": "対話式操作"
+    },
+    "ButtonStyles": {
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "title": "コントロールのスタイル"
+    },
+    "_CustomColorPaletteColor": {
+      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
+      "description": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "カスタム レイアウトの色"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "markdownDescription": "出力値を生成するために必要な正規化された入力値です。",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "出力値を生成するために必要な正規化された入力値です。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "title": "しきい値"
+    },
+    "_SystemColorContrastSecondary": {
+      "markdownDescription": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
+      "description": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "コントラスト セカンダリ システムの色のオーバーライド"
+    },
+    "_SystemColorGamepadActionColor": {
+      "markdownDescription": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "description": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "ゲームパッド アクション システムの色のオーバーライド"
+    },
+    "AssetReference": {
+      "markdownDescription": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "title": "資産参照スタイル設定コンポーネント"
+    },
+    "FaceImage": {
+      "markdownDescription": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "title": "顔画像のスタイル設定コンポーネント"
+    },
+    "_ControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ],
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      }
+    },
+    "JoystickActivatedStyle": {
+      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "コントロールがアクティブ化されたスタイル"
+    },
+    "LayoutLowerContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "title": "下位レイアウトのコンテンツ"
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ControlVisibility": {
+      "markdownDescription": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "表示"
+    },
+    "LayerLowerArrayContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "title": "下位レイヤー配列のコンテンツ"
+    },
+    "OuterLayoutControlWheel": {
+      "markdownDescription": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "title": "外側​​"
+    },
+    "ControlEnabled": {
+      "markdownDescription": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "有効"
+    },
+    "ExpandInteraction": {
+      "markdownDescription": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "title": "展開"
+    },
+    "Deadzone2D": {
+      "markdownDescription": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            },
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
+      "examples": [
+        {
+          "threshold": 0,
+          "radial": true
+        },
+        {
+          "threshold": 0.1,
+          "radial": false
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "2 次元のデッドゾーン"
+    },
+    "_ColorPaletteColor": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ]
+    },
+    "_InputAxisZY": {
+      "const": "axisZY",
+      "markdownDescription": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "type": "string",
+      "description": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "title": "Z 軸と Y 軸の入力マッピング"
+    },
+    "DirectionalPadIdleStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "gradient": {
+            "color": "#0099ffaa"
+          },
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
       ]
     },
     "Definitions": {
-      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "additionalProperties": false,
-      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
-      "title": "定義",
       "examples": [
         {},
         {
@@ -93,95 +3145,184 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "定義",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/LayoutDefinableType"
         }
       },
-      "type": "object"
+      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "type": "object",
+      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "additionalProperties": false
     },
-    "_InputAxisXY": {
-      "description": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
-      "title": "X 軸と Y 軸の入力マッピング",
+    "_SystemColorContentSecondary": {
+      "markdownDescription": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
+      "description": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "コンテンツ セカンダリ システムの色のオーバーライド"
+    },
+    "Color": {
+      "markdownDescription": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "description": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "$ref": "#/$defs/_Color",
+      "title": "色"
+    },
+    "_RelativeMouse1DOutputType": {
+      "markdownDescription": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
       "type": "string",
-      "const": "axisXY",
-      "markdownDescription": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。"
-    },
-    "LayerControlGroupItem": {
-      "description": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+      "description": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "title": "タッチ レイアウト レイヤー コントロール グループ アイテム",
+      "title": "相対マウスの 1 次元出力"
+    },
+    "_ArcadeButtons": {
+      "type": "object",
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
       "examples": [
         {
-          "$ref": "#/definitions/commonLayerButtonControl"
+          "type": "arcadeButtons",
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          }
         }
       ],
-      "markdownDescription": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。"
+      "properties": {
+        "specialPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "スペシャル パンチ ボタン"
+        },
+        "heavyPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "ヘビー キック ボタン"
+        },
+        "lightPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "ライト パンチ ボタン"
+        },
+        "lightKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "ライト キック ボタン"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        },
+        "mediumKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "ミディアム キック ボタン"
+        },
+        "specialKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "スペシャル キック ボタン"
+        },
+        "heavyKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "ヘビー キック ボタン"
+        },
+        "mediumPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "ミディアム パンチ ボタン"
+        }
+      },
+      "additionalProperties": false
     },
-    "Indicator": {
-      "description": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
-      "title": "インジケーターのスタイル設定コンポーネント",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。"
-    },
-    "FaceImage": {
-      "description": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+    "OuterLayerControlWheel": {
+      "markdownDescription": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "顔画像のスタイル設定コンポーネント",
+      "description": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
       "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
         {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
+          "$ref": "#/definitions/commonLayerOuterWheel"
         }
       ],
-      "markdownDescription": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、対話の意味を示すために使用されます。顔画像には、`icon` または `asset` の種類を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。"
+      "title": "外側​​"
     },
-    "ControlGroupItem": {
-      "description": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+    "_InputMapping3DTo2DOutput": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControlBase"
+          "$ref": "#/$defs/_InputMappingXY"
         },
         {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_InputMappingZY"
         }
-      ],
-      "title": "タッチ レイアウト コントロール グループ アイテム",
-      "markdownDescription": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。"
+      ]
+    },
+    "_ControlTypeThrottle": {
+      "const": "throttle",
+      "markdownDescription": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
+      "type": "string",
+      "description": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
+      "title": "スロットル コントロールの種類"
     },
     "LayoutOrientation": {
-      "markdownDescription": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
-      "deprecated": true,
+      "title": "[非推奨] レイアウトの向き",
+      "description": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
       "enum": [
         "landscape-left",
         "landscape-right",
@@ -189,202 +3330,291 @@
         "portrait-up",
         "portrait"
       ],
-      "description": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
-      "title": "[非推奨] レイアウトの向き",
+      "deprecated": true,
+      "markdownDescription": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
       "type": "string"
     },
-    "PullIndicator": {
-      "description": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
             }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          ]
         },
-        {
-          "$ref": "#/$defs/Reference"
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
         }
-      ],
-      "title": "pull インジケーターのスタイル設定コンポーネント",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "markdownDescription": "コントロールが現在 pull されているインジケーターの視覚的なスタイル設定です。この色は、コントロールを pull する意味論を示すようにカスタマイズできます。"
+      },
+      "additionalProperties": false
     },
-    "_ActionTypeBase": {
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          }
-        }
-      ]
-    },
-    "_CustomColorPaletteColor": {
-      "description": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
-      "title": "カスタム レイアウトの色",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。"
-    },
-    "ColorPaletteHighContrastVariant": {
-      "description": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
-      "title": "ハイ コントラストの色のみ",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。"
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "description": "指定したゲーム パッドジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "ゲームパッドのアナログ ジョイスティック出力",
+    "_InputAxisXY": {
+      "const": "axisXY",
+      "markdownDescription": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
       "type": "string",
-      "markdownDescription": "指定したゲーム パッドジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。"
+      "description": "コントロールの X 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "title": "X 軸と Y 軸の入力マッピング"
     },
-    "JoystickStyles": {
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+    "PullActionType": {
+      "markdownDescription": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "description": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "pull アクションの制御"
+    },
+    "Knob": {
+      "markdownDescription": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
             },
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
             },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
+            "background": {
+              "$ref": "#/$defs/Background"
             },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "コントロールのスタイル",
+      "description": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
       "examples": [
-        {},
         {
-          "default": {
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyles"
+          "$ref": "#/definitions/commonControlKnobStyling"
         }
       ],
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。"
+      "title": "ノブ スタイル設定コンポーネント"
     },
-    "_InputMappingZY": {
+    "Control": {
+      "markdownDescription": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+          "$ref": "#/$defs/_ControlBase"
         },
         {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
-    },
-    "LayerControlGroup": {
+      ],
+      "description": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
       "examples": [
-        [],
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "title": "タッチ レイアウト コントロール"
+    },
+    "LayerUpperRightContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
+      "examples": [
         [
-          null,
           {
             "type": "blank"
           },
-          null
-        ]
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
       ],
-      "description": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
-      "minItems": 1,
-      "title": "タッチ レイアウト レイヤー コントロール グループ",
-      "markdownDescription": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      },
-      "maxItems": 4
+      "title": "上位レイヤーの右側のコンテンツ"
     },
-    "ThrottleAxisOutput": {
-      "description": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+    "AxisCapColor": {
+      "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+              "type": "string",
+              "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+              "title": "軸キャップ スタイル設定コンポーネント"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "スロットル軸",
+      "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
       "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
         {
-          "$ref": "#/definitions/commonThrottleAxis"
+          "type": "color",
+          "value": "#0099ffaa"
         }
       ],
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの対話から、中間点から指定された出力への上または下への単一のマッピングを定義します。"
+      "title": "軸キャップ スタイル設定コンポーネント"
+    },
+    "_Throttle": {
+      "type": "object",
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "examples": [
+        {
+          "sticky": true,
+          "type": "throttle",
+          "axisDown": "leftTrigger",
+          "axisUp": "rightTrigger"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_Blank": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "properties": {
+        "type": {
+          "const": "blank",
+          "markdownDescription": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
+          "type": "string",
+          "description": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
+          "title": "空白のコントロールの種類"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RenderAsButton": {
+      "markdownDescription": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "title": "[レンダリング] ボタン"
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
     },
     "_InputMappingXYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
       "properties": {
         "sensitivity": {
           "$ref": "#/$defs/Sensitivity"
@@ -396,374 +3626,444 @@
           "$ref": "#/$defs/_InputAxisXY"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": false
+    },
+    "ColorPaletteHighContrastVariant": {
+      "markdownDescription": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "description": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "ハイ コントラストの色のみ"
+    },
+    "LayoutStyles": {
+      "markdownDescription": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "description": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "$ref": "#/$defs/_LayoutStyles",
+      "title": "レイアウト スタイル"
+    },
+    "LayerControlGroup": {
+      "type": "array",
+      "markdownDescription": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "minItems": 1,
+      "description": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "maxItems": 4,
+      "title": "タッチ レイアウト レイヤー コントロール グループ",
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      }
+    },
+    "_BackgroundColor": {
       "type": "object",
       "required": [
-        "input",
-        "output"
-      ]
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "type": {
+          "const": "color",
+          "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+          "type": "string",
+          "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
     },
     "_Gyroscope": {
-      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "output": "rightJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
       "properties": {
         "axis": {
           "$ref": "#/$defs/AxisMapping3D"
         },
         "type": {
-          "description": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
-          "title": "ジャイロスコープ コントロールの種類",
-          "type": "string",
           "const": "gyroscope",
-          "markdownDescription": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。"
+          "markdownDescription": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
+          "type": "string",
+          "description": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
+          "title": "ジャイロスコープ コントロールの種類"
         },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         }
       },
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "input": "axisXY",
-            "output": "rightJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
+      "additionalProperties": false
     },
-    "LayerLowerArrayContent": {
-      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+    "FaceImageIconLabel": {
+      "markdownDescription": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
       "anyOf": [
         {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "下位レイヤー配列のコンテンツ",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。"
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "_SystemColorContrastSecondary": {
-      "description": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
-      "title": "コントラスト セカンダリ システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。"
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "description": "このプロパティを使用すると、1 つのゲーム パッド アクションまたはゲーム パッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "ゲームパッド アクション",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "markdownDescription": "このプロパティを使用すると、1 つのゲーム パッド アクションまたはゲーム パッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。"
-    },
-    "_Color": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ExpandInteraction": {
-      "description": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "展開",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な領域を埋めるために、コントロールの対話可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。"
-    },
-    "ControlEnabled": {
-      "description": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "有効",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "markdownDescription": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。"
-    },
-    "_ControlTypeButton": {
-      "description": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。",
-      "title": "ボタン コントロールの種類",
-      "type": "string",
-      "const": "button",
-      "markdownDescription": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロールの種類です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、2 つ目の同時アクションが、撮影中の目標など、コントロールの主なアクションと連携して必要な場合に役立ちます。"
-    },
-    "PullIndicatorBackground": {
-      "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "背景スタイル設定コンポーネント",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。"
-    },
-    "PullActionType": {
-      "description": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
-      "title": "pull アクションの制御",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "このプロパティを使用すると、コントロールが `pulled` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。"
-    },
-    "ControlGroup": {
-      "markdownDescription": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
-      "items": {
-        "$ref": "#/$defs/ControlGroupItem"
-      },
-      "description": "グループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。コントロールが 1 つだけのグループは、グループ化されていないコントロールとは異なります。グループには、より大きな操作領域が含まれる可能性があります。`null` の特別な値を使用して、配置内のコントロールをスキップできることに注意してください。",
-      "title": "タッチ レイアウト コントロール グループ",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
           },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerSensorContent": {
-      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "センサー レイヤーのコンテンツ",
+      "description": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
       "examples": [
-        [
-          {
-            "type": "blank"
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "title": "顔画像アイコンラベルのスタイル設定コンポーネント"
+    },
+    "TouchpadStyles": {
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "コントロールのアイドルのスタイル"
+            },
+            "disabled": {
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "コントロールの無効なスタイル"
+            },
+            "activated": {
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "コントロールがアクティブ化されたスタイル"
+            },
+            "moving": {
+              "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+              "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "コントロールの移動スタイル"
+            },
+            "default": {
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "コントロールの既定のスタイル"
+            }
           },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
             }
           }
-        ],
+        },
         {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
+          "$ref": "#/definitions/commonTouchpadControlStyles"
         }
       ],
-      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。"
+      "title": "コントロールのスタイル"
     },
-    "ButtonActivatedStyle": {
-      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
+    "Layer": {
+      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
       "anyOf": [
         {
+          "type": "object",
+          "properties": {
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "sticky": true,
+                "type": "throttle",
+                "axisDown": "leftTrigger",
+                "axisUp": "rightTrigger"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "title": "タッチ レイアウト レイヤー"
+    },
+    "LayerControlGroupItem": {
+      "markdownDescription": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "title": "タッチ レイアウト レイヤー コントロール グループ アイテム"
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "title": "右上のレイアウト コンテンツ"
+    },
+    "JoystickDefaultStyle": {
+      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
             },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
             "opacity": {
               "$ref": "#/$defs/Opacity"
             },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "コントロールがアクティブ化されたスタイル",
+      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
       "examples": [
         {},
         {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonButtonStyle"
+          "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
+      "title": "コントロールの既定のスタイル"
     },
-    "_InputMapping1DToGamepad1DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
+    "_ControllerAnalog2DOutputType": {
+      "markdownDescription": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
+      "type": "string",
+      "description": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "title": "ゲームパッドのアナログ ジョイスティック出力"
+    },
+    "LayerLowerContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
         },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
+        {
+          "$ref": "#/$defs/Reference"
         }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
+      ],
+      "description": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "title": "下位レイヤーのコンテンツ"
     },
     "LayoutDefinableType": {
-      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -1078,731 +4378,42 @@
           "$ref": "#/$defs/TouchpadStyles"
         }
       ],
-      "title": "定義可能な型",
-      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください"
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_TurboAction": {
-      "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-      "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        },
-        "type": {
-          "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
-          "title": "ターボ アクション",
-          "type": "string",
-          "const": "turbo",
-          "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。"
-        },
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        }
-      },
-      "title": "ターボ アクション",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "type": "object"
-    },
-    "_ArcadeButtons": {
-      "additionalProperties": false,
-      "properties": {
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ミディアム パンチ ボタン"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ヘビー キック ボタン"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ヘビー キック ボタン"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ライト キック ボタン"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "スペシャル キック ボタン"
-        },
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "スペシャル パンチ ボタン"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ライト パンチ ボタン"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "ミディアム キック ボタン"
-        }
-      },
-      "examples": [
-        {
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "type": "arcadeButtons",
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ]
-    },
-    "Opacity": {
-      "description": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "type": "number",
-          "maximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "不透明度",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "markdownDescription": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。"
-    },
-    "LayoutColors": {
-      "description": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            },
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "色",
-      "examples": [
-        {},
-        {
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "markdownDescription": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。"
-    },
-    "_ControllerTriggerOutputType": {
-      "description": "指定されたゲームパッド トリガーにマップされる値を出力します。",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "ゲームパッドのアナログ トリガー出力",
-      "type": "string",
-      "markdownDescription": "指定されたゲームパッド トリガーにマップされる値を出力します。"
-    },
-    "ButtonDefaultStyle": {
-      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールの既定のスタイル",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。"
-    },
-    "_ControlTypeDirectionalPad": {
-      "description": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
-      "title": "方向パッド コントロールの種類",
-      "type": "string",
-      "const": "directionalPad",
-      "markdownDescription": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。"
-    },
-    "_ControlTypeTouchpad": {
-      "description": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
-      "title": "タッチパッド コントロールの種類",
-      "type": "string",
-      "const": "touchpad",
-      "markdownDescription": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` を持つボタンとしてレンダリングして、動きやカメラと、目標やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。"
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "DirectionalPadInteraction": {
-      "description": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
-      "anyOf": [
-        {
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "対話式操作",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "markdownDescription": "このプロパティは、プレーヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。"
-    },
-    "_ControllerAction": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        }
-      ]
-    },
-    "LayerControl": {
-      "description": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー コントロール",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "markdownDescription": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。"
-    },
-    "AxisMapping3D": {
-      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "3 次元軸マッピング",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。"
-    },
-    "ActionType": {
-      "description": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
-      "title": "コントロール アクション",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。"
-    },
-    "InputCurveType": {
-      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
-      "deprecated": true,
-      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線の種類を定義します。`circular` の種類を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
-      "title": "[非推奨] 入力応答曲線の種類",
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ColorPaletteColor": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "TouchpadStyles": {
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "title": "コントロールの既定のスタイル",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。"
-            },
-            "idle": {
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "title": "コントロールのアイドルのスタイル",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。"
-            },
-            "disabled": {
-              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "title": "コントロールの無効なスタイル",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。"
-            },
-            "activated": {
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "title": "コントロールがアクティブ化されたスタイル",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
-            },
-            "moving": {
-              "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
-              "title": "コントロールの移動スタイル",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのスタイル",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。"
-    },
-    "ButtonIdleStyle": {
-      "description": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのアイドルのスタイル",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、対話されていないことを示します。"
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "additionalProperties": false,
-      "properties": {
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "examples": [
-        {},
-        {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "type": "object",
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      }
-    },
-    "Control": {
-      "description": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "タッチ レイアウト コントロール",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "markdownDescription": "プレイヤーが操作して翻訳された操作を実行できる個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。"
-    },
-    "_ControllerButtonOutputType": {
-      "description": "ゲームパッド ボタンの押下を出力します。",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "ゲームパッド ボタンの出力",
-      "type": "string",
-      "markdownDescription": "ゲームパッド ボタンの押下を出力します。"
-    },
-    "ButtonToggledStyle": {
-      "description": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールの切り替えスタイル",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。"
-    },
-    "_RelativeMouse2DOutputType": {
-      "description": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
-      "title": "相対マウスの 2 次元出力",
-      "type": "string",
-      "const": "relativeMouse",
-      "markdownDescription": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。"
-    },
-    "_ControlTypeArcadeButtons": {
-      "description": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
-      "title": "アーケード ボタン コントロールの種類",
-      "type": "string",
-      "const": "arcadeButtons",
-      "markdownDescription": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。"
+      "description": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含む共用体型です。詳細については、`definitions` セクションを参照してください",
+      "title": "定義可能な型"
     },
     "LayoutControlWheel": {
-      "description": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
+      "markdownDescription": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            },
             "inner": {
               "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "タッチ レイアウト コントロール ホイール",
+      "description": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
       "examples": [
         {},
         {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "output": "leftJoystick",
+                "input": "axisXY"
+              }
+            }
+          ],
           "outer": [
             null,
             [
@@ -1815,818 +4426,148 @@
               "type": "button",
               "action": "gamepadY"
             }
-          ],
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "input": "axisXY",
-                "output": "leftJoystick"
-              }
-            }
           ]
         },
         {
           "$ref": "#/definitions/commonControlWheel"
         }
       ],
-      "markdownDescription": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。"
+      "title": "タッチ レイアウト コントロール ホイール"
     },
-    "Reference": {
-      "additionalProperties": false,
-      "properties": {
-        "$ref": {
-          "description": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
-          "exmaples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ],
-          "type": "string",
-          "format": "uri-reference",
-          "markdownDescription": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。"
-        }
-      },
-      "type": "object",
-      "required": [
-        "$ref"
-      ]
-    },
-    "LayerUpperRightContent": {
-      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "上位レイヤーの右側のコンテンツ",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロールの種類を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。"
-    },
-    "LayoutStyles": {
-      "description": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
-      "title": "レイアウト スタイル",
-      "$ref": "#/$defs/_LayoutStyles",
-      "markdownDescription": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。"
-    },
-    "OuterWheelControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Control"
-        },
-        {
-          "$ref": "#/$defs/ControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonStyles": {
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのスタイル",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。"
-    },
-    "JoystickMovingStyle": {
-      "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールの移動スタイル",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。"
-    },
-    "LayoutActionTarget": {
-      "description": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "レイアウト アクション ターゲット",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。"
-    },
-    "DirectionalPadStyles": {
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "title": "コントロールの既定のスタイル",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。"
-            },
-            "idle": {
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。",
-              "title": "コントロールのアイドルのスタイル",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、対話中でないことを示します。"
-            },
-            "disabled": {
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "title": "コントロールがアクティブ化されたスタイル",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
-            },
-            "activated": {
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "title": "コントロールがアクティブ化されたスタイル",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのスタイル",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。"
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "AssetReference": {
-      "description": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "資産参照スタイル設定コンポーネント",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "markdownDescription": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シートアセットの場合、拡張子の後に`/`とスプライトアトラス内のスプライト名を付けずにテクスチャ ファイル名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。"
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "description": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
-      "title": "スロットル コントロールの種類",
+    "_RelativeMouse2DOutputType": {
+      "const": "relativeMouse",
+      "markdownDescription": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
       "type": "string",
-      "const": "throttle",
-      "markdownDescription": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。"
+      "description": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
+      "title": "相対マウスの 2 次元出力"
     },
-    "_Null": {
-      "description": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
-      "title": "Null",
-      "examples": [
-        null
-      ],
-      "type": "null",
-      "markdownDescription": "これは、場所をスキップするコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。"
-    },
-    "_SystemColorAccentPrimary": {
-      "description": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
-      "title": "アクセントのプライマリ システム カラーのオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。"
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ArcadeButtonStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ],
+    "LayerControl": {
+      "markdownDescription": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Deadzone2D": {
-      "description": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ]
+          "$ref": "#/$defs/_LayerControlBase"
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "2 次元のデッドゾーン",
+      "description": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロールの種類を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
       "examples": [
         {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
+          "$ref": "#/definitions/commonLayerButtonControl"
         }
       ],
-      "markdownDescription": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。"
+      "title": "タッチ レイアウト レイヤー コントロール"
     },
-    "DirectionalPadIdleStyle": {
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          }
-        }
-      ],
-      "title": "2 次元軸マッピング",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。"
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "OuterLayerControlWheel": {
-      "description": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "外側​​",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。"
-    },
-    "FillColor": {
-      "description": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
-      "title": "塗りつぶし",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。"
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_InputAxisMagnitudinal": {
-      "description": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "軸のマグニチューディナル入力マッピング",
-      "type": "string",
-      "markdownDescription": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。"
-    },
-    "_LayoutStyles": {
-      "examples": [
-        {},
-        {
-          "colors": {
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "description": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。",
+    "Sensitivity": {
+      "markdownDescription": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
       "anyOf": [
         {
           "type": "number",
-          "minimum": 0
+          "exclusiveMinimum": 0
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "アクションのしきい値",
+      "description": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
       "examples": [
-        1,
+        10,
         1.5,
-        0,
+        0.5,
         {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
         }
       ],
-      "markdownDescription": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの対話が割り当てられたアクションをすぐに実行することを意味します。"
+      "title": "感度"
     },
-    "ControlVisibility": {
-      "description": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+    "InnerLayerControlWheel": {
+      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
       "anyOf": [
         {
-          "type": "boolean"
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "表示",
+      "description": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
       "examples": [
-        true,
-        false,
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
         {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "markdownDescription": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレーヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。"
+      "title": "内側​​"
     },
-    "_BackgroundAsset": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "背景のスタイルを設定するために使用するカスタム資産です。",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "背景のスタイルを設定するために使用するカスタム資産です。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        }
-      },
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
+    "_Joystick": {
       "type": "object",
       "required": [
         "type",
-        "value"
-      ]
-    },
-    "Gradient": {
-      "description": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+        "axis"
       ],
-      "title": "グラデーション",
       "examples": [
         {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          },
+          "type": "joystick",
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
           }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
         }
       ],
-      "markdownDescription": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。"
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "additionalProperties": false
     },
     "InputCurve": {
-      "markdownDescription": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
-      "deprecated": true,
-      "description": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
-      "title": "[非推奨] 入力応答曲線",
       "examples": [
         {
           "type": "circular",
@@ -2646,8 +4587,15 @@
           "$ref": "#/$defs/commonJoystickResponseCurve"
         }
       ],
+      "title": "[非推奨] 入力応答曲線",
+      "description": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
       "anyOf": [
         {
+          "type": "object",
+          "required": [
+            "range",
+            "type"
+          ],
           "properties": {
             "type": {
               "$ref": "#/$defs/InputCurveType"
@@ -2656,247 +4604,61 @@
               "$ref": "#/$defs/InputCurveRange"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerLowerContent": {
-      "description": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "下位レイヤーのコンテンツ",
+      "deprecated": true,
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。"
+    },
+    "AxisMapping3D": {
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
       "examples": [
         {
-          "center": {
-            "type": "blank"
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
           }
-        },
+        ],
         {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+          "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。"
-    },
-    "_InputAxis1D": {
-      "anyOf": [
-        {
-          "description": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
-          "title": "X 軸入力マッピング",
-          "type": "string",
-          "const": "axisX",
-          "markdownDescription": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。"
-        },
-        {
-          "description": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
-          "title": "Y 軸の入力マッピング",
-          "type": "string",
-          "const": "axisY",
-          "markdownDescription": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。"
-        }
-      ]
-    },
-    "Toggle": {
-      "description": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "トグル",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。"
-    },
-    "_Joystick": {
-      "additionalProperties": false,
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeJoystick"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "styles": {
-          "$ref": "#/$defs/JoystickStyles"
-        },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          },
-          "type": "joystick",
-          "styles": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "icon",
-                  "value": "walk"
-                }
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "JoystickActivatedStyle": {
-      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールがアクティブ化されたスタイル",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
-    },
-    "TouchpadStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
+      "title": "3 次元軸マッピング"
     },
     "_RelativeMouseMagnitudinalOutputType": {
+      "markdownDescription": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
+      "type": "string",
       "description": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
       "enum": [
         "relativeMouseUp",
@@ -2904,39 +4666,60 @@
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "相対マウス方向の方向出力",
-      "type": "string",
-      "markdownDescription": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。"
+      "title": "相対マウス方向の方向出力"
     },
-    "JoystickOutlineWithIndicator": {
-      "description": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+    "_InputAxisMagnitudinal": {
+      "markdownDescription": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
+      "type": "string",
+      "description": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "title": "軸のマグニチューディナル入力マッピング"
+    },
+    "_InputAxis1D": {
       "anyOf": [
         {
+          "const": "axisX",
+          "markdownDescription": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "type": "string",
+          "description": "指定された出力に変換するために、コントロールの X 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "title": "X 軸入力マッピング"
+        },
+        {
+          "const": "axisY",
+          "markdownDescription": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "type": "string",
+          "description": "指定された出力に変換するために、コントロールの Y 軸に沿った相互作用 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "title": "Y 軸の入力マッピング"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "markdownDescription": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             },
             "stroke": {
               "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "アウトライン スタイル設定コンポーネント",
+      "description": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
       "examples": [
         {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
           "stroke": {
             "type": "solid",
             "color": "#0099ffaa"
@@ -2946,158 +4729,15 @@
           "$ref": "#/definitions/commonOutlineStyling"
         }
       ],
-      "markdownDescription": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。"
-    },
-    "_ControlTypeJoystick": {
-      "description": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
-      "title": "ジョイスティック コントロールの種類",
-      "type": "string",
-      "const": "joystick",
-      "markdownDescription": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。"
-    },
-    "ColorPaletteDefaultVariant": {
-      "description": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
-      "title": "既定の色",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。"
-    },
-    "InnerLayoutControlWheel": {
-      "description": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "内側​​",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "input": "axisXY",
-              "output": "leftJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された 1 ~ 4 個のコントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。"
-    },
-    "SensorControl": {
-      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロールの種類とその目的については、`type` プロパティを参照してください。",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ]
-        }
-      },
-      "title": "センサー コントロール",
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_BackgroundColor": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
-          "type": "string",
-          "const": "color",
-          "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/Color"
-        }
-      },
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
+      "title": "アウトライン スタイル設定コンポーネント"
     },
     "ThrottleStyleBase": {
-      "examples": [
-        {
-          "axisUp": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "axisDown": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          }
-        }
-      ],
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
+            "knob": {
+              "$ref": "#/$defs/Knob"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
@@ -3108,214 +4748,59 @@
             "axisDown": {
               "$ref": "#/$defs/ThrottleAxisStyle"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Sticky": {
-      "description": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
-      "anyOf": [
-        {
-          "type": "boolean"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "付箋",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、プレイヤーがコントロールとの対話を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、船のコントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。"
-    },
-    "RenderAsButton": {
-      "description": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "[レンダリング] ボタン",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "markdownDescription": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。"
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "type": "string",
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ]
-        }
-      ]
-    },
-    "_Button": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
       "examples": [
         {
-          "action": "gamepadA",
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
+          "axisUp": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "axisDown": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
             }
           }
         }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "action"
       ]
-    },
-    "JoystickDirectionIndicator": {
-      "description": "対話の方向を示す視覚的なスタイル設定",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "方向インジケーターのスタイル設定コンポーネント",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "markdownDescription": "対話の方向を示す視覚的なスタイル設定"
-    },
-    "Color": {
-      "description": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
-      "title": "色",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。"
-    },
-    "OuterLayoutControlWheel": {
-      "description": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "外側​​",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "ホイールの外側のリングに存在するコントロールまたはコントロール グループの外側のリングを定義します。各インデックスには、1 つのコントロールまたはコントロールの配列を指定できます。配列を指定すると、このコントロール グループは操作領域の 2 倍になり、追加されたコントロールはホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには、8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以外のコントロールは削除されるか、検証規則の失敗を引き起こす可能性があります。`null` コントロールは、外側のホイール配列の先頭でコントロール グループをオフセットするために使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。"
     },
     "_AxisMapping3DItem": {
-      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
       "anyOf": [
         {
           "$ref": "#/$defs/_InputMapping3DTo2DOutput"
@@ -3324,7 +4809,7 @@
           "$ref": "#/$defs/_AxisMapping2DItem"
         }
       ],
-      "title": "3 次元軸マッピング アイテム",
+      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。",
       "examples": [
         {
           "sensitivity": 0.3,
@@ -3332,43 +4817,85 @@
           "input": "axisXY"
         },
         {
-          "input": "axisUp",
-          "output": "rightTrigger"
+          "output": "rightTrigger",
+          "input": "axisUp"
         },
         {
           "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレーヤーに向かってビデオから外れているということです。"
+      "title": "3 次元軸マッピング アイテム"
     },
-    "_RelativeMouse1DOutputType": {
-      "description": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "相対マウスの 1 次元出力",
-      "type": "string",
-      "markdownDescription": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。"
+    "ActionType": {
+      "markdownDescription": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "description": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "コントロール アクション"
     },
-    "_InputMapping1D": {
+    "Layers": {
+      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+          "type": "object",
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          },
+          "additionalProperties": false
         },
         {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
+      ],
+      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "sticky": true,
+                  "type": "throttle",
+                  "axisDown": "leftTrigger",
+                  "axisUp": "rightTrigger"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "title": "タッチ レイアウト レイヤー"
     },
-    "ArcadeButton": {
-      "description": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。",
+    "DeadzoneRadial": {
+      "markdownDescription": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
       "anyOf": [
         {
+          "type": "boolean"
+        }
+      ],
+      "description": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "title": "放射状"
+    },
+    "ArcadeButton": {
+      "markdownDescription": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "action"
+          ],
           "properties": {
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            },
             "enabled": {
               "$ref": "#/$defs/ControlEnabled"
             },
@@ -3377,18 +4904,18 @@
             },
             "styles": {
               "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "action": {
+              "$ref": "#/$defs/ActionType"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "action"
-          ]
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
+      "description": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。",
       "examples": [
         {
           "action": "gamepadX",
@@ -3404,277 +4931,13 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ],
-      "markdownDescription": "`arcadeButtons` コントロールの種類の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロールの種類の簡略化されたバージョンです。"
-    },
-    "Deadzone1D": {
-      "description": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "1 次元のデッドゾーン",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "markdownDescription": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。"
-    },
-    "Layer": {
-      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
-      "anyOf": [
-        {
-          "properties": {
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "$ref": "#/$defs/LayerControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "axisUp": "rightTrigger",
-                "type": "throttle",
-                "axisDown": "leftTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。"
-    },
-    "LayerControlWheel": {
-      "description": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
-      "anyOf": [
-        {
-          "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            },
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー コントロール ホイール",
-      "examples": [
-        {
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "markdownDescription": "円またはホイールの形で整理されたレイヤー コントロールのセットです。"
-    },
-    "_Accelerometer": {
-      "additionalProperties": false,
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "description": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
-          "title": "加速度計コントロールの種類",
-          "type": "string",
-          "const": "accelerometer",
-          "markdownDescription": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
       ]
     },
-    "ButtonPulledStyle": {
-      "description": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+    "JoystickMovingStyle": {
+      "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールの pull されたスタイル",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。"
-    },
-    "Scale": {
-      "description": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "type": "number",
-          "maximum": 2
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "スケール",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "markdownDescription": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。"
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "description": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
-      "anyOf": [
-        {
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "アウトライン スタイル設定コンポーネント",
-      "examples": [
-        {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "markdownDescription": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが対話している他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。"
-    },
-    "JoystickDefaultStyle": {
-      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-      "anyOf": [
-        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
@@ -3689,29 +4952,28 @@
               "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "コントロールの既定のスタイル",
+      "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
       "examples": [
         {},
         {
           "knob": {
-            "background": {
+            "faceImage": {
               "type": "asset",
-              "value": "CustomKnobBackgroundImage"
+              "value": "CustomKnobFaceImage"
             },
             "stroke": {
               "type": "solid",
               "color": "#0099ffaa"
             },
-            "faceImage": {
+            "background": {
               "type": "asset",
-              "value": "CustomKnobFaceImage"
+              "value": "CustomKnobBackgroundImage"
             }
           },
           "background": {
@@ -3723,24 +4985,334 @@
           "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。"
+      "title": "コントロールの移動スタイル"
+    },
+    "DirectionalPadInteractionActivationType": {
+      "markdownDescription": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "title": "アクティブ化の種類"
+    },
+    "_HexColor": {
+      "type": "string",
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_FaceImageAsset": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
+          "type": "string",
+          "description": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
+          "title": "顔画像資産スタイル設定コンポーネント"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object",
+      "examples": [
+        {},
+        {
+          "myColor": "#ff00ffff",
+          "system_contentPrimary": "#ffffffff"
+        }
+      ],
+      "properties": {
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        }
+      },
+      "additionalProperties": false
     },
     "TurboActionInterval": {
-      "markdownDescription": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
-      "description": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
-      "exclusiveMinimum": 0,
-      "title": "間隔",
       "examples": [
         500,
         1000
       ],
+      "title": "間隔",
+      "description": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
+      "exclusiveMinimum": 0,
+      "markdownDescription": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
       "type": "number"
     },
+    "_ControlTypeJoystick": {
+      "const": "joystick",
+      "markdownDescription": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
+      "type": "string",
+      "description": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
+      "title": "ジョイスティック コントロールの種類"
+    },
+    "JoystickDisabledStyle": {
+      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "コントロールの無効なスタイル"
+    },
+    "Opacity": {
+      "markdownDescription": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
+      "anyOf": [
+        {
+          "minimum": 0,
+          "maximum": 1,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "title": "不透明度"
+    },
+    "_ControlTypeArcadeButtons": {
+      "const": "arcadeButtons",
+      "markdownDescription": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
+      "type": "string",
+      "description": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
+      "title": "アーケード ボタン コントロールの種類"
+    },
+    "_Touchpad": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "axis": [
+            {
+              "output": "relativeMouse",
+              "input": "axisXY"
+            }
+          ],
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerUpperContent": {
+      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "title": "上位レイヤーのコンテンツ"
+    },
     "InputCurveRange": {
-      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
-      "deprecated": true,
-      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
-      "title": "[非推奨] 入力曲線の範囲",
       "examples": [
         [
           0,
@@ -3762,1672 +5334,103 @@
           }
         ]
       ],
+      "title": "[非推奨] 入力曲線の範囲",
+      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
       "anyOf": [
         {
-          "maxItems": 2,
-          "minItems": 2,
           "items": {
             "anyOf": [
               {
                 "minimum": -1,
-                "type": "number",
-                "maximum": 1
+                "maximum": 1,
+                "type": "number"
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。"
+    },
+    "_ActionTypeBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
           "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayoutContent": {
-      "description": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "center": {
-              "$ref": "#/$defs/LayoutControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "レイアウト コンテンツ",
       "examples": [
-        {},
+        "gamepadB",
         {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "input": "axisXY",
-                  "output": "leftJoystick"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "markdownDescription": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。"
-    },
-    "LayoutLowerContent": {
-      "description": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "../../context.json#/state/jumpControllerMapping"
         },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "下位レイアウトのコンテンツ",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。"
-    },
-    "_AxisMapping2DItem": {
-      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "2 次元軸マッピング アイテム",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisUp",
-          "output": "rightTrigger"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 つまたは 2 つの次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。"
-    },
-    "DeadzoneThreshold": {
-      "description": "出力値を生成するために必要な正規化された入力値です。",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "しきい値",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "markdownDescription": "出力値を生成するために必要な正規化された入力値です。"
-    },
-    "JoystickDisabledStyle": {
-      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールの無効なスタイル",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。"
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "RelativeInteraction": {
-      "description": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "相対",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、コントロールとの対話の計算方法を決定します。対話は、対話が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、対話の開始点を基準にして計算します。"
-    },
-    "FaceImageIconValue": {
-      "description": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "顔画像アイコン",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "markdownDescription": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。"
-    },
-    "LayoutUpperRightContent": {
-      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "右上のレイアウト コンテンツ",
-      "examples": [
         [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。"
-    },
-    "_Throttle": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "sticky": true,
-          "axisUp": "rightTrigger",
-          "type": "throttle",
-          "axisDown": "leftTrigger"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
+          "gamepadA",
+          "leftTrigger"
+        ]
       ]
     },
-    "_FaceImageIcon": {
-      "properties": {
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "description": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
-          "title": "顔画像アイコンのスタイル設定コンポーネント",
-          "type": "string",
-          "const": "icon",
-          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "_SystemColorAccentSecondary": {
-      "description": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
-      "title": "アクセントのセカンダリ システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。"
-    },
-    "_ControllerAnalog2DOutputType": {
-      "description": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "ゲームパッドのアナログ ジョイスティック出力",
-      "type": "string",
-      "markdownDescription": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。"
-    },
-    "_SystemColorContentPrimary": {
-      "description": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
-      "title": "コンテンツのプライマリ システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。"
-    },
-    "_DirectionalPad": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        }
-      },
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "Stroke": {
-      "description": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
-      "title": "ストローク スタイル設定コンポーネント",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。"
-    },
-    "ThrottleAxisStyle": {
-      "description": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+    "_ControllerAction": {
       "anyOf": [
         {
-          "properties": {
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "#/$defs/_ControllerButtonOutputType"
         },
         {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "スロットル軸のスタイル設定コンポーネント",
-      "examples": [
-        {
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        }
-      ],
-      "markdownDescription": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。"
-    },
-    "_SystemColorContrastPrimary": {
-      "description": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
-      "title": "コントラストのプライマリ システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、内側/外側のストロークや顔画像のバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。"
-    },
-    "_FaceImageAsset": {
-      "properties": {
-        "type": {
-          "description": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。",
-          "title": "顔画像資産スタイル設定コンポーネント",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム資産です。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_Blank": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。",
-          "title": "空白のコントロールの種類",
-          "type": "string",
-          "const": "blank",
-          "markdownDescription": "レイヤーを使用するレイアウトを作成する場合、空のコントロールの種類を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは対話可能ではなく、スタイル可能なコンポーネントがありません。"
-        }
-      },
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "_SystemColorGamepadActionColor": {
-      "description": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
-      "title": "ゲームパッド アクション システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。"
-    },
-    "ThrottleStyles": {
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "idleUp": {
-              "description": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。",
-              "title": "コントロールのアイドル アップのスタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` されている場合のみです。"
-            },
-            "disabled": {
-              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "title": "コントロールの無効なスタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。"
-            },
-            "activatedUp": {
-              "description": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
-              "title": "コントロールがアクティブ化されたアップ スタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。"
-            },
-            "idle": {
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "title": "コントロールのアイドルのスタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。"
-            },
-            "activated": {
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "title": "コントロールがアクティブ化されたスタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
-            },
-            "activatedDown": {
-              "description": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。",
-              "title": "コントロールがアクティブ化されたダウン スタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが対話しているとき (特にコントロールの中央の下の領域) です。"
-            },
-            "default": {
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "title": "コントロールの既定のスタイル",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのスタイル",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "axisDown": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。"
-    },
-    "LayoutSensorContent": {
-      "description": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "センサー レイアウト コンテンツ",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "markdownDescription": "このプロパティは、デバイスのセンサー入力を相互作用として使用するレイアウト コンテンツのコンテナーを定義します。"
-    },
-    "AxisCapColor": {
-      "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
-              "title": "軸キャップ スタイル設定コンポーネント",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "軸キャップ スタイル設定コンポーネント",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。"
-    },
-    "_StrokeBase": {
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "description": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
-              "type": "string",
-              "const": "solid",
-              "markdownDescription": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
         }
       ]
     },
-    "Background": {
-      "description": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+    "OuterWheelControlGroup": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_BackgroundColor"
+          "$ref": "#/$defs/Control"
         },
         {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "背景スタイル設定コンポーネント",
-      "markdownDescription": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。"
-    },
-    "_ControllerAnalog1DOutputType": {
-      "description": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "ゲームパッドのアナログ ジョイスティック出力",
-      "type": "string",
-      "markdownDescription": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。"
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "Knob": {
-      "description": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "ノブ スタイル設定コンポーネント",
-      "examples": [
-        {
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "markdownDescription": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。"
-    },
-    "DirectionalPadInteractionActivationType": {
-      "description": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "exclusive",
-            "allowNeighboring"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "アクティブ化の種類",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、プレーヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化の種類には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレーヤーがコントロールと対話している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。"
-    },
-    "FaceImageIconLabel": {
-      "description": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "action",
-                "none"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "顔画像アイコンラベルのスタイル設定コンポーネント",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "markdownDescription": "このプロパティは、顔画像アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。"
-    },
-    "SensorLayerControl": {
-      "markdownDescription": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "description": "デバイスの使用可能なセンサーから対話を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ]
-        }
-      },
-      "title": "レイヤー センサー コントロール",
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
+          "$ref": "#/$defs/ControlGroup"
         },
         {
           "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ]
-    },
-    "ButtonDisabledStyle": {
-      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールの無効なスタイル",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。"
-    },
-    "Layers": {
-      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。",
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "タッチ レイアウト レイヤー",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "axisUp": "rightTrigger",
-                  "type": "throttle",
-                  "axisDown": "leftTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレーヤー操作に応じてレイアウト コンテンツを変更したりできます。"
-    },
-    "_SystemColorContentSecondary": {
-      "description": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
-      "title": "コンテンツ セカンダリ システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。"
-    },
-    "_LayoutAction": {
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "additionalProperties": false,
-      "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-      "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-      "required": [
-        "type",
-        "target"
-      ],
-      "title": "レイアウト アクション",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。",
-          "title": "レイアウト アクション",
-          "type": "string",
-          "const": "layer",
-          "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクションの種類。"
-        }
-      },
-      "type": "object"
-    },
-    "InnerLayerControlWheel": {
-      "description": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "内側​​",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 ~ 4 個のレイヤー コントロールのセットです。システムは、使用可能な領域内でグループからコントロールを最適に配置する方法を決定します。内部セグメント全体の操作領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合、そのレイヤーのすべての項目は非表示になります。"
-    },
-    "ArcadeButtonStyles": {
-      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
-              "title": "コントロールの既定のスタイル",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。"
-            },
-            "idle": {
-              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-              "title": "コントロールのアイドルのスタイル",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。"
-            },
-            "disabled": {
-              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
-              "title": "コントロールの無効なスタイル",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレーヤーがコントロールと対話するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。"
-            },
-            "activated": {
-              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。",
-              "title": "コントロールがアクティブ化されたスタイル",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが対話中で、そのアクションが実行されているときです。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのスタイル",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          },
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。"
-    },
-    "LayoutLowerArrayContent": {
-      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "下位レイアウト配列のコンテンツ",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。"
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "LayerUpperContent": {
-      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "上位レイヤーのコンテンツ",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロールの種類を使用して、この下のレイヤーからコントロールを非表示にすることができます。"
-    },
-    "JoystickIdleStyle": {
-      "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "コントロールのアイドルのスタイル",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは対話されず、ニュートラルまたは休止していると見なされます。"
-    },
-    "DeadzoneDirectionalPad": {
-      "description": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。",
-      "anyOf": [
-        {
-          "exclusiveMinimum": 0,
-          "type": "number",
-          "exclusiveMaximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "方向パッドのデッドゾーン",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "markdownDescription": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、このサイズのプレイヤーに表示されます。"
-    },
-    "Sensitivity": {
-      "description": "コントロールの秘密度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "感度",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "markdownDescription": "コントロールの秘密度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。"
-    },
-    "_InputAxisZY": {
-      "description": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
-      "title": "Z 軸と Y 軸の入力マッピング",
-      "type": "string",
-      "const": "axisZY",
-      "markdownDescription": "コントロールの Z 軸と Y 軸の相互作用を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。"
-    },
-    "_Touchpad": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
-      "examples": [
-        {
-          "axis": [
-            {
-              "input": "axisXY",
-              "output": "relativeMouse"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "_SystemColorActionColor": {
-      "description": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
-      "title": "アクション システムの色のオーバーライド",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。"
-    },
-    "LayoutUpperContent": {
-      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "上部レイアウトのコンテンツ",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大規模なデバイスでは簡単にアクセスできないため、この領域は、一時停止メニューの pull や映画の瞬間のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。"
-    },
-    "DeadzoneRadial": {
-      "description": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "title": "放射状",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "markdownDescription": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。"
     }
   },
-  "type": "object"
+  "description": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+  "properties": {
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "content"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "title": "タッチ適応バンドルのレイアウト スキーマ",
+  "markdownDescription": "タッチ適応バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを許可するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。"
 }

--- a/touch-adaptation-kit/schemas/ja-JP/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/ja-JP/takxconfig/v1/takxconfig.json
@@ -1,155 +1,9 @@
 {
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
-      "markdownDescription": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
-      "required": [
-        "path"
-      ],
-      "title": "タッチ適応バンドルのコンテキスト ファイル構成",
-      "properties": {
-        "path": {
-          "markdownDescription": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
-          "description": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
-          "title": "タッチ適応バンドルのコンテキスト ファイル パス",
-          "examples": [
-            "./context.json"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "versionName": {
-      "description": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "title": "タッチ適応バンドルのバージョン名",
-      "examples": [
-        "DLC 2"
-      ],
-      "type": "string",
-      "markdownDescription": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。"
-    },
-    "assets": {
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
-      "markdownDescription": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
-      "required": [
-        "path"
-      ],
-      "title": "タッチ適応バンドルの資産構成",
-      "properties": {
-        "path": {
-          "markdownDescription": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "description": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "title": "タッチ適応バンドルの資産パス",
-          "examples": [
-            "./assets"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "languages": {
-      "markdownDescription": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "description": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
-      "title": "タッチ適応バンドルの言語構成",
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "type": "array"
-    },
-    "version": {
-      "markdownDescription": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "description": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "title": "タッチ適応バンドルのバージョン",
-      "examples": [
-        "1.0.0.0"
-      ],
-      "type": "string"
-    },
-    "layouts": {
-      "examples": [
-        {
-          "path": "./layouts"
-        },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
-      "markdownDescription": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
-      "required": [
-        "path"
-      ],
-      "title": "タッチ適応バンドルのレイアウト構成",
-      "properties": {
-        "default": {
-          "description": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
-          "title": "タッチ適応バンドルの既定レイアウト",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "type": "string",
-          "markdownDescription": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。"
-        },
-        "path": {
-          "markdownDescription": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "description": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "title": "タッチ適応バンドルのレイアウト パス",
-          "examples": [
-            "./layouts"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    }
-  },
-  "title": "タッチ適応バンドルの構成ファイル スキーマ",
-  "description": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
-  "markdownDescription": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v4.0/takxconfig.json",
+  "type": "object",
   "$defs": {
     "LanguageItem": {
+      "markdownDescription": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。",
       "description": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。",
       "enum": [
         "ar",
@@ -213,9 +67,155 @@
         "zh-CN",
         "zh-TW"
       ],
-      "title": "IETF 言語タグ",
-      "markdownDescription": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。"
+      "title": "IETF 言語タグ"
     }
   },
-  "type": "object"
+  "description": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+  "properties": {
+    "versionName": {
+      "markdownDescription": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+      "type": "string",
+      "description": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+      "examples": [
+        "DLC 2"
+      ],
+      "title": "タッチ適応バンドルのバージョン名"
+    },
+    "layouts": {
+      "type": "object",
+      "markdownDescription": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
+      "properties": {
+        "default": {
+          "markdownDescription": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
+          "type": "string",
+          "description": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
+          "examples": [
+            "cinematic",
+            "menu",
+            "firstPerson"
+          ],
+          "title": "タッチ適応バンドルの既定レイアウト"
+        },
+        "path": {
+          "examples": [
+            "./layouts"
+          ],
+          "title": "タッチ適応バンドルのレイアウト パス",
+          "format": "uri-reference",
+          "description": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
+          "markdownDescription": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
+          "type": "string"
+        }
+      },
+      "description": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
+      "examples": [
+        {
+          "path": "./layouts"
+        },
+        {
+          "default": "cinematic",
+          "path": "./layouts"
+        }
+      ],
+      "title": "タッチ適応バンドルのレイアウト構成",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "version": {
+      "examples": [
+        "1.0.0.0"
+      ],
+      "title": "タッチ適応バンドルのバージョン",
+      "description": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
+      "markdownDescription": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+      "type": "string"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "context": {
+      "type": "object",
+      "markdownDescription": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
+      "properties": {
+        "path": {
+          "examples": [
+            "./context.json"
+          ],
+          "title": "タッチ適応バンドルのコンテキスト ファイル パス",
+          "format": "uri-reference",
+          "description": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
+          "markdownDescription": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
+          "type": "string"
+        }
+      },
+      "description": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
+      "examples": [
+        {
+          "path": "./context.json"
+        }
+      ],
+      "title": "タッチ適応バンドルのコンテキスト ファイル構成",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "languages": {
+      "examples": [
+        [],
+        [
+          "en-US"
+        ],
+        [
+          "en",
+          "fr-FR"
+        ]
+      ],
+      "title": "タッチ適応バンドルの言語構成",
+      "description": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
+      "items": {
+        "$ref": "#/$defs/LanguageItem"
+      },
+      "markdownDescription": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
+      "type": "array"
+    },
+    "assets": {
+      "type": "object",
+      "markdownDescription": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
+      "properties": {
+        "path": {
+          "examples": [
+            "./assets"
+          ],
+          "title": "タッチ適応バンドルの資産パス",
+          "format": "uri-reference",
+          "description": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
+          "markdownDescription": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
+          "type": "string"
+        }
+      },
+      "description": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
+      "examples": [
+        {
+          "path": "./assets"
+        }
+      ],
+      "title": "タッチ適応バンドルの資産構成",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "layouts",
+    "version"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+  "title": "タッチ適応バンドルの構成ファイル スキーマ",
+  "markdownDescription": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。"
 }

--- a/touch-adaptation-kit/schemas/ja-JP/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/ja-JP/takxconfig/v1/takxconfig.json
@@ -1,221 +1,221 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "LanguageItem": {
-      "markdownDescription": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。",
-      "description": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。",
-      "enum": [
-        "ar",
-        "ar-SA",
-        "cs",
-        "cs-CZ",
-        "da",
-        "da-DK",
-        "de",
-        "de-DE",
-        "el",
-        "el-GR",
-        "en",
-        "en-US",
-        "en-GB",
-        "es",
-        "es-ES",
-        "es-MX",
-        "fi",
-        "fi-FI",
-        "fil",
-        "fil-PH",
-        "fr",
-        "fr-FR",
-        "he",
-        "he-IL",
-        "hu",
-        "hu-HU",
-        "id",
-        "id-ID",
-        "it",
-        "it-IT",
-        "ja",
-        "ja-JP",
-        "ko",
-        "ko-KR",
-        "ms",
-        "ms-MY",
-        "nb",
-        "nb-NO",
-        "nl",
-        "nl-NL",
-        "pl",
-        "pl-PL",
-        "pt",
-        "pt-BR",
-        "pt-PT",
-        "ru",
-        "ru-RU",
-        "sk",
-        "sk-SK",
-        "sv",
-        "sv-SE",
-        "th",
-        "th-TH",
-        "tr",
-        "tr-TR",
-        "vi",
-        "vi-VN",
-        "zh",
-        "zh-CN",
-        "zh-TW"
-      ],
-      "title": "IETF 言語タグ"
-    }
-  },
-  "description": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
-  "properties": {
-    "versionName": {
-      "markdownDescription": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "type": "string",
-      "description": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "examples": [
-        "DLC 2"
-      ],
-      "title": "タッチ適応バンドルのバージョン名"
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "タッチ適応バンドルの構成ファイル スキーマ",
+    "description": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+    "markdownDescription": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+    "$defs": {
+        "LanguageItem": {
+            "title": "IETF 言語タグ",
+            "description": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。",
+            "markdownDescription": "バンドルがサポートするニュートラル言語に加えて、言語を定義する単一言語タグです。",
+            "enum": [
+                "ar",
+                "ar-SA",
+                "cs",
+                "cs-CZ",
+                "da",
+                "da-DK",
+                "de",
+                "de-DE",
+                "el",
+                "el-GR",
+                "en",
+                "en-US",
+                "en-GB",
+                "es",
+                "es-ES",
+                "es-MX",
+                "fi",
+                "fi-FI",
+                "fil",
+                "fil-PH",
+                "fr",
+                "fr-FR",
+                "he",
+                "he-IL",
+                "hu",
+                "hu-HU",
+                "id",
+                "id-ID",
+                "it",
+                "it-IT",
+                "ja",
+                "ja-JP",
+                "ko",
+                "ko-KR",
+                "ms",
+                "ms-MY",
+                "nb",
+                "nb-NO",
+                "nl",
+                "nl-NL",
+                "pl",
+                "pl-PL",
+                "pt",
+                "pt-BR",
+                "pt-PT",
+                "ru",
+                "ru-RU",
+                "sk",
+                "sk-SK",
+                "sv",
+                "sv-SE",
+                "th",
+                "th-TH",
+                "tr",
+                "tr-TR",
+                "vi",
+                "vi-VN",
+                "zh",
+                "zh-CN",
+                "zh-TW"
+            ]
+        }
     },
-    "layouts": {
-      "type": "object",
-      "markdownDescription": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
-      "properties": {
-        "default": {
-          "markdownDescription": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
-          "type": "string",
-          "description": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "title": "タッチ適応バンドルの既定レイアウト"
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
         },
-        "path": {
-          "examples": [
-            "./layouts"
-          ],
-          "title": "タッチ適応バンドルのレイアウト パス",
-          "format": "uri-reference",
-          "description": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "markdownDescription": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "type": "string"
-        }
-      },
-      "description": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
-      "examples": [
-        {
-          "path": "./layouts"
+        "layouts": {
+            "title": "タッチ適応バンドルのレイアウト構成",
+            "description": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
+            "markdownDescription": "このプロパティは、レイアウト ファイルに関連するバンドル プロパティを定義します。たとえば、ディスク レイアウト ファイルの場所や、既定のレイアウトとして使用するレイアウト ファイルなどです。",
+            "examples": [
+                {
+                    "path": "./layouts"
+                },
+                {
+                    "path": "./layouts",
+                    "default": "cinematic"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "タッチ適応バンドルのレイアウト パス",
+                    "description": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
+                    "markdownDescription": "このプロパティは、このバンドルのすべてのレイアウトを含むディレクトリへの、このファイルからの相対パスを定義します。",
+                    "examples": [
+                        "./layouts"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "default": {
+                    "title": "タッチ適応バンドルの既定レイアウト",
+                    "description": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
+                    "markdownDescription": "このプロパティは、タッチ バンドルの開始アクティブ レイアウトを定義します。既定のレイアウトを指定するには、ファイル拡張子のないレイアウト ファイルの名前を使用します。アクティブなレイアウトは、後で https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient で説明されている API 呼び出しを使用して変更できます。省略すると、開始レイアウトは使用されません。",
+                    "examples": [
+                        "cinematic",
+                        "menu",
+                        "firstPerson"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ]
         },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
+        "assets": {
+            "title": "タッチ適応バンドルの資産構成",
+            "description": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
+            "markdownDescription": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
+            "examples": [
+                {
+                    "path": "./assets"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "タッチ適応バンドルの資産パス",
+                    "description": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
+                    "markdownDescription": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
+                    "examples": [
+                        "./assets"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "context": {
+            "title": "タッチ適応バンドルのコンテキスト ファイル構成",
+            "description": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
+            "markdownDescription": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
+            "examples": [
+                {
+                    "path": "./context.json"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "タッチ適応バンドルのコンテキスト ファイル パス",
+                    "description": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
+                    "markdownDescription": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
+                    "examples": [
+                        "./context.json"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "languages": {
+            "title": "タッチ適応バンドルの言語構成",
+            "description": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
+            "markdownDescription": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
+            "examples": [
+                [],
+                [
+                    "en-US"
+                ],
+                [
+                    "en",
+                    "fr-FR"
+                ]
+            ],
+            "items": {
+                "$ref": "#/$defs/LanguageItem"
+            },
+            "type": "array"
+        },
+        "version": {
+            "title": "タッチ適応バンドルのバージョン",
+            "description": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+            "markdownDescription": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+            "examples": [
+                "1.0.0.0"
+            ],
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+        },
+        "versionName": {
+            "title": "タッチ適応バンドルのバージョン名",
+            "description": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+            "markdownDescription": "このプロパティは、このバージョンのタッチ バンドルを表すわかりやすい名前を定義します。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
+            "examples": [
+                "DLC 2"
+            ],
+            "type": "string"
         }
-      ],
-      "title": "タッチ適応バンドルのレイアウト構成",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
     },
-    "version": {
-      "examples": [
-        "1.0.0.0"
-      ],
-      "title": "タッチ適応バンドルのバージョン",
-      "description": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "markdownDescription": "このプロパティは、タッチ バンドルのバージョン番号を定義します。バージョンはメジャー コンポーネント、マイナー コンポーネント、ビルド コンポーネント、およびリビジョン コンポーネントで構成されていますが、これらの特定の意味論はタッチ バンドル ランタイムによって解釈されません。代わりに、ランタイムが読み込むことができる最新バージョンのバンドルが使用されます。バンドルを読み込む機能は、バンドル内で使用される最大レイアウト スキーマ バージョンによって決まります。このプロパティは、https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion で説明されている API を使用して照会できます。",
-      "type": "string"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "type": "object",
-      "markdownDescription": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
-      "properties": {
-        "path": {
-          "examples": [
-            "./context.json"
-          ],
-          "title": "タッチ適応バンドルのコンテキスト ファイル パス",
-          "format": "uri-reference",
-          "description": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
-          "markdownDescription": "このプロパティは、このファイルからコンテキスト ファイルへの相対パスを定義します。",
-          "type": "string"
-        }
-      },
-      "description": "このプロパティは、ファイルが配置されているディスク上の場所など、コンテキスト ファイルに関連するバンドル プロパティを定義します。省略した場合、バンドルにはコンテキスト ファイルは含まれません。",
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "title": "タッチ適応バンドルのコンテキスト ファイル構成",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    },
-    "languages": {
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "title": "タッチ適応バンドルの言語構成",
-      "description": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "markdownDescription": "このプロパティは、バンドルでサポートされている言語に関連するバンドル プロパティを定義します。省略した場合、バンドルはレイアウト フォルダーと資産フォルダーのディレクトリ構造から推論されたすべての言語をサポートします。ニュートラル言語は、このプロパティの値に関係なく、常にバンドルに含まれます。",
-      "type": "array"
-    },
-    "assets": {
-      "type": "object",
-      "markdownDescription": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
-      "properties": {
-        "path": {
-          "examples": [
-            "./assets"
-          ],
-          "title": "タッチ適応バンドルの資産パス",
-          "format": "uri-reference",
-          "description": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "markdownDescription": "このプロパティは、このバンドルのすべての資産 (画像ファイルなど) を含むディレクトリへの、このファイルからの相対パスを定義します。",
-          "type": "string"
-        }
-      },
-      "description": "このプロパティは、ディスク資産ファイルの場所など、資産ファイルに関連するバンドル プロパティを定義します。",
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "title": "タッチ適応バンドルの資産構成",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
-  "title": "タッチ適応バンドルの構成ファイル スキーマ",
-  "markdownDescription": "タッチ適応バンドル構成ファイル (`takxconfig.json`) は、バンドルのプロジェクト ファイルとして機能し、バンドルのすべてのメタデータとプロパティを再利用可能で一貫性のある方法で定義するファイルです。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。"
+    "additionalProperties": false,
+    "required": [
+      "layouts",
+      "version"
+    ]
 }

--- a/touch-adaptation-kit/schemas/ko-KR/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/ko-KR/context/v4.0/context.json
@@ -1,163 +1,163 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "AllowedStateValues": {
-      "examples": [
-        {},
-        {
-          "inventorySlotForegroundImage": [
-            "InventoryForegroundFireballSpell",
-            "InventoryForegroundLightningBoltSpell"
-          ],
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          }
-        }
-      ],
-      "title": "터치 번들 허용 상태 값",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/StateType"
-              }
-            },
-            {
-              "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
-            }
-          ]
-        }
-      },
-      "description": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
-      "type": "object",
-      "markdownDescription": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
-      "additionalProperties": false
-    },
-    "State": {
-      "examples": [
-        {},
-        {
-          "inventorySlotBackgroundImage": "InventoryBackground",
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground"
-        }
-      ],
-      "title": "번들 상태 터치",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "description": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
-      "type": "object",
-      "markdownDescription": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
-      "additionalProperties": false
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/$defs/joystickAssetName"
-                  }
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "터치 적응 번들 컨텍스트 스키마",
+    "description": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+    "markdownDescription": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "터치 번들 허용 상태 값",
+            "description": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
+            "markdownDescription": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
                 }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "정의 가능한 유형",
+            "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+            "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "정의",
+            "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+            "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "번들 상태 터치",
+            "description": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
+            "markdownDescription": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "번들 상태 항목 터치",
+            "description": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
+            "markdownDescription": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "스타일",
+            "description": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
+            "markdownDescription": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
+            "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles"
         }
-      ],
-      "title": "정의",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/ContextDefinableType"
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
         }
-      },
-      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "type": "object",
-      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "additionalProperties": false
     },
-    "StateType": {
-      "markdownDescription": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "description": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "title": "번들 상태 항목 터치"
-    },
-    "ContextDefinableType": {
-      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
-      "title": "정의 가능한 유형"
-    },
-    "ContextStyles": {
-      "markdownDescription": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
-      "description": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "title": "스타일"
-    }
-  },
-  "description": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
-  "properties": {
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    },
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "$schema": {
-      "type": "string"
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
-  "title": "터치 적응 번들 컨텍스트 스키마",
-  "markdownDescription": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요."
+    "additionalProperties": false
 }

--- a/touch-adaptation-kit/schemas/ko-KR/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/ko-KR/context/v4.0/context.json
@@ -1,116 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    }
-  },
-  "title": "터치 적응 번들 컨텍스트 스키마",
-  "description": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
-  "markdownDescription": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "type": "object",
   "$defs": {
-    "State": {
-      "markdownDescription": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
-      "additionalProperties": false,
-      "description": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
-      "title": "번들 상태 터치",
-      "examples": [
-        {},
-        {
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground",
-          "inventorySlotBackgroundImage": "InventoryBackground"
-        }
-      ],
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "type": "object"
-    },
-    "StateType": {
-      "description": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "title": "번들 상태 항목 터치",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "markdownDescription": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다."
-    },
-    "ContextStyles": {
-      "description": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
-      "title": "스타일",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "markdownDescription": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다."
-    },
-    "ContextDefinableType": {
-      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "title": "정의 가능한 유형",
-      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요."
-    },
     "AllowedStateValues": {
-      "markdownDescription": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
-      "additionalProperties": false,
-      "description": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
-      "title": "터치 번들 허용 상태 값",
       "examples": [
         {},
         {
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          },
           "inventorySlotForegroundImage": [
             "InventoryForegroundFireballSpell",
             "InventoryForegroundLightningBoltSpell"
-          ]
+          ],
+          "inventorySlotBackgroundImage": {
+            "$ref": "#/definitions/AllowedBackgroundImages"
+          }
         }
       ],
+      "title": "터치 번들 허용 상태 값",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "anyOf": [
@@ -126,13 +31,32 @@
           ]
         }
       },
-      "type": "object"
+      "description": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
+      "type": "object",
+      "markdownDescription": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
+      "additionalProperties": false
+    },
+    "State": {
+      "examples": [
+        {},
+        {
+          "inventorySlotBackgroundImage": "InventoryBackground",
+          "inventorySlotEnabled": true,
+          "inventorySlotForegroundImage": "InventoryForeground"
+        }
+      ],
+      "title": "번들 상태 터치",
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/StateType"
+        }
+      },
+      "description": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
+      "type": "object",
+      "markdownDescription": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
+      "additionalProperties": false
     },
     "Definitions": {
-      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "additionalProperties": false,
-      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "title": "정의",
       "examples": [
         {},
         {
@@ -151,13 +75,89 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "정의",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/ContextDefinableType"
         }
       },
-      "type": "object"
+      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "type": "object",
+      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "additionalProperties": false
+    },
+    "StateType": {
+      "markdownDescription": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ],
+      "description": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
+      "examples": [
+        "customAssetName",
+        false,
+        true,
+        1,
+        0
+      ],
+      "title": "번들 상태 항목 터치"
+    },
+    "ContextDefinableType": {
+      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "anyOf": [
+        {
+          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+        },
+        {
+          "$ref": "#/$defs/StateType"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StateType"
+          }
+        }
+      ],
+      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "title": "정의 가능한 유형"
+    },
+    "ContextStyles": {
+      "markdownDescription": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
+      "description": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
+      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
+      "title": "스타일"
     }
   },
-  "type": "object"
+  "description": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+  "properties": {
+    "state": {
+      "$ref": "#/$defs/State"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/ContextStyles"
+    },
+    "allowedStateValues": {
+      "$ref": "#/$defs/AllowedStateValues"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "title": "터치 적응 번들 컨텍스트 스키마",
+  "markdownDescription": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요."
 }

--- a/touch-adaptation-kit/schemas/ko-KR/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/ko-KR/layout/v4.0/layout.json
@@ -1,4069 +1,15 @@
 {
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "additionalProperties": false,
-  "type": "object",
+  "title": "터치 적응 번들 레이아웃 스키마",
+  "description": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+  "markdownDescription": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
   "$defs": {
-    "_StrokeBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "solid",
-              "markdownDescription": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
-              "type": "string",
-              "description": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ]
-    },
-    "_SystemColorContentPrimary": {
-      "markdownDescription": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
-      "description": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "콘텐츠 기본 시스템 색상 재정의"
-    },
-    "_ControlTypeDirectionalPad": {
-      "const": "directionalPad",
-      "markdownDescription": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
-      "type": "string",
-      "description": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
-      "title": "방향 패드 제어 유형"
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "JoystickDirectionIndicator": {
-      "markdownDescription": "상호 작용 방향을 나타내는 시각적 스타일 지정",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
-              "type": "string",
-              "description": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "상호 작용 방향을 나타내는 시각적 스타일 지정",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "title": "방향 표시기 스타일링 구성 요소"
-    },
-    "LayerSensorContent": {
-      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
-        }
-      ],
-      "title": "센서 레이어 콘텐츠"
-    },
-    "Background": {
-      "markdownDescription": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
-      "title": "배경 스타일 구성 요소"
-    },
-    "_Accelerometer": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "accelerometer",
-          "markdownDescription": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
-          "type": "string",
-          "description": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
-          "title": "가속도계 제어 유형"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "SensorControl": {
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "센서 제어",
-      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_Null": {
-      "markdownDescription": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
-      "type": "null",
-      "description": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
-      "examples": [
-        null
-      ],
-      "title": "null"
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "markdownDescription": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
-      "type": "string",
-      "description": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "게임패드 아날로그 조이스틱 출력"
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "PullIndicator": {
-      "markdownDescription": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "title": "끌어오기 표시기 스타일 구성 요소"
-    },
-    "_SystemColorAccentPrimary": {
-      "markdownDescription": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
-      "description": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "악센트 기본 시스템 색상 재정의"
-    },
-    "Scale": {
-      "markdownDescription": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "maximum": 2,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "title": "규모"
-    },
-    "JoystickIdleStyle": {
-      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "유휴 스타일 제어"
-    },
-    "_AxisMapping2DItem": {
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "2차원 축 매핑 항목"
-    },
-    "TouchpadStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ]
-    },
-    "ButtonIdleStyle": {
-      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "유휴 스타일 제어"
-    },
-    "_LayoutStyles": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "colors": {
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ]
-    },
-    "DeadzoneDirectionalPad": {
-      "markdownDescription": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
-      "anyOf": [
-        {
-          "exclusiveMaximum": 1,
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "title": "방향 패드 데드존"
-    },
-    "Sticky": {
-      "markdownDescription": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "title": "접착식"
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayoutContent": {
-      "markdownDescription": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "output": "leftJoystick",
-                  "input": "axisXY"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "title": "레이아웃 콘텐츠"
-    },
-    "Reference": {
-      "type": "object",
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-          "format": "uri-reference",
-          "markdownDescription": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
-          "type": "string",
-          "description": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
-          "examples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerControlWheel": {
-      "markdownDescription": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
-      "examples": [
-        {
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ],
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "title": "레이아웃 레이어 컨트롤 휠 터치"
-    },
-    "_SystemColorAccentSecondary": {
-      "markdownDescription": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
-      "description": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "악센트 보조 시스템 색상 재정의"
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonToggledStyle": {
-      "markdownDescription": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "전환된 스타일 제어"
-    },
-    "LayoutLowerArrayContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "title": "하위 레이아웃 배열 콘텐츠"
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          },
-          "type": "array"
-        }
-      ],
-      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "2차원 축 매핑"
-    },
-    "ThrottleAxisOutput": {
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
-      "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
-        {
-          "$ref": "#/definitions/commonThrottleAxis"
-        }
-      ],
-      "title": "스로틀 축"
-    },
-    "ColorPaletteDefaultVariant": {
-      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "기본 색상"
-    },
-    "Deadzone1D": {
-      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "1차원 데드존"
-    },
-    "JoystickOutlineWithIndicator": {
-      "markdownDescription": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
-      "examples": [
-        {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "title": "아웃라인 스타일링 구성 요소"
-    },
-    "_ControllerButtonOutputType": {
-      "markdownDescription": "게임패드 버튼 누름을 출력합니다.",
-      "type": "string",
-      "description": "게임패드 버튼 누름을 출력합니다.",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "게임패드 버튼 출력"
-    },
-    "ButtonActivatedStyle": {
-      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "컨트롤 활성화 스타일"
-    },
-    "JoystickStyles": {
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "default": {
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyles"
-        }
-      ],
-      "title": "컨트롤 스타일"
-    },
-    "ButtonDisabledStyle": {
-      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "컨트롤 비활성화 스타일"
-    },
-    "LayoutActionTarget": {
-      "markdownDescription": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "title": "레이아웃 작업 대상"
-    },
-    "_ControlTypeButton": {
-      "const": "button",
-      "markdownDescription": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
-      "type": "string",
-      "description": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
-      "title": "버튼 제어 유형"
-    },
-    "_ControllerAnalog1DOutputType": {
-      "markdownDescription": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
-      "type": "string",
-      "description": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "게임패드 아날로그 조이스틱 출력"
-    },
-    "_LayoutAction": {
-      "type": "object",
-      "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "const": "layer",
-          "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-          "type": "string",
-          "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-          "title": "레이아웃 작업"
-        }
-      },
-      "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "title": "레이아웃 작업",
-      "required": [
-        "type",
-        "target"
-      ],
-      "additionalProperties": false
-    },
-    "InnerLayoutControlWheel": {
-      "markdownDescription": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "output": "leftJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "title": "내부"
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "_ControllerTriggerOutputType": {
-      "markdownDescription": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
-      "type": "string",
-      "description": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "게임패드 아날로그 트리거 출력"
-    },
-    "DirectionalPadStyles": {
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
-              "description": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "유휴 스타일 제어"
-            },
-            "disabled": {
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "컨트롤 활성화 스타일"
-            },
-            "activated": {
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "컨트롤 활성화 스타일"
-            },
-            "default": {
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "제어 기본 스타일"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "title": "컨트롤 스타일"
-    },
-    "Indicator": {
-      "markdownDescription": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
-      "description": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "지표 스타일링 구성 요소"
-    },
-    "Stroke": {
-      "markdownDescription": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
-      "description": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "획 스타일 지정 구성 요소"
-    },
-    "Gradient": {
-      "markdownDescription": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
-      "examples": [
-        {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
-        }
-      ],
-      "title": "그라데이션"
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "markdownDescription": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "title": "게임패드 액션"
-    },
-    "_DirectionalPad": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_TurboAction": {
-      "title": "터보 액션",
-      "properties": {
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        },
-        "type": {
-          "const": "turbo",
-          "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-          "type": "string",
-          "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-          "title": "터보 액션"
-        },
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        }
-      },
-      "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-      "type": "object",
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-      "additionalProperties": false
-    },
-    "ControlGroup": {
-      "markdownDescription": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/ControlGroupItem"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
-          },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "title": "터치 레이아웃 컨트롤 그룹"
-    },
-    "_SystemColorContrastPrimary": {
-      "markdownDescription": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
-      "description": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "대비 기본 시스템 색상 재정의"
-    },
-    "ControlGroupItem": {
-      "markdownDescription": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
-      "title": "터치 레이아웃 제어 그룹 항목"
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "markdownDescription": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
-      "anyOf": [
-        {
-          "type": "number",
-          "minimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
-      "examples": [
-        1,
-        1.5,
-        0,
-        {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
-        }
-      ],
-      "title": "작업 임계값"
-    },
-    "ArcadeButtonStyles": {
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "유휴 스타일 제어"
-            },
-            "disabled": {
-              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "컨트롤 비활성화 스타일"
-            },
-            "activated": {
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "컨트롤 활성화 스타일"
-            },
-            "default": {
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "제어 기본 스타일"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "examples": [
-        {
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          },
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "title": "컨트롤 스타일"
-    },
-    "_BackgroundAsset": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
-          "type": "string",
-          "description": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_FaceImageIcon": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        },
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "const": "icon",
-          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
-          "type": "string",
-          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
-          "title": "얼굴 이미지 아이콘 스타일링 구성 요소"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1D": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
-        }
-      ]
-    },
-    "_InputMappingZY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
-        }
-      ]
-    },
-    "FaceImageIconValue": {
-      "markdownDescription": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
-      "anyOf": [
-        {
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "title": "얼굴 이미지 아이콘"
-    },
-    "Toggle": {
-      "markdownDescription": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "title": "토글"
-    },
-    "ArcadeButtonStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ]
-    },
-    "_ControlTypeTouchpad": {
-      "const": "touchpad",
-      "markdownDescription": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
-      "type": "string",
-      "description": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
-      "title": "터치패드 제어 방식"
-    },
-    "ThrottleStyles": {
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "제어 기본 스타일"
-            },
-            "idleUp": {
-              "markdownDescription": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
-              "description": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "유휴 스타일 제어"
-            },
-            "activatedDown": {
-              "markdownDescription": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
-              "description": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "컨트롤 활성화 다운 스타일"
-            },
-            "disabled": {
-              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "컨트롤 비활성화 스타일"
-            },
-            "activatedUp": {
-              "markdownDescription": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
-              "description": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "컨트롤 활성화 업 스타일"
-            },
-            "idle": {
-              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "유휴 스타일 제어"
-            },
-            "activated": {
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "컨트롤 활성화 스타일"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "axisDown": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "title": "컨트롤 스타일"
-    },
-    "SensorLayerControl": {
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "레이어 센서 제어",
-      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_SystemColorActionColor": {
-      "markdownDescription": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
-      "description": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "액션 시스템 색상 재정의"
-    },
-    "LayoutSensorContent": {
-      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "title": "센서 레이아웃 콘텐츠"
-    },
-    "LayoutColors": {
-      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            },
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "title": "색"
-    },
-    "LayoutUpperContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "title": "상위 레이아웃 콘텐츠"
-    },
-    "_Color": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ]
-    },
-    "DirectionalPadDefaultStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "RelativeInteraction": {
-      "markdownDescription": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "title": "상대적인"
-    },
-    "ButtonPulledStyle": {
-      "markdownDescription": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "끌어온 컨트롤 스타일"
-    },
-    "InputCurveType": {
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "title": "[사용되지 않음] 입력 응답 곡선 유형",
-      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
-      "anyOf": [
-        {
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다."
-    },
-    "ThrottleAxisStyle": {
-      "markdownDescription": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
-      "examples": [
-        {
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          },
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        }
-      ],
-      "title": "스로틀 축 스타일링 구성 요소"
-    },
-    "ButtonDefaultStyle": {
-      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "제어 기본 스타일"
-    },
-    "_InputMapping1DToGamepad1DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FillColor": {
-      "markdownDescription": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
-      "description": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
-      "$ref": "#/$defs/_Color",
-      "title": "채우다"
-    },
-    "PullIndicatorBackground": {
-      "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "title": "배경 스타일 구성 요소"
-    },
-    "_Button": {
-      "type": "object",
-      "required": [
-        "type",
-        "action"
-      ],
-      "examples": [
-        {
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
-            }
-          },
-          "action": "gamepadA"
-        }
-      ],
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        }
-      },
-      "additionalProperties": false
-    },
-    "DirectionalPadInteraction": {
-      "markdownDescription": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "title": "상호 작용"
-    },
-    "ButtonStyles": {
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "title": "컨트롤 스타일"
-    },
-    "_CustomColorPaletteColor": {
-      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
-      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "사용자 지정 레이아웃 색상"
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "DeadzoneThreshold": {
-      "markdownDescription": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "title": "임계값"
-    },
-    "_SystemColorContrastSecondary": {
-      "markdownDescription": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
-      "description": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "대비 보조 시스템 색상 재정의"
-    },
-    "_SystemColorGamepadActionColor": {
-      "markdownDescription": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
-      "description": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "게임패드 액션 시스템 색상 재정의"
-    },
-    "AssetReference": {
-      "markdownDescription": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "title": "자산 참조 스타일링 구성 요소"
-    },
-    "FaceImage": {
-      "markdownDescription": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
-        }
-      ],
-      "title": "얼굴 이미지 스타일링 구성 요소"
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      }
-    },
-    "JoystickActivatedStyle": {
-      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "컨트롤 활성화 스타일"
-    },
-    "LayoutLowerContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "title": "하위 레이아웃 콘텐츠"
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "ControlVisibility": {
-      "markdownDescription": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "표시"
-    },
-    "LayerLowerArrayContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "title": "하위 계층 배열 콘텐츠"
-    },
-    "OuterLayoutControlWheel": {
-      "markdownDescription": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "밖의"
-    },
-    "ControlEnabled": {
-      "markdownDescription": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "사용"
-    },
-    "ExpandInteraction": {
-      "markdownDescription": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "title": "확장"
-    },
-    "Deadzone2D": {
-      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
-      "examples": [
-        {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "2차원 데드존"
-    },
-    "_ColorPaletteColor": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ]
-    },
-    "_InputAxisZY": {
-      "const": "axisZY",
-      "markdownDescription": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-      "type": "string",
-      "description": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-      "title": "Z 및 Y축 입력 매핑"
-    },
-    "DirectionalPadIdleStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/definitions/joystickAssetName"
-                  }
-                }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
-        }
-      ],
-      "title": "정의",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/LayoutDefinableType"
-        }
-      },
-      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "type": "object",
-      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "additionalProperties": false
-    },
-    "_SystemColorContentSecondary": {
-      "markdownDescription": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
-      "description": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "콘텐츠 보조 시스템 색상 재정의"
-    },
-    "Color": {
-      "markdownDescription": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
-      "description": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
-      "$ref": "#/$defs/_Color",
-      "title": "색상"
-    },
-    "_RelativeMouse1DOutputType": {
-      "markdownDescription": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
-      "type": "string",
-      "description": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "상대 마우스 1차원 출력"
-    },
-    "_ArcadeButtons": {
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ],
-      "examples": [
-        {
-          "type": "arcadeButtons",
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          },
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          }
-        }
-      ],
-      "properties": {
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "특수 펀치 버튼"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "헤비 킥 버튼"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "라이트 펀치 버튼"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "라이트 킥 버튼"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "미디엄 킥 버튼"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "스페셜 킥 버튼"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "헤비 킥 버튼"
-        },
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "중간 펀치 버튼"
-        }
-      },
-      "additionalProperties": false
-    },
-    "OuterLayerControlWheel": {
-      "markdownDescription": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "밖의"
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "const": "throttle",
-      "markdownDescription": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
-      "type": "string",
-      "description": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
-      "title": "스로틀 제어 유형"
-    },
-    "LayoutOrientation": {
-      "title": "[사용되지 않음] 레이아웃 방향",
-      "description": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
-      "enum": [
-        "landscape-left",
-        "landscape-right",
-        "landscape",
-        "portrait-up",
-        "portrait"
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
-      "type": "string"
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputAxisXY": {
-      "const": "axisXY",
-      "markdownDescription": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-      "type": "string",
-      "description": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-      "title": "X축 및 Y축 입력 매핑"
-    },
-    "PullActionType": {
-      "markdownDescription": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
-      "description": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "컨트롤 끌어오기 동작"
-    },
-    "Knob": {
-      "markdownDescription": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "title": "노브 스타일링 구성 요소"
-    },
-    "Control": {
-      "markdownDescription": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "title": "터치 레이아웃 제어"
-    },
-    "LayerUpperRightContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "title": "상위 계층 오른쪽 콘텐츠"
-    },
-    "AxisCapColor": {
-      "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
-              "type": "string",
-              "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
-              "title": "축 캡 스타일링 구성 요소"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "title": "축 캡 스타일링 구성 요소"
-    },
-    "_Throttle": {
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
-      ],
-      "examples": [
-        {
-          "sticky": true,
-          "type": "throttle",
-          "axisDown": "leftTrigger",
-          "axisUp": "rightTrigger"
-        }
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Blank": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "properties": {
-        "type": {
-          "const": "blank",
-          "markdownDescription": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
-          "type": "string",
-          "description": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
-          "title": "공백 제어 유형"
-        }
-      },
-      "additionalProperties": false
-    },
-    "RenderAsButton": {
-      "markdownDescription": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "title": "버튼으로 렌더링"
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "_InputMappingXYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "ColorPaletteHighContrastVariant": {
-      "markdownDescription": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "description": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "고대비 색상"
-    },
-    "LayoutStyles": {
-      "markdownDescription": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
-      "description": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
-      "$ref": "#/$defs/_LayoutStyles",
-      "title": "레이아웃 스타일"
-    },
-    "LayerControlGroup": {
-      "type": "array",
-      "markdownDescription": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "minItems": 1,
-      "description": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          },
-          null
-        ]
-      ],
-      "maxItems": 4,
-      "title": "터치 레이아웃 레이어 컨트롤 그룹",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      }
-    },
-    "_BackgroundColor": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/Color"
-        },
-        "type": {
-          "const": "color",
-          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
-          "type": "string",
-          "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Gyroscope": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "output": "rightJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "gyroscope",
-          "markdownDescription": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
-          "type": "string",
-          "description": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
-          "title": "자이로스코프 제어 유형"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageIconLabel": {
-      "markdownDescription": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "action",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "title": "얼굴 이미지 아이콘 레이블 스타일링 구성 요소"
-    },
-    "TouchpadStyles": {
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "유휴 스타일 제어"
-            },
-            "disabled": {
-              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "컨트롤 비활성화 스타일"
-            },
-            "activated": {
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "컨트롤 활성화 스타일"
-            },
-            "moving": {
-              "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
-              "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "제어 이동 스타일"
-            },
-            "default": {
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "제어 기본 스타일"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "title": "컨트롤 스타일"
-    },
-    "Layer": {
-      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "type": "throttle",
-                "axisDown": "leftTrigger",
-                "axisUp": "rightTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "title": "터치 레이아웃 레이어"
-    },
-    "LayerControlGroupItem": {
-      "markdownDescription": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "터치 레이아웃 레이어 제어 그룹 항목"
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ],
-          "type": "string"
-        }
-      ]
-    },
-    "LayoutUpperRightContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "title": "오른쪽 상단 레이아웃 콘텐츠"
-    },
-    "JoystickDefaultStyle": {
-      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "제어 기본 스타일"
-    },
-    "_ControllerAnalog2DOutputType": {
-      "markdownDescription": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
-      "type": "string",
-      "description": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "게임패드 아날로그 조이스틱 출력"
-    },
-    "LayerLowerContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "examples": [
-        {
-          "center": {
-            "type": "blank"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
-        }
-      ],
-      "title": "하위 계층 콘텐츠"
-    },
     "LayoutDefinableType": {
+      "title": "정의 가능한 유형",
+      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -4377,153 +323,1116 @@
         {
           "$ref": "#/$defs/TouchpadStyles"
         }
-      ],
-      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
-      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
-      "title": "정의 가능한 유형"
+      ]
     },
-    "LayoutControlWheel": {
-      "markdownDescription": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayoutControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
+    "Definitions": {
+      "title": "정의",
+      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
       "examples": [
         {},
         {
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "output": "leftJoystick",
-                "input": "axisXY"
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
               }
             }
-          ],
-          "outer": [
-            null,
-            [
-              {
-                "type": "button",
-                "action": "gamepadX"
-              }
-            ],
-            {
-              "type": "button",
-              "action": "gamepadY"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonControlWheel"
-        }
-      ],
-      "title": "터치 레이아웃 컨트롤 휠"
-    },
-    "_RelativeMouse2DOutputType": {
-      "const": "relativeMouse",
-      "markdownDescription": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
-      "type": "string",
-      "description": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
-      "title": "상대 마우스 2차원 출력"
-    },
-    "LayerControl": {
-      "markdownDescription": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "터치 레이아웃 레이어 컨트롤"
-    },
-    "Sensitivity": {
-      "markdownDescription": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "title": "민감도"
-    },
-    "InnerLayerControlWheel": {
-      "markdownDescription": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
           }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "title": "내부"
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
     },
-    "_Joystick": {
+    "Reference": {
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
+          "markdownDescription": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "null",
+      "description": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
+      "markdownDescription": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "가속도계 제어 유형",
+          "description": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
+          "markdownDescription": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
       "required": [
         "type",
         "axis"
       ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
       "examples": [
         {
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
           },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "헤비 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "헤비 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "라이트 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "라이트 펀치 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "미디엄 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "중간 펀치 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "스페셜 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "특수 펀치 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "2차원 축 매핑 항목",
+      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "3차원 축 매핑 항목",
+      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
+          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "공백 제어 유형",
+          "description": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
+          "markdownDescription": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "게임패드 아날로그 조이스틱 출력",
+      "description": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
+      "markdownDescription": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "게임패드 아날로그 조이스틱 출력",
+      "description": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "markdownDescription": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "게임패드 아날로그 조이스틱 출력",
+      "description": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "markdownDescription": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "게임패드 버튼 출력",
+      "description": "게임패드 버튼 누름을 출력합니다.",
+      "markdownDescription": "게임패드 버튼 누름을 출력합니다.",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "게임패드 아날로그 트리거 출력",
+      "description": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
+      "markdownDescription": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "아케이드 버튼 제어 유형",
+      "description": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
+      "markdownDescription": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "버튼 제어 유형",
+      "description": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
+      "markdownDescription": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "방향 패드 제어 유형",
+      "description": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
+      "markdownDescription": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "조이스틱 제어 유형",
+      "description": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
+      "markdownDescription": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "스로틀 제어 유형",
+      "description": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
+      "markdownDescription": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "터치패드 제어 방식",
+      "description": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
+      "markdownDescription": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "사용자 지정 레이아웃 색상",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "얼굴 이미지 자산 스타일링 구성 요소",
+          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
+          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "얼굴 이미지 아이콘 스타일링 구성 요소",
+          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
+          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "자이로스코프 제어 유형",
+          "description": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
+          "markdownDescription": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "축 크기 입력 매핑",
+      "description": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
+      "markdownDescription": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X축 입력 매핑",
+          "description": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "markdownDescription": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y축 입력 매핑",
+          "description": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "markdownDescription": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X축 및 Y축 입력 매핑",
+      "description": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "markdownDescription": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z 및 Y축 입력 매핑",
+      "description": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "markdownDescription": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
           "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
           "styles": {
             "default": {
               "knob": {
@@ -4536,24 +1445,22 @@
           }
         }
       ],
+      "additionalProperties": false,
       "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
+        "action": {
+          "$ref": "#/$defs/ActionType"
         },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
         },
         "axis": {
           "$ref": "#/$defs/AxisMapping2D"
         },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
         },
         "relative": {
           "$ref": "#/$defs/RelativeInteraction"
@@ -4561,361 +1468,374 @@
         "styles": {
           "$ref": "#/$defs/JoystickStyles"
         },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
         "type": {
           "$ref": "#/$defs/_ControlTypeJoystick"
         }
       },
-      "additionalProperties": false
-    },
-    "InputCurve": {
-      "examples": [
-        {
-          "type": "circular",
-          "range": [
-            0,
-            0.33
-          ]
-        },
-        {
-          "type": "circular-inverse",
-          "range": [
-            0,
-            1
-          ]
-        },
-        {
-          "$ref": "#/$defs/commonJoystickResponseCurve"
-        }
+      "required": [
+        "type",
+        "axis"
       ],
-      "title": "[사용되지 않음] 입력 응답 곡선",
-      "description": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
+      "type": "object"
+    },
+    "_LayerControlBase": {
       "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/InputCurveType"
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "레이아웃 작업",
+      "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+      "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "레이아웃 작업",
+          "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+          "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
             },
-            "range": {
-              "$ref": "#/$defs/InputCurveRange"
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다."
+      ]
     },
-    "AxisMapping3D": {
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+    "_RelativeMouse1DOutputType": {
+      "title": "상대 마우스 1차원 출력",
+      "description": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
+      "markdownDescription": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "3차원 축 매핑"
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "상대 마우스 2차원 출력",
+      "description": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
+      "markdownDescription": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
+      "const": "relativeMouse",
+      "type": "string"
     },
     "_RelativeMouseMagnitudinalOutputType": {
-      "markdownDescription": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
-      "type": "string",
+      "title": "상대 마우스 방향 방향 출력",
       "description": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
+      "markdownDescription": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
       "enum": [
         "relativeMouseUp",
         "relativeMouseDown",
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "상대 마우스 방향 방향 출력"
+      "type": "string"
     },
-    "_InputAxisMagnitudinal": {
-      "markdownDescription": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
-      "type": "string",
-      "description": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "축 크기 입력 매핑"
-    },
-    "_InputAxis1D": {
+    "_SingleControlActionAssignableTypes": {
       "anyOf": [
         {
-          "const": "axisX",
-          "markdownDescription": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-          "type": "string",
-          "description": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-          "title": "X축 입력 매핑"
+          "$ref": "#/$defs/_ControllerAction"
         },
         {
-          "const": "axisY",
-          "markdownDescription": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-          "type": "string",
-          "description": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-          "title": "Y축 입력 매핑"
-        }
-      ]
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "markdownDescription": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
-      "anyOf": [
+          "$ref": "#/$defs/_LayoutAction"
+        },
         {
-          "type": "object",
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/_TurboAction"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
+      ]
+    },
+    "_StrokeBase": {
       "examples": [
         {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
         },
         {
-          "$ref": "#/definitions/commonOutlineStyling"
+          "$ref": "#/definitions/commonControlStroke"
         }
       ],
-      "title": "아웃라인 스타일링 구성 요소"
-    },
-    "ThrottleStyleBase": {
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "type": {
+              "description": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
+              "markdownDescription": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
-            },
-            "axisUp": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "axisDown": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "type"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "examples": [
-        {
-          "axisUp": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "axisDown": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          }
-        }
       ]
     },
-    "_AxisMapping3DItem": {
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        }
-      ],
-      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+    "_SystemColorContentPrimary": {
+      "title": "콘텐츠 기본 시스템 색상 재정의",
+      "description": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "콘텐츠 보조 시스템 색상 재정의",
+      "description": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
+      "markdownDescription": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "대비 기본 시스템 색상 재정의",
+      "description": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "대비 보조 시스템 색상 재정의",
+      "description": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
+      "markdownDescription": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "액션 시스템 색상 재정의",
+      "description": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "게임패드 액션 시스템 색상 재정의",
+      "description": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "악센트 기본 시스템 색상 재정의",
+      "description": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "악센트 보조 시스템 색상 재정의",
+      "description": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
       "examples": [
         {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
         }
       ],
-      "title": "3차원 축 매핑 항목"
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "터보 액션",
+      "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+      "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "터보 액션",
+          "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+          "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "작업 임계값",
+      "description": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+      "markdownDescription": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "ActionType": {
-      "markdownDescription": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "title": "제어 동작",
       "description": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "제어 동작"
-    },
-    "Layers": {
-      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "type": "throttle",
-                  "axisDown": "leftTrigger",
-                  "axisUp": "rightTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "title": "터치 레이아웃 레이어"
-    },
-    "DeadzoneRadial": {
-      "markdownDescription": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "description": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "title": "방사형"
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "$ref": "#/$defs/_ActionTypeBase"
     },
     "ArcadeButton": {
-      "markdownDescription": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "enabled": {
-              "$ref": "#/$defs/ControlEnabled"
-            },
-            "visible": {
-              "$ref": "#/$defs/ControlVisibility"
-            },
-            "styles": {
-              "$ref": "#/$defs/ArcadeButtonStyles"
-            },
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
       "description": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
+      "markdownDescription": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
       "examples": [
         {
           "action": "gamepadX",
@@ -4931,64 +1851,993 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ]
-    },
-    "JoystickMovingStyle": {
-      "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+      ],
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
+            "action": {
+              "$ref": "#/$defs/ActionType"
             },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
             },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "action"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+      ]
+    },
+    "ArcadeButtonStyleBase": {
       "examples": [
-        {},
         {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
           "background": {
             "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyle"
+          "$ref": "#/definitions/commonArcadeButtonStyle"
         }
       ],
-      "title": "제어 이동 스타일"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "컨트롤 비활성화 스타일",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "자산 참조 스타일링 구성 요소",
+      "description": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
+      "markdownDescription": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "축 캡 스타일링 구성 요소",
+      "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+      "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "축 캡 스타일링 구성 요소",
+              "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+              "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "2차원 축 매핑",
+      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "3차원 축 매핑",
+      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "배경 스타일 구성 요소",
+      "description": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+      "markdownDescription": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "컨트롤 활성화 스타일",
+      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "제어 기본 스타일",
+      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "컨트롤 비활성화 스타일",
+      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "유휴 스타일 제어",
+      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
+      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "전환된 스타일 제어",
+      "description": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
+      "markdownDescription": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "끌어온 컨트롤 스타일",
+      "description": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+      "markdownDescription": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "색상",
+      "description": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "markdownDescription": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "기본 색상",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "고대비 색상",
+      "description": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "터치 레이아웃 제어",
+      "description": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "markdownDescription": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "사용",
+      "description": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
+      "markdownDescription": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "터치 레이아웃 컨트롤 그룹",
+      "description": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
+      "markdownDescription": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "터치 레이아웃 제어 그룹 항목",
+      "description": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+      "markdownDescription": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "게임패드 액션",
+      "description": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "표시",
+      "description": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+      "markdownDescription": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "1차원 데드존",
+      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
+      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "2차원 데드존",
+      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
+      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "방향 패드 데드존",
+      "description": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
+      "markdownDescription": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "임계값",
+      "description": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
+      "markdownDescription": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "방사형",
+      "description": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
+      "markdownDescription": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "상호 작용",
+      "description": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
+      "markdownDescription": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "DirectionalPadInteractionActivationType": {
+      "title": "활성화 유형",
+      "description": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
       "markdownDescription": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
       "anyOf": [
         {
           "type": "string",
@@ -5000,319 +2849,458 @@
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "title": "활성화 유형"
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
       ]
     },
-    "_FaceImageAsset": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
-          "type": "string",
-          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
-          "title": "얼굴 이미지 자산 스타일링 구성 요소"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      },
-      "type": "object",
+    "DirectionalPadStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
       "examples": [
         {},
         {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "properties": {
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "additionalProperties": false
-    },
-    "TurboActionInterval": {
-      "examples": [
-        500,
-        1000
-      ],
-      "title": "간격",
-      "description": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
-      "exclusiveMinimum": 0,
-      "markdownDescription": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
-      "type": "number"
-    },
-    "_ControlTypeJoystick": {
-      "const": "joystick",
-      "markdownDescription": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
-      "type": "string",
-      "description": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
-      "title": "조이스틱 제어 유형"
-    },
-    "JoystickDisabledStyle": {
-      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
+          "default": {
             "stroke": {
               "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
               "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "컨트롤 비활성화 스타일"
-    },
-    "Opacity": {
-      "markdownDescription": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "maximum": 1,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "title": "불투명"
-    },
-    "_ControlTypeArcadeButtons": {
-      "const": "arcadeButtons",
-      "markdownDescription": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
-      "type": "string",
-      "description": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
-      "title": "아케이드 버튼 제어 유형"
-    },
-    "_Touchpad": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "axis": [
-            {
-              "output": "relativeMouse",
-              "input": "axisXY"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
             }
           }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
         }
       ],
-      "properties": {
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerUpperContent": {
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
+              "markdownDescription": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "확장",
+      "description": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
+      "markdownDescription": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
       "examples": [
+        true,
+        false,
         {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
         }
       ],
-      "title": "상위 계층 콘텐츠"
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "얼굴 이미지 스타일링 구성 요소",
+      "description": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+      "markdownDescription": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "얼굴 이미지 아이콘 레이블 스타일링 구성 요소",
+      "description": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
+      "markdownDescription": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "얼굴 이미지 아이콘",
+      "description": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
+      "markdownDescription": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "채우다",
+      "description": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "markdownDescription": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "그라데이션",
+      "description": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
+      "markdownDescription": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "지표 스타일링 구성 요소",
+      "description": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
+      "markdownDescription": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "내부",
+      "description": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
+      "markdownDescription": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "내부",
+      "description": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "markdownDescription": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "InputCurveRange": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 입력 곡선 범위",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
       "examples": [
         [
           0,
@@ -5334,63 +3322,1480 @@
           }
         ]
       ],
-      "title": "[사용되지 않음] 입력 곡선 범위",
-      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
       "anyOf": [
         {
           "items": {
             "anyOf": [
               {
+                "type": "number",
                 "minimum": -1,
-                "maximum": 1,
-                "type": "number"
+                "maximum": 1
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
-          "type": "array",
           "maxItems": 2,
-          "minItems": 2
+          "minItems": 2,
+          "type": "array"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다."
-    },
-    "_ActionTypeBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          },
-          "type": "array"
-        }
-      ],
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
       ]
     },
-    "_ControllerAction": {
-      "anyOf": [
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 입력 응답 곡선",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
+      "examples": [
         {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
         },
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 입력 응답 곡선 유형",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "컨트롤 활성화 스타일",
+      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "제어 기본 스타일",
+      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "방향 표시기 스타일링 구성 요소",
+      "description": "상호 작용 방향을 나타내는 시각적 스타일 지정",
+      "markdownDescription": "상호 작용 방향을 나타내는 시각적 스타일 지정",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
+              "markdownDescription": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "컨트롤 비활성화 스타일",
+      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "유휴 스타일 제어",
+      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "제어 이동 스타일",
+      "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+      "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "아웃라인 스타일링 구성 요소",
+      "description": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+      "markdownDescription": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "아웃라인 스타일링 구성 요소",
+      "description": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
+      "markdownDescription": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "노브 스타일링 구성 요소",
+      "description": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
+      "markdownDescription": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "터치 레이아웃 레이어",
+      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "터치 레이아웃 레이어",
+      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "터치 레이아웃 레이어 컨트롤",
+      "description": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
+      "markdownDescription": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "터치 레이아웃 레이어 컨트롤 그룹",
+      "description": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "markdownDescription": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "터치 레이아웃 레이어 제어 그룹 항목",
+      "description": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
+      "markdownDescription": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "레이아웃 레이어 컨트롤 휠 터치",
+      "description": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
+      "markdownDescription": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "하위 계층 배열 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "하위 계층 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "센서 레이어 콘텐츠",
+      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "상위 계층 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "상위 계층 오른쪽 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "레이아웃 작업 대상",
+      "description": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
+      "markdownDescription": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "색",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "레이아웃 콘텐츠",
+      "description": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
+      "markdownDescription": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "터치 레이아웃 컨트롤 휠",
+      "description": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
+      "markdownDescription": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 레이아웃 방향",
+      "description": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "하위 레이아웃 배열 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "하위 레이아웃 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "센서 레이아웃 콘텐츠",
+      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
+      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "레이아웃 스타일",
+      "description": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
+      "markdownDescription": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "상위 레이아웃 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "오른쪽 상단 레이아웃 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "불투명",
+      "description": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
+      "markdownDescription": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "밖의",
+      "description": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
+      "markdownDescription": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "밖의",
+      "description": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
+      "markdownDescription": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
         }
       ]
     },
@@ -5406,31 +4811,626 @@
           "$ref": "#/$defs/_Null"
         }
       ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "컨트롤 끌어오기 동작",
+      "description": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "PullIndicator": {
+      "title": "끌어오기 표시기 스타일 구성 요소",
+      "description": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
+      "markdownDescription": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "배경 스타일 구성 요소",
+      "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+      "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "상대적인",
+      "description": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
+      "markdownDescription": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "버튼으로 렌더링",
+      "description": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "규모",
+      "description": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "markdownDescription": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "민감도",
+      "description": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "markdownDescription": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "센서 제어",
+      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "레이어 센서 제어",
+      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "접착식",
+      "description": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
+      "markdownDescription": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "획 스타일 지정 구성 요소",
+      "description": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
+      "markdownDescription": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "스로틀 축",
+      "description": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "스로틀 축 스타일링 구성 요소",
+      "description": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+      "markdownDescription": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "컨트롤 활성화 업 스타일",
+              "description": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "markdownDescription": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "컨트롤 활성화 다운 스타일",
+              "description": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "markdownDescription": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "컨트롤 비활성화 스타일",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
+              "markdownDescription": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "토글",
+      "description": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
+      "markdownDescription": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "컨트롤 비활성화 스타일",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "제어 이동 스타일",
+              "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+              "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "간격",
+      "description": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
+      "markdownDescription": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
     }
   },
-  "description": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
   "properties": {
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
+    "$schema": {
+      "type": "string"
     },
     "content": {
       "$ref": "#/$defs/LayoutContent"
     },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
     "styles": {
       "$ref": "#/$defs/LayoutStyles"
     },
-    "$schema": {
-      "type": "string"
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
     }
   },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "required": [
     "content"
   ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
-  "title": "터치 적응 번들 레이아웃 스키마",
-  "markdownDescription": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요."
+  "type": "object"
 }

--- a/touch-adaptation-kit/schemas/ko-KR/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/ko-KR/layout/v4.0/layout.json
@@ -1,32 +1,2268 @@
 {
-  "required": [
-    "content"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "styles": {
-      "$ref": "#/$defs/LayoutStyles"
-    },
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "content": {
-      "$ref": "#/$defs/LayoutContent"
-    }
-  },
-  "title": "터치 적응 번들 레이아웃 스키마",
-  "description": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
-  "markdownDescription": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "type": "object",
   "$defs": {
+    "_StrokeBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "solid",
+              "markdownDescription": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
+              "type": "string",
+              "description": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다."
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "color": "#0099ff",
+          "type": "solid",
+          "opacity": 1
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "markdownDescription": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
+      "description": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "콘텐츠 기본 시스템 색상 재정의"
+    },
+    "_ControlTypeDirectionalPad": {
+      "const": "directionalPad",
+      "markdownDescription": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
+      "type": "string",
+      "description": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
+      "title": "방향 패드 제어 유형"
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JoystickDirectionIndicator": {
+      "markdownDescription": "상호 작용 방향을 나타내는 시각적 스타일 지정",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
+              "type": "string",
+              "description": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다."
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "상호 작용 방향을 나타내는 시각적 스타일 지정",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "title": "방향 표시기 스타일링 구성 요소"
+    },
+    "LayerSensorContent": {
+      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "title": "센서 레이어 콘텐츠"
+    },
+    "Background": {
+      "markdownDescription": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+      "title": "배경 스타일 구성 요소"
+    },
+    "_Accelerometer": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "const": "accelerometer",
+          "markdownDescription": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
+          "type": "string",
+          "description": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
+          "title": "가속도계 제어 유형"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "SensorControl": {
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "센서 제어",
+      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_Null": {
+      "markdownDescription": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
+      "type": "null",
+      "description": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
+      "examples": [
+        null
+      ],
+      "title": "null"
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "markdownDescription": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
+      "type": "string",
+      "description": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "title": "게임패드 아날로그 조이스틱 출력"
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "PullIndicator": {
+      "markdownDescription": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "title": "끌어오기 표시기 스타일 구성 요소"
+    },
+    "_SystemColorAccentPrimary": {
+      "markdownDescription": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
+      "description": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "악센트 기본 시스템 색상 재정의"
+    },
+    "Scale": {
+      "markdownDescription": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "anyOf": [
+        {
+          "minimum": 0.5,
+          "maximum": 2,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "title": "규모"
+    },
+    "JoystickIdleStyle": {
+      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "유휴 스타일 제어"
+    },
+    "_AxisMapping2DItem": {
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "rightTrigger",
+          "input": "axisUp"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "2차원 축 매핑 항목"
+    },
+    "TouchpadStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "유휴 스타일 제어"
+    },
+    "_LayoutStyles": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "colors": {
+            "highContrast": {
+              "myColor": "#00ff00ff",
+              "system_contentPrimary": "#ffffffff"
+            },
+            "default": {
+              "myColor": "#ff0000ff",
+              "system_contentPrimary": "#ffffffff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "markdownDescription": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "title": "방향 패드 데드존"
+    },
+    "Sticky": {
+      "markdownDescription": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "title": "접착식"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayoutContent": {
+      "markdownDescription": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "output": "leftJoystick",
+                  "input": "axisXY"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "레이아웃 콘텐츠"
+    },
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "format": "uri-reference",
+          "markdownDescription": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
+          "type": "string",
+          "description": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerControlWheel": {
+      "markdownDescription": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "title": "레이아웃 레이어 컨트롤 휠 터치"
+    },
+    "_SystemColorAccentSecondary": {
+      "markdownDescription": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
+      "description": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "악센트 보조 시스템 색상 재정의"
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "markdownDescription": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "전환된 스타일 제어"
+    },
+    "LayoutLowerArrayContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "title": "하위 레이아웃 배열 콘텐츠"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "2차원 축 매핑"
+    },
+    "ThrottleAxisOutput": {
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "title": "스로틀 축"
+    },
+    "ColorPaletteDefaultVariant": {
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "기본 색상"
+    },
+    "Deadzone1D": {
+      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "1차원 데드존"
+    },
+    "JoystickOutlineWithIndicator": {
+      "markdownDescription": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "title": "아웃라인 스타일링 구성 요소"
+    },
+    "_ControllerButtonOutputType": {
+      "markdownDescription": "게임패드 버튼 누름을 출력합니다.",
+      "type": "string",
+      "description": "게임패드 버튼 누름을 출력합니다.",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "title": "게임패드 버튼 출력"
+    },
+    "ButtonActivatedStyle": {
+      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "컨트롤 활성화 스타일"
+    },
+    "JoystickStyles": {
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "title": "컨트롤 스타일"
+    },
+    "ButtonDisabledStyle": {
+      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "컨트롤 비활성화 스타일"
+    },
+    "LayoutActionTarget": {
+      "markdownDescription": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "title": "레이아웃 작업 대상"
+    },
+    "_ControlTypeButton": {
+      "const": "button",
+      "markdownDescription": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
+      "type": "string",
+      "description": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
+      "title": "버튼 제어 유형"
+    },
+    "_ControllerAnalog1DOutputType": {
+      "markdownDescription": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "type": "string",
+      "description": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "title": "게임패드 아날로그 조이스틱 출력"
+    },
+    "_LayoutAction": {
+      "type": "object",
+      "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "const": "layer",
+          "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+          "type": "string",
+          "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+          "title": "레이아웃 작업"
+        }
+      },
+      "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "title": "레이아웃 작업",
+      "required": [
+        "type",
+        "target"
+      ],
+      "additionalProperties": false
+    },
+    "InnerLayoutControlWheel": {
+      "markdownDescription": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "output": "leftJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "title": "내부"
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_ControllerTriggerOutputType": {
+      "markdownDescription": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
+      "type": "string",
+      "description": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "title": "게임패드 아날로그 트리거 출력"
+    },
+    "DirectionalPadStyles": {
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
+              "description": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "유휴 스타일 제어"
+            },
+            "disabled": {
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "컨트롤 활성화 스타일"
+            },
+            "activated": {
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "컨트롤 활성화 스타일"
+            },
+            "default": {
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "제어 기본 스타일"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "gradient": {
+              "color": "#0099ffaa"
+            },
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "title": "컨트롤 스타일"
+    },
+    "Indicator": {
+      "markdownDescription": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
+      "description": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "지표 스타일링 구성 요소"
+    },
+    "Stroke": {
+      "markdownDescription": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
+      "description": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "획 스타일 지정 구성 요소"
+    },
+    "Gradient": {
+      "markdownDescription": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "title": "그라데이션"
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "markdownDescription": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "title": "게임패드 액션"
+    },
+    "_DirectionalPad": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_TurboAction": {
+      "title": "터보 액션",
+      "properties": {
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "const": "turbo",
+          "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+          "type": "string",
+          "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+          "title": "터보 액션"
+        },
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        }
+      },
+      "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+      "type": "object",
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+      "additionalProperties": false
+    },
+    "ControlGroup": {
+      "markdownDescription": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "title": "터치 레이아웃 컨트롤 그룹"
+    },
+    "_SystemColorContrastPrimary": {
+      "markdownDescription": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
+      "description": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "대비 기본 시스템 색상 재정의"
+    },
+    "ControlGroupItem": {
+      "markdownDescription": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+      "title": "터치 레이아웃 제어 그룹 항목"
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionThreshold": {
+      "markdownDescription": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "title": "작업 임계값"
+    },
+    "ArcadeButtonStyles": {
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "유휴 스타일 제어"
+            },
+            "disabled": {
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "컨트롤 비활성화 스타일"
+            },
+            "activated": {
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "컨트롤 활성화 스타일"
+            },
+            "default": {
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "제어 기본 스타일"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "activated": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            }
+          },
+          "default": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "title": "컨트롤 스타일"
+    },
+    "_BackgroundAsset": {
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
+          "type": "string",
+          "description": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다."
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_FaceImageIcon": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        "type": {
+          "const": "icon",
+          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
+          "type": "string",
+          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
+          "title": "얼굴 이미지 아이콘 스타일링 구성 요소"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "markdownDescription": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "title": "얼굴 이미지 아이콘"
+    },
+    "Toggle": {
+      "markdownDescription": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "title": "토글"
+    },
+    "ArcadeButtonStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ]
+    },
+    "_ControlTypeTouchpad": {
+      "const": "touchpad",
+      "markdownDescription": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
+      "type": "string",
+      "description": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
+      "title": "터치패드 제어 방식"
+    },
+    "ThrottleStyles": {
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "제어 기본 스타일"
+            },
+            "idleUp": {
+              "markdownDescription": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
+              "description": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "유휴 스타일 제어"
+            },
+            "activatedDown": {
+              "markdownDescription": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "description": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "컨트롤 활성화 다운 스타일"
+            },
+            "disabled": {
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "컨트롤 비활성화 스타일"
+            },
+            "activatedUp": {
+              "markdownDescription": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "description": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "컨트롤 활성화 업 스타일"
+            },
+            "idle": {
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "유휴 스타일 제어"
+            },
+            "activated": {
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "컨트롤 활성화 스타일"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "axisDown": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "title": "컨트롤 스타일"
+    },
+    "SensorLayerControl": {
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "레이어 센서 제어",
+      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_SystemColorActionColor": {
+      "markdownDescription": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
+      "description": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "액션 시스템 색상 재정의"
+    },
+    "LayoutSensorContent": {
+      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "title": "센서 레이아웃 콘텐츠"
+    },
+    "LayoutColors": {
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            },
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "highContrast": {
+            "myColor": "#00ff00ff",
+            "system_contentPrimary": "#ffffffff"
+          },
+          "default": {
+            "myColor": "#ff0000ff",
+            "system_contentPrimary": "#ffffffff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "title": "색"
+    },
+    "LayoutUpperContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "title": "상위 레이아웃 콘텐츠"
+    },
+    "_Color": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ]
+    },
     "DirectionalPadDefaultStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
       "examples": [
         {},
         {
@@ -42,39 +2278,855 @@
         {
           "$ref": "#/definitions/commonDPadStyle"
         }
-      ],
+      ]
+    },
+    "RelativeInteraction": {
+      "markdownDescription": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "type": "boolean"
         },
         {
           "$ref": "#/$defs/Reference"
         }
+      ],
+      "description": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "title": "상대적인"
+    },
+    "ButtonPulledStyle": {
+      "markdownDescription": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "끌어온 컨트롤 스타일"
+    },
+    "InputCurveType": {
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "title": "[사용되지 않음] 입력 응답 곡선 유형",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다."
+    },
+    "ThrottleAxisStyle": {
+      "markdownDescription": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+      "examples": [
+        {
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          },
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        }
+      ],
+      "title": "스로틀 축 스타일링 구성 요소"
+    },
+    "ButtonDefaultStyle": {
+      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "제어 기본 스타일"
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FillColor": {
+      "markdownDescription": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "description": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "$ref": "#/$defs/_Color",
+      "title": "채우다"
+    },
+    "PullIndicatorBackground": {
+      "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "title": "배경 스타일 구성 요소"
+    },
+    "_Button": {
+      "type": "object",
+      "required": [
+        "type",
+        "action"
+      ],
+      "examples": [
+        {
+          "type": "button",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          },
+          "action": "gamepadA"
+        }
+      ],
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DirectionalPadInteraction": {
+      "markdownDescription": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "title": "상호 작용"
+    },
+    "ButtonStyles": {
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "title": "컨트롤 스타일"
+    },
+    "_CustomColorPaletteColor": {
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "사용자 지정 레이아웃 색상"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "markdownDescription": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "title": "임계값"
+    },
+    "_SystemColorContrastSecondary": {
+      "markdownDescription": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
+      "description": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "대비 보조 시스템 색상 재정의"
+    },
+    "_SystemColorGamepadActionColor": {
+      "markdownDescription": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
+      "description": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "게임패드 액션 시스템 색상 재정의"
+    },
+    "AssetReference": {
+      "markdownDescription": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "title": "자산 참조 스타일링 구성 요소"
+    },
+    "FaceImage": {
+      "markdownDescription": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "title": "얼굴 이미지 스타일링 구성 요소"
+    },
+    "_ControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ],
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      }
+    },
+    "JoystickActivatedStyle": {
+      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "컨트롤 활성화 스타일"
+    },
+    "LayoutLowerContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "title": "하위 레이아웃 콘텐츠"
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ControlVisibility": {
+      "markdownDescription": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "표시"
+    },
+    "LayerLowerArrayContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "title": "하위 계층 배열 콘텐츠"
+    },
+    "OuterLayoutControlWheel": {
+      "markdownDescription": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "title": "밖의"
+    },
+    "ControlEnabled": {
+      "markdownDescription": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "사용"
+    },
+    "ExpandInteraction": {
+      "markdownDescription": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "title": "확장"
+    },
+    "Deadzone2D": {
+      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            },
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
+      "examples": [
+        {
+          "threshold": 0,
+          "radial": true
+        },
+        {
+          "threshold": 0.1,
+          "radial": false
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "2차원 데드존"
+    },
+    "_ColorPaletteColor": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ]
+    },
+    "_InputAxisZY": {
+      "const": "axisZY",
+      "markdownDescription": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "type": "string",
+      "description": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "title": "Z 및 Y축 입력 매핑"
+    },
+    "DirectionalPadIdleStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "gradient": {
+            "color": "#0099ffaa"
+          },
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
       ]
     },
     "Definitions": {
-      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "additionalProperties": false,
-      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
-      "title": "정의",
       "examples": [
         {},
         {
@@ -93,95 +3145,184 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "정의",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/LayoutDefinableType"
         }
       },
-      "type": "object"
+      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "type": "object",
+      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "additionalProperties": false
     },
-    "_InputAxisXY": {
-      "description": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-      "title": "X축 및 Y축 입력 매핑",
+    "_SystemColorContentSecondary": {
+      "markdownDescription": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
+      "description": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "콘텐츠 보조 시스템 색상 재정의"
+    },
+    "Color": {
+      "markdownDescription": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "description": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "$ref": "#/$defs/_Color",
+      "title": "색상"
+    },
+    "_RelativeMouse1DOutputType": {
+      "markdownDescription": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
       "type": "string",
-      "const": "axisXY",
-      "markdownDescription": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오."
-    },
-    "LayerControlGroupItem": {
-      "description": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+      "description": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "title": "터치 레이아웃 레이어 제어 그룹 항목",
+      "title": "상대 마우스 1차원 출력"
+    },
+    "_ArcadeButtons": {
+      "type": "object",
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
       "examples": [
         {
-          "$ref": "#/definitions/commonLayerButtonControl"
+          "type": "arcadeButtons",
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          }
         }
       ],
-      "markdownDescription": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다."
+      "properties": {
+        "specialPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "특수 펀치 버튼"
+        },
+        "heavyPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "헤비 킥 버튼"
+        },
+        "lightPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "라이트 펀치 버튼"
+        },
+        "lightKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "라이트 킥 버튼"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        },
+        "mediumKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "미디엄 킥 버튼"
+        },
+        "specialKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "스페셜 킥 버튼"
+        },
+        "heavyKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "헤비 킥 버튼"
+        },
+        "mediumPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "중간 펀치 버튼"
+        }
+      },
+      "additionalProperties": false
     },
-    "Indicator": {
-      "description": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
-      "title": "지표 스타일링 구성 요소",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다."
-    },
-    "FaceImage": {
-      "description": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+    "OuterLayerControlWheel": {
+      "markdownDescription": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "얼굴 이미지 스타일링 구성 요소",
+      "description": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
       "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
         {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
+          "$ref": "#/definitions/commonLayerOuterWheel"
         }
       ],
-      "markdownDescription": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다."
+      "title": "밖의"
     },
-    "ControlGroupItem": {
-      "description": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+    "_InputMapping3DTo2DOutput": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControlBase"
+          "$ref": "#/$defs/_InputMappingXY"
         },
         {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_InputMappingZY"
         }
-      ],
-      "title": "터치 레이아웃 제어 그룹 항목",
-      "markdownDescription": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다."
+      ]
+    },
+    "_ControlTypeThrottle": {
+      "const": "throttle",
+      "markdownDescription": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
+      "type": "string",
+      "description": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
+      "title": "스로틀 제어 유형"
     },
     "LayoutOrientation": {
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
-      "deprecated": true,
+      "title": "[사용되지 않음] 레이아웃 방향",
+      "description": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
       "enum": [
         "landscape-left",
         "landscape-right",
@@ -189,202 +3330,291 @@
         "portrait-up",
         "portrait"
       ],
-      "description": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
-      "title": "[사용되지 않음] 레이아웃 방향",
+      "deprecated": true,
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
       "type": "string"
     },
-    "PullIndicator": {
-      "description": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
             }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          ]
         },
-        {
-          "$ref": "#/$defs/Reference"
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
         }
-      ],
-      "title": "끌어오기 표시기 스타일 구성 요소",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "markdownDescription": "컨트롤이 현재 당겨지고 있음을 나타내는 표시기의 시각적 스타일입니다. 컨트롤을 끌어오는 의미 체계를 나타내도록 색상을 사용자 지정할 수 있습니다."
+      },
+      "additionalProperties": false
     },
-    "_ActionTypeBase": {
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          }
-        }
-      ]
-    },
-    "_CustomColorPaletteColor": {
-      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
-      "title": "사용자 지정 레이아웃 색상",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다."
-    },
-    "ColorPaletteHighContrastVariant": {
-      "description": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "title": "고대비 색상",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다."
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "description": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "게임패드 아날로그 조이스틱 출력",
+    "_InputAxisXY": {
+      "const": "axisXY",
+      "markdownDescription": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
       "type": "string",
-      "markdownDescription": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다."
+      "description": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "title": "X축 및 Y축 입력 매핑"
     },
-    "JoystickStyles": {
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+    "PullActionType": {
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "description": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "컨트롤 끌어오기 동작"
+    },
+    "Knob": {
+      "markdownDescription": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
             },
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
             },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
+            "background": {
+              "$ref": "#/$defs/Background"
             },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "컨트롤 스타일",
+      "description": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
       "examples": [
-        {},
         {
-          "default": {
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyles"
+          "$ref": "#/definitions/commonControlKnobStyling"
         }
       ],
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다."
+      "title": "노브 스타일링 구성 요소"
     },
-    "_InputMappingZY": {
+    "Control": {
+      "markdownDescription": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+          "$ref": "#/$defs/_ControlBase"
         },
         {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
-    },
-    "LayerControlGroup": {
+      ],
+      "description": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
       "examples": [
-        [],
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "title": "터치 레이아웃 제어"
+    },
+    "LayerUpperRightContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
+      "examples": [
         [
-          null,
           {
             "type": "blank"
           },
-          null
-        ]
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
       ],
-      "description": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "minItems": 1,
-      "title": "터치 레이아웃 레이어 컨트롤 그룹",
-      "markdownDescription": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      },
-      "maxItems": 4
+      "title": "상위 계층 오른쪽 콘텐츠"
     },
-    "ThrottleAxisOutput": {
-      "description": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+    "AxisCapColor": {
+      "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+              "type": "string",
+              "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+              "title": "축 캡 스타일링 구성 요소"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "스로틀 축",
+      "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
       "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
         {
-          "$ref": "#/definitions/commonThrottleAxis"
+          "type": "color",
+          "value": "#0099ffaa"
         }
       ],
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다."
+      "title": "축 캡 스타일링 구성 요소"
+    },
+    "_Throttle": {
+      "type": "object",
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "examples": [
+        {
+          "sticky": true,
+          "type": "throttle",
+          "axisDown": "leftTrigger",
+          "axisUp": "rightTrigger"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_Blank": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "properties": {
+        "type": {
+          "const": "blank",
+          "markdownDescription": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
+          "type": "string",
+          "description": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
+          "title": "공백 제어 유형"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RenderAsButton": {
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "title": "버튼으로 렌더링"
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
     },
     "_InputMappingXYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
       "properties": {
         "sensitivity": {
           "$ref": "#/$defs/Sensitivity"
@@ -396,374 +3626,444 @@
           "$ref": "#/$defs/_InputAxisXY"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": false
+    },
+    "ColorPaletteHighContrastVariant": {
+      "markdownDescription": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "description": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "고대비 색상"
+    },
+    "LayoutStyles": {
+      "markdownDescription": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
+      "description": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
+      "$ref": "#/$defs/_LayoutStyles",
+      "title": "레이아웃 스타일"
+    },
+    "LayerControlGroup": {
+      "type": "array",
+      "markdownDescription": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "minItems": 1,
+      "description": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "maxItems": 4,
+      "title": "터치 레이아웃 레이어 컨트롤 그룹",
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      }
+    },
+    "_BackgroundColor": {
       "type": "object",
       "required": [
-        "input",
-        "output"
-      ]
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "type": {
+          "const": "color",
+          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+          "type": "string",
+          "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다."
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
     },
     "_Gyroscope": {
-      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "output": "rightJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
       "properties": {
         "axis": {
           "$ref": "#/$defs/AxisMapping3D"
         },
         "type": {
-          "description": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
-          "title": "자이로스코프 제어 유형",
-          "type": "string",
           "const": "gyroscope",
-          "markdownDescription": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다."
+          "markdownDescription": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
+          "type": "string",
+          "description": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
+          "title": "자이로스코프 제어 유형"
         },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         }
       },
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "input": "axisXY",
-            "output": "rightJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
+      "additionalProperties": false
     },
-    "LayerLowerArrayContent": {
-      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+    "FaceImageIconLabel": {
+      "markdownDescription": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
       "anyOf": [
         {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "하위 계층 배열 콘텐츠",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다."
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "_SystemColorContrastSecondary": {
-      "description": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
-      "title": "대비 보조 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다."
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "description": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "게임패드 액션",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "markdownDescription": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다."
-    },
-    "_Color": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ExpandInteraction": {
-      "description": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "확장",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다."
-    },
-    "ControlEnabled": {
-      "description": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "사용",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다."
-    },
-    "_ControlTypeButton": {
-      "description": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
-      "title": "버튼 제어 유형",
-      "type": "string",
-      "const": "button",
-      "markdownDescription": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다."
-    },
-    "PullIndicatorBackground": {
-      "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "배경 스타일 구성 요소",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다."
-    },
-    "PullActionType": {
-      "description": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임 패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
-      "title": "컨트롤 끌어오기 동작",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "이 속성을 사용하면 컨트롤이 `pulled` 상태일 때 단일 동작 또는 일련의 동작을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임 패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다."
-    },
-    "ControlGroup": {
-      "markdownDescription": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
-      "items": {
-        "$ref": "#/$defs/ControlGroupItem"
-      },
-      "description": "그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 배열에서 컨트롤을 건너뛸 수 있습니다.",
-      "title": "터치 레이아웃 컨트롤 그룹",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
           },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerSensorContent": {
-      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "센서 레이어 콘텐츠",
+      "description": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
       "examples": [
-        [
-          {
-            "type": "blank"
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "title": "얼굴 이미지 아이콘 레이블 스타일링 구성 요소"
+    },
+    "TouchpadStyles": {
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "유휴 스타일 제어"
+            },
+            "disabled": {
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "컨트롤 비활성화 스타일"
+            },
+            "activated": {
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "컨트롤 활성화 스타일"
+            },
+            "moving": {
+              "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+              "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "제어 이동 스타일"
+            },
+            "default": {
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "제어 기본 스타일"
+            }
           },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
             }
           }
-        ],
+        },
         {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
+          "$ref": "#/definitions/commonTouchpadControlStyles"
         }
       ],
-      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다."
+      "title": "컨트롤 스타일"
     },
-    "ButtonActivatedStyle": {
-      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+    "Layer": {
+      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
       "anyOf": [
         {
+          "type": "object",
+          "properties": {
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "sticky": true,
+                "type": "throttle",
+                "axisDown": "leftTrigger",
+                "axisUp": "rightTrigger"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "title": "터치 레이아웃 레이어"
+    },
+    "LayerControlGroupItem": {
+      "markdownDescription": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "title": "터치 레이아웃 레이어 제어 그룹 항목"
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "title": "오른쪽 상단 레이아웃 콘텐츠"
+    },
+    "JoystickDefaultStyle": {
+      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
             },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
             "opacity": {
               "$ref": "#/$defs/Opacity"
             },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "컨트롤 활성화 스타일",
+      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
       "examples": [
         {},
         {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonButtonStyle"
+          "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
+      "title": "제어 기본 스타일"
     },
-    "_InputMapping1DToGamepad1DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
+    "_ControllerAnalog2DOutputType": {
+      "markdownDescription": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "type": "string",
+      "description": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "title": "게임패드 아날로그 조이스틱 출력"
+    },
+    "LayerLowerContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
         },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
+        {
+          "$ref": "#/$defs/Reference"
         }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
+      ],
+      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "title": "하위 계층 콘텐츠"
     },
     "LayoutDefinableType": {
-      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -1078,731 +4378,42 @@
           "$ref": "#/$defs/TouchpadStyles"
         }
       ],
-      "title": "정의 가능한 유형",
-      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요."
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_TurboAction": {
-      "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-      "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        },
-        "type": {
-          "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
-          "title": "터보 액션",
-          "type": "string",
-          "const": "turbo",
-          "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다."
-        },
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        }
-      },
-      "title": "터보 액션",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "type": "object"
-    },
-    "_ArcadeButtons": {
-      "additionalProperties": false,
-      "properties": {
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "중간 펀치 버튼"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "헤비 킥 버튼"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "헤비 킥 버튼"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "라이트 킥 버튼"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "스페셜 킥 버튼"
-        },
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "특수 펀치 버튼"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "라이트 펀치 버튼"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "미디엄 킥 버튼"
-        }
-      },
-      "examples": [
-        {
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "type": "arcadeButtons",
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ]
-    },
-    "Opacity": {
-      "description": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "type": "number",
-          "maximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "불투명",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다."
-    },
-    "LayoutColors": {
-      "description": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            },
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "색",
-      "examples": [
-        {},
-        {
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다."
-    },
-    "_ControllerTriggerOutputType": {
-      "description": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "게임패드 아날로그 트리거 출력",
-      "type": "string",
-      "markdownDescription": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다."
-    },
-    "ButtonDefaultStyle": {
-      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "제어 기본 스타일",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다."
-    },
-    "_ControlTypeDirectionalPad": {
-      "description": "방향 패드 컨트롤은 실제 게임 패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
-      "title": "방향 패드 제어 유형",
-      "type": "string",
-      "const": "directionalPad",
-      "markdownDescription": "방향 패드 컨트롤은 실제 게임 패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요."
-    },
-    "_ControlTypeTouchpad": {
-      "description": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
-      "title": "터치패드 제어 방식",
-      "type": "string",
-      "const": "touchpad",
-      "markdownDescription": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다."
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "DirectionalPadInteraction": {
-      "description": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
-      "anyOf": [
-        {
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "상호 작용",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "markdownDescription": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오."
-    },
-    "_ControllerAction": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        }
-      ]
-    },
-    "LayerControl": {
-      "description": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "터치 레이아웃 레이어 컨트롤",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "markdownDescription": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다."
-    },
-    "AxisMapping3D": {
-      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "3차원 축 매핑",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다."
-    },
-    "ActionType": {
-      "description": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임 패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
-      "title": "제어 동작",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임 패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다."
-    },
-    "InputCurveType": {
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
-      "deprecated": true,
-      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
-      "title": "[사용되지 않음] 입력 응답 곡선 유형",
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ColorPaletteColor": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "TouchpadStyles": {
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "title": "제어 기본 스타일",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다."
-            },
-            "idle": {
-              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "title": "유휴 스타일 제어",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다."
-            },
-            "disabled": {
-              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "title": "컨트롤 비활성화 스타일",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다."
-            },
-            "activated": {
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "title": "컨트롤 활성화 스타일",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
-            },
-            "moving": {
-              "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
-              "title": "제어 이동 스타일",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 스타일",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다."
-    },
-    "ButtonIdleStyle": {
-      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "유휴 스타일 제어",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다."
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "additionalProperties": false,
-      "properties": {
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "examples": [
-        {},
-        {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "type": "object",
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      }
-    },
-    "Control": {
-      "description": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "터치 레이아웃 제어",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "markdownDescription": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요."
-    },
-    "_ControllerButtonOutputType": {
-      "description": "게임패드 버튼 누름을 출력합니다.",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "게임패드 버튼 출력",
-      "type": "string",
-      "markdownDescription": "게임패드 버튼 누름을 출력합니다."
-    },
-    "ButtonToggledStyle": {
-      "description": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "전환된 스타일 제어",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다."
-    },
-    "_RelativeMouse2DOutputType": {
-      "description": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
-      "title": "상대 마우스 2차원 출력",
-      "type": "string",
-      "const": "relativeMouse",
-      "markdownDescription": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다."
-    },
-    "_ControlTypeArcadeButtons": {
-      "description": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
-      "title": "아케이드 버튼 제어 유형",
-      "type": "string",
-      "const": "arcadeButtons",
-      "markdownDescription": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다."
+      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "title": "정의 가능한 유형"
     },
     "LayoutControlWheel": {
-      "description": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
+      "markdownDescription": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            },
             "inner": {
               "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "터치 레이아웃 컨트롤 휠",
+      "description": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
       "examples": [
         {},
         {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "output": "leftJoystick",
+                "input": "axisXY"
+              }
+            }
+          ],
           "outer": [
             null,
             [
@@ -1815,818 +4426,148 @@
               "type": "button",
               "action": "gamepadY"
             }
-          ],
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "input": "axisXY",
-                "output": "leftJoystick"
-              }
-            }
           ]
         },
         {
           "$ref": "#/definitions/commonControlWheel"
         }
       ],
-      "markdownDescription": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다."
+      "title": "터치 레이아웃 컨트롤 휠"
     },
-    "Reference": {
-      "additionalProperties": false,
-      "properties": {
-        "$ref": {
-          "description": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
-          "exmaples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ],
-          "type": "string",
-          "format": "uri-reference",
-          "markdownDescription": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오."
-        }
-      },
-      "type": "object",
-      "required": [
-        "$ref"
-      ]
-    },
-    "LayerUpperRightContent": {
-      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "상위 계층 오른쪽 콘텐츠",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다."
-    },
-    "LayoutStyles": {
-      "description": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
-      "title": "레이아웃 스타일",
-      "$ref": "#/$defs/_LayoutStyles",
-      "markdownDescription": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다."
-    },
-    "OuterWheelControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Control"
-        },
-        {
-          "$ref": "#/$defs/ControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonStyles": {
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 스타일",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다."
-    },
-    "JoystickMovingStyle": {
-      "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "제어 이동 스타일",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다."
-    },
-    "LayoutActionTarget": {
-      "description": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "레이아웃 작업 대상",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "markdownDescription": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다."
-    },
-    "DirectionalPadStyles": {
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "title": "제어 기본 스타일",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다."
-            },
-            "idle": {
-              "description": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
-              "title": "유휴 스타일 제어",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다."
-            },
-            "disabled": {
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "title": "컨트롤 활성화 스타일",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
-            },
-            "activated": {
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "title": "컨트롤 활성화 스타일",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 스타일",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다."
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "AssetReference": {
-      "description": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "자산 참조 스타일링 구성 요소",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "markdownDescription": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다."
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "description": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
-      "title": "스로틀 제어 유형",
+    "_RelativeMouse2DOutputType": {
+      "const": "relativeMouse",
+      "markdownDescription": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
       "type": "string",
-      "const": "throttle",
-      "markdownDescription": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다."
+      "description": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
+      "title": "상대 마우스 2차원 출력"
     },
-    "_Null": {
-      "description": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
-      "title": "null",
-      "examples": [
-        null
-      ],
-      "type": "null",
-      "markdownDescription": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다."
-    },
-    "_SystemColorAccentPrimary": {
-      "description": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
-      "title": "악센트 기본 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다."
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ArcadeButtonStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ],
+    "LayerControl": {
+      "markdownDescription": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Deadzone2D": {
-      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ]
+          "$ref": "#/$defs/_LayerControlBase"
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "2차원 데드존",
+      "description": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
       "examples": [
         {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
+          "$ref": "#/definitions/commonLayerButtonControl"
         }
       ],
-      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다."
+      "title": "터치 레이아웃 레이어 컨트롤"
     },
-    "DirectionalPadIdleStyle": {
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          }
-        }
-      ],
-      "title": "2차원 축 매핑",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다."
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "OuterLayerControlWheel": {
-      "description": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "밖의",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다."
-    },
-    "FillColor": {
-      "description": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
-      "title": "채우다",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요."
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_InputAxisMagnitudinal": {
-      "description": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "축 크기 입력 매핑",
-      "type": "string",
-      "markdownDescription": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다."
-    },
-    "_LayoutStyles": {
-      "examples": [
-        {},
-        {
-          "colors": {
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "description": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+    "Sensitivity": {
+      "markdownDescription": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
       "anyOf": [
         {
           "type": "number",
-          "minimum": 0
+          "exclusiveMinimum": 0
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "작업 임계값",
+      "description": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
       "examples": [
-        1,
+        10,
         1.5,
-        0,
+        0.5,
         {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
         }
       ],
-      "markdownDescription": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다."
+      "title": "민감도"
     },
-    "ControlVisibility": {
-      "description": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+    "InnerLayerControlWheel": {
+      "markdownDescription": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
       "anyOf": [
         {
-          "type": "boolean"
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "표시",
+      "description": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
       "examples": [
-        true,
-        false,
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
         {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "markdownDescription": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다."
+      "title": "내부"
     },
-    "_BackgroundAsset": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        }
-      },
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
+    "_Joystick": {
       "type": "object",
       "required": [
         "type",
-        "value"
-      ]
-    },
-    "Gradient": {
-      "description": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+        "axis"
       ],
-      "title": "그라데이션",
       "examples": [
         {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          },
+          "type": "joystick",
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
           }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
         }
       ],
-      "markdownDescription": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다."
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "additionalProperties": false
     },
     "InputCurve": {
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
-      "deprecated": true,
-      "description": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
-      "title": "[사용되지 않음] 입력 응답 곡선",
       "examples": [
         {
           "type": "circular",
@@ -2646,8 +4587,15 @@
           "$ref": "#/$defs/commonJoystickResponseCurve"
         }
       ],
+      "title": "[사용되지 않음] 입력 응답 곡선",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
       "anyOf": [
         {
+          "type": "object",
+          "required": [
+            "range",
+            "type"
+          ],
           "properties": {
             "type": {
               "$ref": "#/$defs/InputCurveType"
@@ -2656,247 +4604,61 @@
               "$ref": "#/$defs/InputCurveRange"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerLowerContent": {
-      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "하위 계층 콘텐츠",
+      "deprecated": true,
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다."
+    },
+    "AxisMapping3D": {
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
       "examples": [
         {
-          "center": {
-            "type": "blank"
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
           }
-        },
+        ],
         {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+          "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다."
-    },
-    "_InputAxis1D": {
-      "anyOf": [
-        {
-          "description": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-          "title": "X축 입력 매핑",
-          "type": "string",
-          "const": "axisX",
-          "markdownDescription": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오."
-        },
-        {
-          "description": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-          "title": "Y축 입력 매핑",
-          "type": "string",
-          "const": "axisY",
-          "markdownDescription": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오."
-        }
-      ]
-    },
-    "Toggle": {
-      "description": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "토글",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다."
-    },
-    "_Joystick": {
-      "additionalProperties": false,
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeJoystick"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "styles": {
-          "$ref": "#/$defs/JoystickStyles"
-        },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          },
-          "type": "joystick",
-          "styles": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "icon",
-                  "value": "walk"
-                }
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "JoystickActivatedStyle": {
-      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 활성화 스타일",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
-    },
-    "TouchpadStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
+      "title": "3차원 축 매핑"
     },
     "_RelativeMouseMagnitudinalOutputType": {
+      "markdownDescription": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
+      "type": "string",
       "description": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
       "enum": [
         "relativeMouseUp",
@@ -2904,39 +4666,60 @@
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "상대 마우스 방향 방향 출력",
-      "type": "string",
-      "markdownDescription": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다."
+      "title": "상대 마우스 방향 방향 출력"
     },
-    "JoystickOutlineWithIndicator": {
-      "description": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+    "_InputAxisMagnitudinal": {
+      "markdownDescription": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
+      "type": "string",
+      "description": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "title": "축 크기 입력 매핑"
+    },
+    "_InputAxis1D": {
       "anyOf": [
         {
+          "const": "axisX",
+          "markdownDescription": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "type": "string",
+          "description": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "title": "X축 입력 매핑"
+        },
+        {
+          "const": "axisY",
+          "markdownDescription": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "type": "string",
+          "description": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "title": "Y축 입력 매핑"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "markdownDescription": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             },
             "stroke": {
               "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "아웃라인 스타일링 구성 요소",
+      "description": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
       "examples": [
         {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
           "stroke": {
             "type": "solid",
             "color": "#0099ffaa"
@@ -2946,158 +4729,15 @@
           "$ref": "#/definitions/commonOutlineStyling"
         }
       ],
-      "markdownDescription": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다."
-    },
-    "_ControlTypeJoystick": {
-      "description": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
-      "title": "조이스틱 제어 유형",
-      "type": "string",
-      "const": "joystick",
-      "markdownDescription": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다."
-    },
-    "ColorPaletteDefaultVariant": {
-      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
-      "title": "기본 색상",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다."
-    },
-    "InnerLayoutControlWheel": {
-      "description": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다.",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "내부",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "input": "axisXY",
-              "output": "leftJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "컨트롤 휠의 내부 세그먼트에 그룹으로 배열된 1~4개의 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다."
-    },
-    "SensorControl": {
-      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ]
-        }
-      },
-      "title": "센서 제어",
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_BackgroundColor": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
-          "type": "string",
-          "const": "color",
-          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/Color"
-        }
-      },
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
+      "title": "아웃라인 스타일링 구성 요소"
     },
     "ThrottleStyleBase": {
-      "examples": [
-        {
-          "axisUp": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "axisDown": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          }
-        }
-      ],
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
+            "knob": {
+              "$ref": "#/$defs/Knob"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
@@ -3108,214 +4748,59 @@
             "axisDown": {
               "$ref": "#/$defs/ThrottleAxisStyle"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Sticky": {
-      "description": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "접착식",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "markdownDescription": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다."
-    },
-    "RenderAsButton": {
-      "description": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "버튼으로 렌더링",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "markdownDescription": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다."
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "type": "string",
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ]
-        }
-      ]
-    },
-    "_Button": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
       "examples": [
         {
-          "action": "gamepadA",
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
+          "axisUp": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "axisDown": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
             }
           }
         }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "action"
       ]
-    },
-    "JoystickDirectionIndicator": {
-      "description": "상호 작용 방향을 나타내는 시각적 스타일 지정",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "방향 표시기 스타일링 구성 요소",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "markdownDescription": "상호 작용 방향을 나타내는 시각적 스타일 지정"
-    },
-    "Color": {
-      "description": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
-      "title": "색상",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요."
-    },
-    "OuterLayoutControlWheel": {
-      "description": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "밖의",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 각 인덱스는 단일 컨트롤이거나 컨트롤 배열일 수 있습니다. 배열이 지정되면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중앙에서 더 멀리 확장될 수 있습니다. 전체적으로 외부 휠에는 8개의 개별 컨트롤 또는 4개의 컨트롤 그룹을 위한 공간이 있습니다. 이를 초과하는 모든 컨트롤은 제거되거나 유효성 검사 규칙 실패를 유발할 수 있습니다. `null` 컨트롤은 컨트롤 그룹을 오프셋하기 위해 바깥쪽 휠 배열의 시작 부분에서 사용할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다."
     },
     "_AxisMapping3DItem": {
-      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
       "anyOf": [
         {
           "$ref": "#/$defs/_InputMapping3DTo2DOutput"
@@ -3324,7 +4809,7 @@
           "$ref": "#/$defs/_AxisMapping2DItem"
         }
       ],
-      "title": "3차원 축 매핑 항목",
+      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
       "examples": [
         {
           "sensitivity": 0.3,
@@ -3332,43 +4817,85 @@
           "input": "axisXY"
         },
         {
-          "input": "axisUp",
-          "output": "rightTrigger"
+          "output": "rightTrigger",
+          "input": "axisUp"
         },
         {
           "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다."
+      "title": "3차원 축 매핑 항목"
     },
-    "_RelativeMouse1DOutputType": {
-      "description": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "상대 마우스 1차원 출력",
-      "type": "string",
-      "markdownDescription": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다."
+    "ActionType": {
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "description": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "제어 동작"
     },
-    "_InputMapping1D": {
+    "Layers": {
+      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+          "type": "object",
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          },
+          "additionalProperties": false
         },
         {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
+      ],
+      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "sticky": true,
+                  "type": "throttle",
+                  "axisDown": "leftTrigger",
+                  "axisUp": "rightTrigger"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "title": "터치 레이아웃 레이어"
     },
-    "ArcadeButton": {
-      "description": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
+    "DeadzoneRadial": {
+      "markdownDescription": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
       "anyOf": [
         {
+          "type": "boolean"
+        }
+      ],
+      "description": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "title": "방사형"
+    },
+    "ArcadeButton": {
+      "markdownDescription": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "action"
+          ],
           "properties": {
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            },
             "enabled": {
               "$ref": "#/$defs/ControlEnabled"
             },
@@ -3377,18 +4904,18 @@
             },
             "styles": {
               "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "action": {
+              "$ref": "#/$defs/ActionType"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "action"
-          ]
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
+      "description": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
       "examples": [
         {
           "action": "gamepadX",
@@ -3404,277 +4931,13 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ],
-      "markdownDescription": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다."
-    },
-    "Deadzone1D": {
-      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "1차원 데드존",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다."
-    },
-    "Layer": {
-      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "$ref": "#/$defs/LayerControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "터치 레이아웃 레이어",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "axisUp": "rightTrigger",
-                "type": "throttle",
-                "axisDown": "leftTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다."
-    },
-    "LayerControlWheel": {
-      "description": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            },
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "레이아웃 레이어 컨트롤 휠 터치",
-      "examples": [
-        {
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "markdownDescription": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다."
-    },
-    "_Accelerometer": {
-      "additionalProperties": false,
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "description": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
-          "title": "가속도계 제어 유형",
-          "type": "string",
-          "const": "accelerometer",
-          "markdownDescription": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다."
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
       ]
     },
-    "ButtonPulledStyle": {
-      "description": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+    "JoystickMovingStyle": {
+      "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "끌어온 컨트롤 스타일",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다."
-    },
-    "Scale": {
-      "description": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "type": "number",
-          "maximum": 2
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "규모",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "markdownDescription": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다."
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "description": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "아웃라인 스타일링 구성 요소",
-      "examples": [
-        {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "markdownDescription": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다."
-    },
-    "JoystickDefaultStyle": {
-      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-      "anyOf": [
-        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
@@ -3689,29 +4952,28 @@
               "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "제어 기본 스타일",
+      "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
       "examples": [
         {},
         {
           "knob": {
-            "background": {
+            "faceImage": {
               "type": "asset",
-              "value": "CustomKnobBackgroundImage"
+              "value": "CustomKnobFaceImage"
             },
             "stroke": {
               "type": "solid",
               "color": "#0099ffaa"
             },
-            "faceImage": {
+            "background": {
               "type": "asset",
-              "value": "CustomKnobFaceImage"
+              "value": "CustomKnobBackgroundImage"
             }
           },
           "background": {
@@ -3723,24 +4985,334 @@
           "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다."
+      "title": "제어 이동 스타일"
+    },
+    "DirectionalPadInteractionActivationType": {
+      "markdownDescription": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "title": "활성화 유형"
+    },
+    "_HexColor": {
+      "type": "string",
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_FaceImageAsset": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
+          "type": "string",
+          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
+          "title": "얼굴 이미지 자산 스타일링 구성 요소"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object",
+      "examples": [
+        {},
+        {
+          "myColor": "#ff00ffff",
+          "system_contentPrimary": "#ffffffff"
+        }
+      ],
+      "properties": {
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        }
+      },
+      "additionalProperties": false
     },
     "TurboActionInterval": {
-      "markdownDescription": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
-      "description": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
-      "exclusiveMinimum": 0,
-      "title": "간격",
       "examples": [
         500,
         1000
       ],
+      "title": "간격",
+      "description": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
+      "exclusiveMinimum": 0,
+      "markdownDescription": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
       "type": "number"
     },
+    "_ControlTypeJoystick": {
+      "const": "joystick",
+      "markdownDescription": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
+      "type": "string",
+      "description": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
+      "title": "조이스틱 제어 유형"
+    },
+    "JoystickDisabledStyle": {
+      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "컨트롤 비활성화 스타일"
+    },
+    "Opacity": {
+      "markdownDescription": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
+      "anyOf": [
+        {
+          "minimum": 0,
+          "maximum": 1,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "title": "불투명"
+    },
+    "_ControlTypeArcadeButtons": {
+      "const": "arcadeButtons",
+      "markdownDescription": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
+      "type": "string",
+      "description": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
+      "title": "아케이드 버튼 제어 유형"
+    },
+    "_Touchpad": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "axis": [
+            {
+              "output": "relativeMouse",
+              "input": "axisXY"
+            }
+          ],
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerUpperContent": {
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "title": "상위 계층 콘텐츠"
+    },
     "InputCurveRange": {
-      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
-      "deprecated": true,
-      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
-      "title": "[사용되지 않음] 입력 곡선 범위",
       "examples": [
         [
           0,
@@ -3762,1672 +5334,103 @@
           }
         ]
       ],
+      "title": "[사용되지 않음] 입력 곡선 범위",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
       "anyOf": [
         {
-          "maxItems": 2,
-          "minItems": 2,
           "items": {
             "anyOf": [
               {
                 "minimum": -1,
-                "type": "number",
-                "maximum": 1
+                "maximum": 1,
+                "type": "number"
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다."
+    },
+    "_ActionTypeBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
           "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayoutContent": {
-      "description": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "center": {
-              "$ref": "#/$defs/LayoutControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "레이아웃 콘텐츠",
       "examples": [
-        {},
+        "gamepadB",
         {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "input": "axisXY",
-                  "output": "leftJoystick"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "markdownDescription": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다."
-    },
-    "LayoutLowerContent": {
-      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "../../context.json#/state/jumpControllerMapping"
         },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "하위 레이아웃 콘텐츠",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다."
-    },
-    "_AxisMapping2DItem": {
-      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "2차원 축 매핑 항목",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisUp",
-          "output": "rightTrigger"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다."
-    },
-    "DeadzoneThreshold": {
-      "description": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "임계값",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "markdownDescription": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다."
-    },
-    "JoystickDisabledStyle": {
-      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 비활성화 스타일",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다."
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "RelativeInteraction": {
-      "description": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "상대적인",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "markdownDescription": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다."
-    },
-    "FaceImageIconValue": {
-      "description": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "얼굴 이미지 아이콘",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "markdownDescription": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다."
-    },
-    "LayoutUpperRightContent": {
-      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "오른쪽 상단 레이아웃 콘텐츠",
-      "examples": [
         [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다."
-    },
-    "_Throttle": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "sticky": true,
-          "axisUp": "rightTrigger",
-          "type": "throttle",
-          "axisDown": "leftTrigger"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
+          "gamepadA",
+          "leftTrigger"
+        ]
       ]
     },
-    "_FaceImageIcon": {
-      "properties": {
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
-          "title": "얼굴 이미지 아이콘 스타일링 구성 요소",
-          "type": "string",
-          "const": "icon",
-          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "_SystemColorAccentSecondary": {
-      "description": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
-      "title": "악센트 보조 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다."
-    },
-    "_ControllerAnalog2DOutputType": {
-      "description": "두 게임 패드 조이스틱 축 전체를 따라 값을 출력합니다.",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "게임패드 아날로그 조이스틱 출력",
-      "type": "string",
-      "markdownDescription": "두 게임 패드 조이스틱 축 전체를 따라 값을 출력합니다."
-    },
-    "_SystemColorContentPrimary": {
-      "description": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
-      "title": "콘텐츠 기본 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다."
-    },
-    "_DirectionalPad": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        }
-      },
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "Stroke": {
-      "description": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
-      "title": "획 스타일 지정 구성 요소",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다."
-    },
-    "ThrottleAxisStyle": {
-      "description": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+    "_ControllerAction": {
       "anyOf": [
         {
-          "properties": {
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "#/$defs/_ControllerButtonOutputType"
         },
         {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "스로틀 축 스타일링 구성 요소",
-      "examples": [
-        {
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        }
-      ],
-      "markdownDescription": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다."
-    },
-    "_SystemColorContrastPrimary": {
-      "description": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
-      "title": "대비 기본 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다."
-    },
-    "_FaceImageAsset": {
-      "properties": {
-        "type": {
-          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
-          "title": "얼굴 이미지 자산 스타일링 구성 요소",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_Blank": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
-          "title": "공백 제어 유형",
-          "type": "string",
-          "const": "blank",
-          "markdownDescription": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다."
-        }
-      },
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "_SystemColorGamepadActionColor": {
-      "description": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
-      "title": "게임패드 액션 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다."
-    },
-    "ThrottleStyles": {
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "idleUp": {
-              "description": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
-              "title": "유휴 스타일 제어",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다."
-            },
-            "disabled": {
-              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "title": "컨트롤 비활성화 스타일",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다."
-            },
-            "activatedUp": {
-              "description": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
-              "title": "컨트롤 활성화 업 스타일",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다."
-            },
-            "idle": {
-              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "title": "유휴 스타일 제어",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다."
-            },
-            "activated": {
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "title": "컨트롤 활성화 스타일",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
-            },
-            "activatedDown": {
-              "description": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
-              "title": "컨트롤 활성화 다운 스타일",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다."
-            },
-            "default": {
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "title": "제어 기본 스타일",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 스타일",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "axisDown": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다."
-    },
-    "LayoutSensorContent": {
-      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "센서 레이아웃 콘텐츠",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다."
-    },
-    "AxisCapColor": {
-      "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
-              "title": "축 캡 스타일링 구성 요소",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "축 캡 스타일링 구성 요소",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다."
-    },
-    "_StrokeBase": {
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "description": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
-              "type": "string",
-              "const": "solid",
-              "markdownDescription": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
         }
       ]
     },
-    "Background": {
-      "description": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+    "OuterWheelControlGroup": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_BackgroundColor"
+          "$ref": "#/$defs/Control"
         },
         {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "배경 스타일 구성 요소",
-      "markdownDescription": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다."
-    },
-    "_ControllerAnalog1DOutputType": {
-      "description": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "게임패드 아날로그 조이스틱 출력",
-      "type": "string",
-      "markdownDescription": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다."
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "Knob": {
-      "description": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "노브 스타일링 구성 요소",
-      "examples": [
-        {
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "markdownDescription": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다."
-    },
-    "DirectionalPadInteractionActivationType": {
-      "description": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "exclusive",
-            "allowNeighboring"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "활성화 유형",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "markdownDescription": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다."
-    },
-    "FaceImageIconLabel": {
-      "description": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "action",
-                "none"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "얼굴 이미지 아이콘 레이블 스타일링 구성 요소",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "markdownDescription": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다."
-    },
-    "SensorLayerControl": {
-      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ]
-        }
-      },
-      "title": "레이어 센서 제어",
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
+          "$ref": "#/$defs/ControlGroup"
         },
         {
           "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ]
-    },
-    "ButtonDisabledStyle": {
-      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 비활성화 스타일",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다."
-    },
-    "Layers": {
-      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "터치 레이아웃 레이어",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "axisUp": "rightTrigger",
-                  "type": "throttle",
-                  "axisDown": "leftTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다."
-    },
-    "_SystemColorContentSecondary": {
-      "description": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
-      "title": "콘텐츠 보조 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다."
-    },
-    "_LayoutAction": {
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "additionalProperties": false,
-      "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-      "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-      "required": [
-        "type",
-        "target"
-      ],
-      "title": "레이아웃 작업",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
-          "title": "레이아웃 작업",
-          "type": "string",
-          "const": "layer",
-          "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다."
-        }
-      },
-      "type": "object"
-    },
-    "InnerLayerControlWheel": {
-      "description": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "내부",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트가 컨트롤 휠의 내부 세그먼트에 그룹으로 배열되어 있습니다. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 균등하게 분할됩니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다."
-    },
-    "ArcadeButtonStyles": {
-      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
-              "title": "제어 기본 스타일",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다."
-            },
-            "idle": {
-              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-              "title": "유휴 스타일 제어",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다."
-            },
-            "disabled": {
-              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
-              "title": "컨트롤 비활성화 스타일",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다."
-            },
-            "activated": {
-              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
-              "title": "컨트롤 활성화 스타일",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "컨트롤 스타일",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          },
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다."
-    },
-    "LayoutLowerArrayContent": {
-      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "하위 레이아웃 배열 콘텐츠",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다."
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "LayerUpperContent": {
-      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "상위 계층 콘텐츠",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다."
-    },
-    "JoystickIdleStyle": {
-      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "유휴 스타일 제어",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다."
-    },
-    "DeadzoneDirectionalPad": {
-      "description": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
-      "anyOf": [
-        {
-          "exclusiveMinimum": 0,
-          "type": "number",
-          "exclusiveMaximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "방향 패드 데드존",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "markdownDescription": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다."
-    },
-    "Sensitivity": {
-      "description": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "민감도",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "markdownDescription": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다."
-    },
-    "_InputAxisZY": {
-      "description": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
-      "title": "Z 및 Y축 입력 매핑",
-      "type": "string",
-      "const": "axisZY",
-      "markdownDescription": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오."
-    },
-    "_Touchpad": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
-      "examples": [
-        {
-          "axis": [
-            {
-              "input": "axisXY",
-              "output": "relativeMouse"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "_SystemColorActionColor": {
-      "description": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
-      "title": "액션 시스템 색상 재정의",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다."
-    },
-    "LayoutUpperContent": {
-      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "상위 레이아웃 콘텐츠",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다."
-    },
-    "DeadzoneRadial": {
-      "description": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "title": "방사형",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "markdownDescription": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다."
     }
   },
-  "type": "object"
+  "description": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+  "properties": {
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "content"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "title": "터치 적응 번들 레이아웃 스키마",
+  "markdownDescription": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요."
 }

--- a/touch-adaptation-kit/schemas/ko-KR/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/ko-KR/takxconfig/v1/takxconfig.json
@@ -1,221 +1,221 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "LanguageItem": {
-      "markdownDescription": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다.",
-      "description": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다.",
-      "enum": [
-        "ar",
-        "ar-SA",
-        "cs",
-        "cs-CZ",
-        "da",
-        "da-DK",
-        "de",
-        "de-DE",
-        "el",
-        "el-GR",
-        "en",
-        "en-US",
-        "en-GB",
-        "es",
-        "es-ES",
-        "es-MX",
-        "fi",
-        "fi-FI",
-        "fil",
-        "fil-PH",
-        "fr",
-        "fr-FR",
-        "he",
-        "he-IL",
-        "hu",
-        "hu-HU",
-        "id",
-        "id-ID",
-        "it",
-        "it-IT",
-        "ja",
-        "ja-JP",
-        "ko",
-        "ko-KR",
-        "ms",
-        "ms-MY",
-        "nb",
-        "nb-NO",
-        "nl",
-        "nl-NL",
-        "pl",
-        "pl-PL",
-        "pt",
-        "pt-BR",
-        "pt-PT",
-        "ru",
-        "ru-RU",
-        "sk",
-        "sk-SK",
-        "sv",
-        "sv-SE",
-        "th",
-        "th-TH",
-        "tr",
-        "tr-TR",
-        "vi",
-        "vi-VN",
-        "zh",
-        "zh-CN",
-        "zh-TW"
-      ],
-      "title": "IETF 언어 태그"
-    }
-  },
-  "description": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
-  "properties": {
-    "versionName": {
-      "markdownDescription": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "type": "string",
-      "description": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "examples": [
-        "DLC 2"
-      ],
-      "title": "터치 적응 번들 버전 이름"
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "터치 적응 번들 구성 파일 스키마",
+    "description": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+    "markdownDescription": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+    "$defs": {
+        "LanguageItem": {
+            "title": "IETF 언어 태그",
+            "description": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다.",
+            "markdownDescription": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다.",
+            "enum": [
+                "ar",
+                "ar-SA",
+                "cs",
+                "cs-CZ",
+                "da",
+                "da-DK",
+                "de",
+                "de-DE",
+                "el",
+                "el-GR",
+                "en",
+                "en-US",
+                "en-GB",
+                "es",
+                "es-ES",
+                "es-MX",
+                "fi",
+                "fi-FI",
+                "fil",
+                "fil-PH",
+                "fr",
+                "fr-FR",
+                "he",
+                "he-IL",
+                "hu",
+                "hu-HU",
+                "id",
+                "id-ID",
+                "it",
+                "it-IT",
+                "ja",
+                "ja-JP",
+                "ko",
+                "ko-KR",
+                "ms",
+                "ms-MY",
+                "nb",
+                "nb-NO",
+                "nl",
+                "nl-NL",
+                "pl",
+                "pl-PL",
+                "pt",
+                "pt-BR",
+                "pt-PT",
+                "ru",
+                "ru-RU",
+                "sk",
+                "sk-SK",
+                "sv",
+                "sv-SE",
+                "th",
+                "th-TH",
+                "tr",
+                "tr-TR",
+                "vi",
+                "vi-VN",
+                "zh",
+                "zh-CN",
+                "zh-TW"
+            ]
+        }
     },
-    "layouts": {
-      "type": "object",
-      "markdownDescription": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
-      "properties": {
-        "default": {
-          "markdownDescription": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
-          "type": "string",
-          "description": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "title": "터치 적응 번들 기본 레이아웃"
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
         },
-        "path": {
-          "examples": [
-            "./layouts"
-          ],
-          "title": "터치 적응 번들 레이아웃 경로",
-          "format": "uri-reference",
-          "description": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "type": "string"
-        }
-      },
-      "description": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
-      "examples": [
-        {
-          "path": "./layouts"
+        "layouts": {
+            "title": "터치 적응 번들 레이아웃 구성",
+            "description": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
+            "markdownDescription": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
+            "examples": [
+                {
+                    "path": "./layouts"
+                },
+                {
+                    "path": "./layouts",
+                    "default": "cinematic"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "터치 적응 번들 레이아웃 경로",
+                    "description": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+                    "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+                    "examples": [
+                        "./layouts"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "default": {
+                    "title": "터치 적응 번들 기본 레이아웃",
+                    "description": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
+                    "markdownDescription": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
+                    "examples": [
+                        "cinematic",
+                        "menu",
+                        "firstPerson"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ]
         },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
+        "assets": {
+            "title": "터치 적응 번들 자산 구성",
+            "description": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
+            "markdownDescription": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
+            "examples": [
+                {
+                    "path": "./assets"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "터치 적응 번들 자산 경로",
+                    "description": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+                    "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+                    "examples": [
+                        "./assets"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "context": {
+            "title": "터치 적응 번들 컨텍스트 파일 구성",
+            "description": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
+            "markdownDescription": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
+            "examples": [
+                {
+                    "path": "./context.json"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "터치 적응 번들 컨텍스트 파일 경로",
+                    "description": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
+                    "markdownDescription": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
+                    "examples": [
+                        "./context.json"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "languages": {
+            "title": "터치 적응 번들 언어 구성",
+            "description": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
+            "markdownDescription": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
+            "examples": [
+                [],
+                [
+                    "en-US"
+                ],
+                [
+                    "en",
+                    "fr-FR"
+                ]
+            ],
+            "items": {
+                "$ref": "#/$defs/LanguageItem"
+            },
+            "type": "array"
+        },
+        "version": {
+            "title": "터치 적응 번들 버전",
+            "description": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+            "markdownDescription": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+            "examples": [
+                "1.0.0.0"
+            ],
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+        },
+        "versionName": {
+            "title": "터치 적응 번들 버전 이름",
+            "description": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+            "markdownDescription": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+            "examples": [
+                "DLC 2"
+            ],
+            "type": "string"
         }
-      ],
-      "title": "터치 적응 번들 레이아웃 구성",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
     },
-    "version": {
-      "examples": [
-        "1.0.0.0"
-      ],
-      "title": "터치 적응 번들 버전",
-      "description": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "markdownDescription": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "type": "string"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "type": "object",
-      "markdownDescription": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
-      "properties": {
-        "path": {
-          "examples": [
-            "./context.json"
-          ],
-          "title": "터치 적응 번들 컨텍스트 파일 경로",
-          "format": "uri-reference",
-          "description": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
-          "markdownDescription": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
-          "type": "string"
-        }
-      },
-      "description": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "title": "터치 적응 번들 컨텍스트 파일 구성",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    },
-    "languages": {
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "title": "터치 적응 번들 언어 구성",
-      "description": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "markdownDescription": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
-      "type": "array"
-    },
-    "assets": {
-      "type": "object",
-      "markdownDescription": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
-      "properties": {
-        "path": {
-          "examples": [
-            "./assets"
-          ],
-          "title": "터치 적응 번들 자산 경로",
-          "format": "uri-reference",
-          "description": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "type": "string"
-        }
-      },
-      "description": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "title": "터치 적응 번들 자산 구성",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
-  "title": "터치 적응 번들 구성 파일 스키마",
-  "markdownDescription": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요."
+    "additionalProperties": false,
+    "required": [
+      "layouts",
+      "version"
+    ]
 }

--- a/touch-adaptation-kit/schemas/ko-KR/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/ko-KR/takxconfig/v1/takxconfig.json
@@ -1,155 +1,9 @@
 {
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
-      "markdownDescription": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
-      "required": [
-        "path"
-      ],
-      "title": "터치 적응 번들 컨텍스트 파일 구성",
-      "properties": {
-        "path": {
-          "markdownDescription": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
-          "description": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
-          "title": "터치 적응 번들 컨텍스트 파일 경로",
-          "examples": [
-            "./context.json"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "versionName": {
-      "description": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "title": "터치 적응 번들 버전 이름",
-      "examples": [
-        "DLC 2"
-      ],
-      "type": "string",
-      "markdownDescription": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다."
-    },
-    "assets": {
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
-      "markdownDescription": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
-      "required": [
-        "path"
-      ],
-      "title": "터치 적응 번들 자산 구성",
-      "properties": {
-        "path": {
-          "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "description": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "title": "터치 적응 번들 자산 경로",
-          "examples": [
-            "./assets"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "languages": {
-      "markdownDescription": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "description": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
-      "title": "터치 적응 번들 언어 구성",
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "type": "array"
-    },
-    "version": {
-      "markdownDescription": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "description": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
-      "title": "터치 적응 번들 버전",
-      "examples": [
-        "1.0.0.0"
-      ],
-      "type": "string"
-    },
-    "layouts": {
-      "examples": [
-        {
-          "path": "./layouts"
-        },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
-      "markdownDescription": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
-      "required": [
-        "path"
-      ],
-      "title": "터치 적응 번들 레이아웃 구성",
-      "properties": {
-        "default": {
-          "description": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
-          "title": "터치 적응 번들 기본 레이아웃",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "type": "string",
-          "markdownDescription": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다."
-        },
-        "path": {
-          "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "description": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
-          "title": "터치 적응 번들 레이아웃 경로",
-          "examples": [
-            "./layouts"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    }
-  },
-  "title": "터치 적응 번들 구성 파일 스키마",
-  "description": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
-  "markdownDescription": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v4.0/takxconfig.json",
+  "type": "object",
   "$defs": {
     "LanguageItem": {
+      "markdownDescription": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다.",
       "description": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다.",
       "enum": [
         "ar",
@@ -213,9 +67,155 @@
         "zh-CN",
         "zh-TW"
       ],
-      "title": "IETF 언어 태그",
-      "markdownDescription": "중립 언어 외에도 번들이 지원하는 언어를 정의하는 단일 언어 태그입니다."
+      "title": "IETF 언어 태그"
     }
   },
-  "type": "object"
+  "description": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+  "properties": {
+    "versionName": {
+      "markdownDescription": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+      "type": "string",
+      "description": "이 속성은 이 버전의 터치 번들을 나타내는 설명 이름을 정의합니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+      "examples": [
+        "DLC 2"
+      ],
+      "title": "터치 적응 번들 버전 이름"
+    },
+    "layouts": {
+      "type": "object",
+      "markdownDescription": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
+      "properties": {
+        "default": {
+          "markdownDescription": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
+          "type": "string",
+          "description": "이 속성은 터치 번들의 시작 활성 레이아웃을 정의합니다. 기본 레이아웃을 지정하려면 파일 확장자 없이 레이아웃 파일의 이름을 사용하세요. 활성 레이아웃은 나중에 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient에 설명된 API 호출을 통해 변경될 수 있습니다. 생략하면 시작 레이아웃이 사용되지 않습니다.",
+          "examples": [
+            "cinematic",
+            "menu",
+            "firstPerson"
+          ],
+          "title": "터치 적응 번들 기본 레이아웃"
+        },
+        "path": {
+          "examples": [
+            "./layouts"
+          ],
+          "title": "터치 적응 번들 레이아웃 경로",
+          "format": "uri-reference",
+          "description": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+          "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 모든 레이아웃이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+          "type": "string"
+        }
+      },
+      "description": "이 속성은 디스크 레이아웃 파일의 위치 및 기본 레이아웃으로 사용해야 하는 레이아웃 파일과 같은 레이아웃 파일과 관련된 번들 속성을 정의합니다.",
+      "examples": [
+        {
+          "path": "./layouts"
+        },
+        {
+          "default": "cinematic",
+          "path": "./layouts"
+        }
+      ],
+      "title": "터치 적응 번들 레이아웃 구성",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "version": {
+      "examples": [
+        "1.0.0.0"
+      ],
+      "title": "터치 적응 번들 버전",
+      "description": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
+      "markdownDescription": "이 속성은 터치 번들의 버전 번호를 정의합니다. 버전은 주, 부, 빌드 및 수정 구성 요소로 구성되지만 이러한 특정 의미 체계는 터치 번들 런타임에 의해 해석되지 않습니다. 대신 런타임이 로드할 수 있는 가장 높은 버전의 번들이 사용됩니다. 번들의 로드 기능은 번들 내에서 사용되는 최대 레이아웃 스키마 버전에 따라 결정됩니다. 이 속성은 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion에 설명된 api를 통해 쿼리할 수 있습니다.",
+      "type": "string"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "context": {
+      "type": "object",
+      "markdownDescription": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
+      "properties": {
+        "path": {
+          "examples": [
+            "./context.json"
+          ],
+          "title": "터치 적응 번들 컨텍스트 파일 경로",
+          "format": "uri-reference",
+          "description": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
+          "markdownDescription": "이 속성은 이 파일에서 컨텍스트 파일로의 상대 경로를 정의합니다.",
+          "type": "string"
+        }
+      },
+      "description": "이 속성은 파일이 있는 디스크 위치와 같은 컨텍스트 파일과 관련된 번들 속성을 정의합니다. 생략하면 번들에 컨텍스트 파일이 포함되지 않습니다.",
+      "examples": [
+        {
+          "path": "./context.json"
+        }
+      ],
+      "title": "터치 적응 번들 컨텍스트 파일 구성",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "languages": {
+      "examples": [
+        [],
+        [
+          "en-US"
+        ],
+        [
+          "en",
+          "fr-FR"
+        ]
+      ],
+      "title": "터치 적응 번들 언어 구성",
+      "description": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
+      "items": {
+        "$ref": "#/$defs/LanguageItem"
+      },
+      "markdownDescription": "이 속성은 번들에 대해 지원되는 언어와 관련된 번들 속성을 정의합니다. 생략하면 번들은 레이아웃 및 자산 폴더의 디렉터리 구조에서 유추된 모든 언어를 지원합니다. 중립 언어는 이 속성 값에 관계없이 항상 번들에 포함됩니다.",
+      "type": "array"
+    },
+    "assets": {
+      "type": "object",
+      "markdownDescription": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
+      "properties": {
+        "path": {
+          "examples": [
+            "./assets"
+          ],
+          "title": "터치 적응 번들 자산 경로",
+          "format": "uri-reference",
+          "description": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+          "markdownDescription": "이 속성은 이 파일에서 이 번들에 대한 이미지 파일과 같은 모든 자산이 포함된 디렉터리에 대한 상대 경로를 정의합니다.",
+          "type": "string"
+        }
+      },
+      "description": "이 속성은 디스크 자산 파일의 위치와 같은 자산 파일과 관련된 번들 속성을 정의합니다.",
+      "examples": [
+        {
+          "path": "./assets"
+        }
+      ],
+      "title": "터치 적응 번들 자산 구성",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "layouts",
+    "version"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+  "title": "터치 적응 번들 구성 파일 스키마",
+  "markdownDescription": "터치 적응 번들 구성 파일(예: `takxconfig.json`)은 번들에 대한 프로젝트 파일 역할을 하는 파일이며 모든 번들 메타데이터 및 속성을 재사용 가능하고 일관된 방식으로 정의합니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요."
 }

--- a/touch-adaptation-kit/schemas/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/layout/v4.0/layout.json
@@ -1,32 +1,2268 @@
 {
-  "required": [
-    "content"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "styles": {
-      "$ref": "#/$defs/LayoutStyles"
-    },
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "content": {
-      "$ref": "#/$defs/LayoutContent"
-    }
-  },
-  "title": "Touch Adaptation Bundle Layout Schema",
-  "description": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
-  "markdownDescription": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "type": "object",
   "$defs": {
+    "_StrokeBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "solid",
+              "markdownDescription": "This styling component is used to specify a solid stroke with customizable color and opacity.",
+              "type": "string",
+              "description": "This styling component is used to specify a solid stroke with customizable color and opacity."
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "color": "#0099ff",
+          "type": "solid",
+          "opacity": 1
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "markdownDescription": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
+      "description": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Content Primary System Color Override"
+    },
+    "_ControlTypeDirectionalPad": {
+      "const": "directionalPad",
+      "markdownDescription": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
+      "type": "string",
+      "description": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
+      "title": "Directional Pad Control Type"
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JoystickDirectionIndicator": {
+      "markdownDescription": "The visual styling for an indicator of the direction of the interaction",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "Property used to specify that the direction indicator is of color type whose value can be customized.",
+              "type": "string",
+              "description": "Property used to specify that the direction indicator is of color type whose value can be customized."
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The visual styling for an indicator of the direction of the interaction",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "title": "Direction Indicator Styling Component"
+    },
+    "LayerSensorContent": {
+      "markdownDescription": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "title": "Sensors Layer Content"
+    },
+    "Background": {
+      "markdownDescription": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+      "title": "Background Styling Component"
+    },
+    "_Accelerometer": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "const": "accelerometer",
+          "markdownDescription": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
+          "type": "string",
+          "description": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
+          "title": "Accelerometer Control Type"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "SensorControl": {
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "Sensor Control",
+      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_Null": {
+      "markdownDescription": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
+      "type": "null",
+      "description": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
+      "examples": [
+        null
+      ],
+      "title": "Null"
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "markdownDescription": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
+      "type": "string",
+      "description": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "title": "Gamepad Analog Joystick Output"
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "PullIndicator": {
+      "markdownDescription": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "title": "Pull Indicator Styling Component"
+    },
+    "_SystemColorAccentPrimary": {
+      "markdownDescription": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
+      "description": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Accent Primary System Color Override"
+    },
+    "Scale": {
+      "markdownDescription": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
+      "anyOf": [
+        {
+          "minimum": 0.5,
+          "maximum": 2,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "title": "Scale"
+    },
+    "JoystickIdleStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "Control Idle Style"
+    },
+    "_AxisMapping2DItem": {
+      "markdownDescription": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "rightTrigger",
+          "input": "axisUp"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "Two Dimensional Axis Mapping Item"
+    },
+    "TouchpadStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "Control Idle Style"
+    },
+    "_LayoutStyles": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "colors": {
+            "highContrast": {
+              "myColor": "#00ff00ff",
+              "system_contentPrimary": "#ffffffff"
+            },
+            "default": {
+              "myColor": "#ff0000ff",
+              "system_contentPrimary": "#ffffffff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "markdownDescription": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "title": "Directional Pad Deadzone"
+    },
+    "Sticky": {
+      "markdownDescription": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "title": "Sticky"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayoutContent": {
+      "markdownDescription": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "output": "leftJoystick",
+                  "input": "axisXY"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Layout Content"
+    },
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "format": "uri-reference",
+          "markdownDescription": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
+          "type": "string",
+          "description": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerControlWheel": {
+      "markdownDescription": "A set of layer controls organized in a circle or wheel shape.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A set of layer controls organized in a circle or wheel shape.",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "title": "Touch Layout Layer Control Wheel"
+    },
+    "_SystemColorAccentSecondary": {
+      "markdownDescription": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
+      "description": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Accent Secondary System Color Override"
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "Control Toggled Style"
+    },
+    "LayoutLowerArrayContent": {
+      "markdownDescription": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "title": "Lower Layout Array Content"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "markdownDescription": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "Two Dimensional Axis Mapping"
+    },
+    "ThrottleAxisOutput": {
+      "markdownDescription": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "title": "Throttle Axis"
+    },
+    "ColorPaletteDefaultVariant": {
+      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "description": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "Default Colors"
+    },
+    "Deadzone1D": {
+      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "One Dimensional Deadzone"
+    },
+    "JoystickOutlineWithIndicator": {
+      "markdownDescription": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "title": "Outline Styling Component"
+    },
+    "_ControllerButtonOutputType": {
+      "markdownDescription": "Outputs a gamepad button press.",
+      "type": "string",
+      "description": "Outputs a gamepad button press.",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "title": "Gamepad Button Output"
+    },
+    "ButtonActivatedStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "Control Activated Style"
+    },
+    "JoystickStyles": {
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "title": "Control Styles"
+    },
+    "ButtonDisabledStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "Control Disabled Style"
+    },
+    "LayoutActionTarget": {
+      "markdownDescription": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "title": "Layout Action Target"
+    },
+    "_ControlTypeButton": {
+      "const": "button",
+      "markdownDescription": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
+      "type": "string",
+      "description": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
+      "title": "Button Control Type"
+    },
+    "_ControllerAnalog1DOutputType": {
+      "markdownDescription": "Outputs values along the entirety of the specified gamepad joystick axis.",
+      "type": "string",
+      "description": "Outputs values along the entirety of the specified gamepad joystick axis.",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "title": "Gamepad Analog Joystick Output"
+    },
+    "_LayoutAction": {
+      "type": "object",
+      "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "const": "layer",
+          "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+          "type": "string",
+          "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+          "title": "Layout Action"
+        }
+      },
+      "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "title": "Layout Action",
+      "required": [
+        "type",
+        "target"
+      ],
+      "additionalProperties": false
+    },
+    "InnerLayoutControlWheel": {
+      "markdownDescription": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "output": "leftJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "title": "Inner"
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_ControllerTriggerOutputType": {
+      "markdownDescription": "Outputs values that map to the specified gamepad trigger.",
+      "type": "string",
+      "description": "Outputs values that map to the specified gamepad trigger.",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "title": "Gamepad Analog Trigger Output"
+    },
+    "DirectionalPadStyles": {
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "Control Idle Style"
+            },
+            "disabled": {
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "Control Activated Style"
+            },
+            "activated": {
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "Control Activated Style"
+            },
+            "default": {
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "Control Default Style"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "gradient": {
+              "color": "#0099ffaa"
+            },
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "title": "Control Styles"
+    },
+    "Indicator": {
+      "markdownDescription": "The visual styling for the stroke used to indicate the current value or placement of the control.",
+      "description": "The visual styling for the stroke used to indicate the current value or placement of the control.",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "Indicator Styling Component"
+    },
+    "Stroke": {
+      "markdownDescription": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
+      "description": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "Stroke Styling Component"
+    },
+    "Gradient": {
+      "markdownDescription": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "title": "Gradient"
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "markdownDescription": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "title": "Gamepad Action"
+    },
+    "_DirectionalPad": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_TurboAction": {
+      "title": "Turbo Action",
+      "properties": {
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "const": "turbo",
+          "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
+          "type": "string",
+          "description": "Action that triggers on and off based on an interval instead of continuously.",
+          "title": "Turbo Action"
+        },
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        }
+      },
+      "description": "Action that triggers on and off based on an interval instead of continuously.",
+      "type": "object",
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
+      "additionalProperties": false
+    },
+    "ControlGroup": {
+      "markdownDescription": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "title": "Touch Layout Control Group"
+    },
+    "_SystemColorContrastPrimary": {
+      "markdownDescription": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
+      "description": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Contrast Primary System Color Override"
+    },
+    "ControlGroupItem": {
+      "markdownDescription": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+      "title": "Touch Layout Control Group Item"
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionThreshold": {
+      "markdownDescription": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "title": "Action Threshold"
+    },
+    "ArcadeButtonStyles": {
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "Control Idle Style"
+            },
+            "disabled": {
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "Control Disabled Style"
+            },
+            "activated": {
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "Control Activated Style"
+            },
+            "default": {
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "Control Default Style"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "activated": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            }
+          },
+          "default": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "title": "Control Styles"
+    },
+    "_BackgroundAsset": {
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "A custom asset used to style the background.",
+          "type": "string",
+          "description": "A custom asset used to style the background."
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_FaceImageIcon": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        "type": {
+          "const": "icon",
+          "markdownDescription": "A built-in icon used as the foreground graphic for the control component.",
+          "type": "string",
+          "description": "A built-in icon used as the foreground graphic for the control component.",
+          "title": "Face Image Icon Styling Component"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "markdownDescription": "This property is used to select which built-in icon to use for this component.",
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property is used to select which built-in icon to use for this component.",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "title": "Face Image Icon"
+    },
+    "Toggle": {
+      "markdownDescription": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "title": "Toggle"
+    },
+    "ArcadeButtonStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ]
+    },
+    "_ControlTypeTouchpad": {
+      "const": "touchpad",
+      "markdownDescription": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
+      "type": "string",
+      "description": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
+      "title": "Touchpad Control Type"
+    },
+    "ThrottleStyles": {
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Default Style"
+            },
+            "idleUp": {
+              "markdownDescription": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
+              "description": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Idle Up Style"
+            },
+            "activatedDown": {
+              "markdownDescription": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
+              "description": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Activated Down Style"
+            },
+            "disabled": {
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Disabled Style"
+            },
+            "activatedUp": {
+              "markdownDescription": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
+              "description": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Activated Up Style"
+            },
+            "idle": {
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Idle Style"
+            },
+            "activated": {
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "Control Activated Style"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "axisDown": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "title": "Control Styles"
+    },
+    "SensorLayerControl": {
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "Layer Sensor Control",
+      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_SystemColorActionColor": {
+      "markdownDescription": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
+      "description": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Action System Color Override"
+    },
+    "LayoutSensorContent": {
+      "markdownDescription": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "title": "Sensors Layout Content"
+    },
+    "LayoutColors": {
+      "markdownDescription": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            },
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "examples": [
+        {},
+        {
+          "highContrast": {
+            "myColor": "#00ff00ff",
+            "system_contentPrimary": "#ffffffff"
+          },
+          "default": {
+            "myColor": "#ff0000ff",
+            "system_contentPrimary": "#ffffffff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "title": "Colors"
+    },
+    "LayoutUpperContent": {
+      "markdownDescription": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "title": "Upper Layout Content"
+    },
+    "_Color": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ]
+    },
     "DirectionalPadDefaultStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
       "examples": [
         {},
         {
@@ -42,39 +2278,855 @@
         {
           "$ref": "#/definitions/commonDPadStyle"
         }
-      ],
+      ]
+    },
+    "RelativeInteraction": {
+      "markdownDescription": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "type": "boolean"
         },
         {
           "$ref": "#/$defs/Reference"
         }
+      ],
+      "description": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "title": "Relative"
+    },
+    "ButtonPulledStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "Control Pulled Style"
+    },
+    "InputCurveType": {
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "title": "[DEPRECATED] Input Response Curve Type",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle."
+    },
+    "ThrottleAxisStyle": {
+      "markdownDescription": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+      "examples": [
+        {
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          },
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        }
+      ],
+      "title": "Throttle Axis Styling Component"
+    },
+    "ButtonDefaultStyle": {
+      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "Control Default Style"
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FillColor": {
+      "markdownDescription": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "description": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "$ref": "#/$defs/_Color",
+      "title": "Fill"
+    },
+    "PullIndicatorBackground": {
+      "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "title": "Background Styling Component"
+    },
+    "_Button": {
+      "type": "object",
+      "required": [
+        "type",
+        "action"
+      ],
+      "examples": [
+        {
+          "type": "button",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          },
+          "action": "gamepadA"
+        }
+      ],
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DirectionalPadInteraction": {
+      "markdownDescription": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "title": "Interaction"
+    },
+    "ButtonStyles": {
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "title": "Control Styles"
+    },
+    "_CustomColorPaletteColor": {
+      "markdownDescription": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "description": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Custom Layout Color"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "markdownDescription": "The normalized, input value needed in order to produce output values.",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The normalized, input value needed in order to produce output values.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "title": "Threshold"
+    },
+    "_SystemColorContrastSecondary": {
+      "markdownDescription": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
+      "description": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Contrast Secondary System Color Override"
+    },
+    "_SystemColorGamepadActionColor": {
+      "markdownDescription": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
+      "description": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Gamepad Action System Color Override"
+    },
+    "AssetReference": {
+      "markdownDescription": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "title": "Asset Reference Styling Component"
+    },
+    "FaceImage": {
+      "markdownDescription": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "title": "Face Image Styling Component"
+    },
+    "_ControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ],
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      }
+    },
+    "JoystickActivatedStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "Control Activated Style"
+    },
+    "LayoutLowerContent": {
+      "markdownDescription": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "title": "Lower Layout Content"
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ControlVisibility": {
+      "markdownDescription": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "Visible"
+    },
+    "LayerLowerArrayContent": {
+      "markdownDescription": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "title": "Lower Layer Array Content"
+    },
+    "OuterLayoutControlWheel": {
+      "markdownDescription": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "title": "Outer"
+    },
+    "ControlEnabled": {
+      "markdownDescription": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "Enabled"
+    },
+    "ExpandInteraction": {
+      "markdownDescription": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "title": "Expand"
+    },
+    "Deadzone2D": {
+      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            },
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
+      "examples": [
+        {
+          "threshold": 0,
+          "radial": true
+        },
+        {
+          "threshold": 0.1,
+          "radial": false
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "Two Dimensional Deadzone"
+    },
+    "_ColorPaletteColor": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ]
+    },
+    "_InputAxisZY": {
+      "const": "axisZY",
+      "markdownDescription": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "type": "string",
+      "description": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "title": "Z and Y Axis Input Mapping"
+    },
+    "DirectionalPadIdleStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "gradient": {
+            "color": "#0099ffaa"
+          },
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
       ]
     },
     "Definitions": {
-      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "additionalProperties": false,
-      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "title": "Definitions",
       "examples": [
         {},
         {
@@ -93,95 +3145,184 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "Definitions",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/LayoutDefinableType"
         }
       },
-      "type": "object"
+      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "type": "object",
+      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "additionalProperties": false
     },
-    "_InputAxisXY": {
-      "description": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
-      "title": "X and Y Axis Input Mapping",
+    "_SystemColorContentSecondary": {
+      "markdownDescription": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
+      "description": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "Content Secondary System Color Override"
+    },
+    "Color": {
+      "markdownDescription": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "description": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "$ref": "#/$defs/_Color",
+      "title": "Color"
+    },
+    "_RelativeMouse1DOutputType": {
+      "markdownDescription": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
       "type": "string",
-      "const": "axisXY",
-      "markdownDescription": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping."
-    },
-    "LayerControlGroupItem": {
-      "description": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+      "description": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "title": "Touch Layout Layer Control Group Item",
+      "title": "Relative Mouse One Dimensional Output"
+    },
+    "_ArcadeButtons": {
+      "type": "object",
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
       "examples": [
         {
-          "$ref": "#/definitions/commonLayerButtonControl"
+          "type": "arcadeButtons",
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          }
         }
       ],
-      "markdownDescription": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath."
+      "properties": {
+        "specialPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Special Punch Button"
+        },
+        "heavyPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Heavy Kick Button"
+        },
+        "lightPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Light Punch Button"
+        },
+        "lightKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Light Kick Button"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        },
+        "mediumKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Medium Kick Button"
+        },
+        "specialKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Special Kick Button"
+        },
+        "heavyKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Heavy Kick Button"
+        },
+        "mediumPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "Medium Punch Button"
+        }
+      },
+      "additionalProperties": false
     },
-    "Indicator": {
-      "description": "The visual styling for the stroke used to indicate the current value or placement of the control.",
-      "title": "Indicator Styling Component",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "The visual styling for the stroke used to indicate the current value or placement of the control."
-    },
-    "FaceImage": {
-      "description": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+    "OuterLayerControlWheel": {
+      "markdownDescription": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Face Image Styling Component",
+      "description": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
       "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
         {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
+          "$ref": "#/definitions/commonLayerOuterWheel"
         }
       ],
-      "markdownDescription": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout."
+      "title": "Outer"
     },
-    "ControlGroupItem": {
-      "description": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+    "_InputMapping3DTo2DOutput": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControlBase"
+          "$ref": "#/$defs/_InputMappingXY"
         },
         {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_InputMappingZY"
         }
-      ],
-      "title": "Touch Layout Control Group Item",
-      "markdownDescription": "A single item in the control group. Use `null` to skip a control in the arrangement."
+      ]
+    },
+    "_ControlTypeThrottle": {
+      "const": "throttle",
+      "markdownDescription": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
+      "type": "string",
+      "description": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
+      "title": "Throttle Control Type"
     },
     "LayoutOrientation": {
-      "markdownDescription": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
-      "deprecated": true,
+      "title": "[DEPRECATED] Layout Orientation",
+      "description": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
       "enum": [
         "landscape-left",
         "landscape-right",
@@ -189,202 +3330,291 @@
         "portrait-up",
         "portrait"
       ],
-      "description": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
-      "title": "[DEPRECATED] Layout Orientation",
+      "deprecated": true,
+      "markdownDescription": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
       "type": "string"
     },
-    "PullIndicator": {
-      "description": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
             }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          ]
         },
-        {
-          "$ref": "#/$defs/Reference"
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
         }
-      ],
-      "title": "Pull Indicator Styling Component",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "markdownDescription": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control."
+      },
+      "additionalProperties": false
     },
-    "_ActionTypeBase": {
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          }
-        }
-      ]
-    },
-    "_CustomColorPaletteColor": {
-      "description": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "title": "Custom Layout Color",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes."
-    },
-    "ColorPaletteHighContrastVariant": {
-      "description": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "title": "High Contrast Colors",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes."
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "description": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "Gamepad Analog Joystick Output",
+    "_InputAxisXY": {
+      "const": "axisXY",
+      "markdownDescription": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
       "type": "string",
-      "markdownDescription": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used."
+      "description": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "title": "X and Y Axis Input Mapping"
     },
-    "JoystickStyles": {
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+    "PullActionType": {
+      "markdownDescription": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "description": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "Control Pull Action"
+    },
+    "Knob": {
+      "markdownDescription": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
             },
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
             },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
+            "background": {
+              "$ref": "#/$defs/Background"
             },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Control Styles",
+      "description": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
       "examples": [
-        {},
         {
-          "default": {
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyles"
+          "$ref": "#/definitions/commonControlKnobStyling"
         }
       ],
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state."
+      "title": "Knob Styling Component"
     },
-    "_InputMappingZY": {
+    "Control": {
+      "markdownDescription": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+          "$ref": "#/$defs/_ControlBase"
         },
         {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
-    },
-    "LayerControlGroup": {
+      ],
+      "description": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
       "examples": [
-        [],
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "title": "Touch Layout Control"
+    },
+    "LayerUpperRightContent": {
+      "markdownDescription": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
         [
-          null,
           {
             "type": "blank"
           },
-          null
-        ]
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
       ],
-      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "minItems": 1,
-      "title": "Touch Layout Layer Control Group",
-      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      },
-      "maxItems": 4
+      "title": "Upper Layer Right Content"
     },
-    "ThrottleAxisOutput": {
-      "description": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+    "AxisCapColor": {
+      "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+              "type": "string",
+              "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+              "title": "Axis Cap Styling Component"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Throttle Axis",
+      "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
       "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
         {
-          "$ref": "#/definitions/commonThrottleAxis"
+          "type": "color",
+          "value": "#0099ffaa"
         }
       ],
-      "markdownDescription": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output."
+      "title": "Axis Cap Styling Component"
+    },
+    "_Throttle": {
+      "type": "object",
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "examples": [
+        {
+          "sticky": true,
+          "type": "throttle",
+          "axisDown": "leftTrigger",
+          "axisUp": "rightTrigger"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_Blank": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "properties": {
+        "type": {
+          "const": "blank",
+          "markdownDescription": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
+          "type": "string",
+          "description": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
+          "title": "Blank Control Type"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RenderAsButton": {
+      "markdownDescription": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "title": "Render As Button"
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
     },
     "_InputMappingXYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
       "properties": {
         "sensitivity": {
           "$ref": "#/$defs/Sensitivity"
@@ -396,374 +3626,444 @@
           "$ref": "#/$defs/_InputAxisXY"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": false
+    },
+    "ColorPaletteHighContrastVariant": {
+      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "description": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "High Contrast Colors"
+    },
+    "LayoutStyles": {
+      "markdownDescription": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "description": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "$ref": "#/$defs/_LayoutStyles",
+      "title": "Layout Styles"
+    },
+    "LayerControlGroup": {
+      "type": "array",
+      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "minItems": 1,
+      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "maxItems": 4,
+      "title": "Touch Layout Layer Control Group",
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      }
+    },
+    "_BackgroundColor": {
       "type": "object",
       "required": [
-        "input",
-        "output"
-      ]
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "type": {
+          "const": "color",
+          "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+          "type": "string",
+          "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized."
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
     },
     "_Gyroscope": {
-      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "output": "rightJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
       "properties": {
         "axis": {
           "$ref": "#/$defs/AxisMapping3D"
         },
         "type": {
-          "description": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
-          "title": "Gyroscope Control Type",
-          "type": "string",
           "const": "gyroscope",
-          "markdownDescription": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game."
+          "markdownDescription": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
+          "type": "string",
+          "description": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
+          "title": "Gyroscope Control Type"
         },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         }
       },
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "input": "axisXY",
-            "output": "rightJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
+      "additionalProperties": false
     },
-    "LayerLowerArrayContent": {
-      "description": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+    "FaceImageIconLabel": {
+      "markdownDescription": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
       "anyOf": [
         {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Lower Layer Array Content",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one."
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "_SystemColorContrastSecondary": {
-      "description": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
-      "title": "Contrast Secondary System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes."
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "description": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Gamepad Action",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "markdownDescription": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state."
-    },
-    "_Color": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ExpandInteraction": {
-      "description": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Expand",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "markdownDescription": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used."
-    },
-    "ControlEnabled": {
-      "description": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Enabled",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "markdownDescription": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance."
-    },
-    "_ControlTypeButton": {
-      "description": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
-      "title": "Button Control Type",
-      "type": "string",
-      "const": "button",
-      "markdownDescription": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting."
-    },
-    "PullIndicatorBackground": {
-      "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Background Styling Component",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized."
-    },
-    "PullActionType": {
-      "description": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
-      "title": "Control Pull Action",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout."
-    },
-    "ControlGroup": {
-      "markdownDescription": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
-      "items": {
-        "$ref": "#/$defs/ControlGroupItem"
-      },
-      "description": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
-      "title": "Touch Layout Control Group",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
           },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerSensorContent": {
-      "description": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Sensors Layer Content",
+      "description": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
       "examples": [
-        [
-          {
-            "type": "blank"
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "title": "Face Image Icon Label Styling Component"
+    },
+    "TouchpadStyles": {
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "Control Idle Style"
+            },
+            "disabled": {
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "Control Disabled Style"
+            },
+            "activated": {
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "Control Activated Style"
+            },
+            "moving": {
+              "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+              "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "Control Moving Style"
+            },
+            "default": {
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "Control Default Style"
+            }
           },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
             }
           }
-        ],
+        },
         {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
+          "$ref": "#/definitions/commonTouchpadControlStyles"
         }
       ],
-      "markdownDescription": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one."
+      "title": "Control Styles"
     },
-    "ButtonActivatedStyle": {
-      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+    "Layer": {
+      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
       "anyOf": [
         {
+          "type": "object",
+          "properties": {
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "sticky": true,
+                "type": "throttle",
+                "axisDown": "leftTrigger",
+                "axisUp": "rightTrigger"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "title": "Touch Layout Layers"
+    },
+    "LayerControlGroupItem": {
+      "markdownDescription": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "title": "Touch Layout Layer Control Group Item"
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "markdownDescription": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "title": "Upper Right Layout Content"
+    },
+    "JoystickDefaultStyle": {
+      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
             },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
             "opacity": {
               "$ref": "#/$defs/Opacity"
             },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Control Activated Style",
+      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
       "examples": [
         {},
         {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonButtonStyle"
+          "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
+      "title": "Control Default Style"
     },
-    "_InputMapping1DToGamepad1DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
+    "_ControllerAnalog2DOutputType": {
+      "markdownDescription": "Outputs values along the entirety of both gamepad joystick axes.",
+      "type": "string",
+      "description": "Outputs values along the entirety of both gamepad joystick axes.",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "title": "Gamepad Analog Joystick Output"
+    },
+    "LayerLowerContent": {
+      "markdownDescription": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
         },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
+        {
+          "$ref": "#/$defs/Reference"
         }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
+      ],
+      "description": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "title": "Lower Layer Content"
     },
     "LayoutDefinableType": {
-      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -1078,731 +4378,42 @@
           "$ref": "#/$defs/TouchpadStyles"
         }
       ],
-      "title": "Definable Types",
-      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information"
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_TurboAction": {
-      "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
-      "description": "Action that triggers on and off based on an interval instead of continuously.",
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        },
-        "type": {
-          "description": "Action that triggers on and off based on an interval instead of continuously.",
-          "title": "Turbo Action",
-          "type": "string",
-          "const": "turbo",
-          "markdownDescription": "Action that triggers on and off based on an interval instead of continuously."
-        },
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        }
-      },
-      "title": "Turbo Action",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "type": "object"
-    },
-    "_ArcadeButtons": {
-      "additionalProperties": false,
-      "properties": {
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Medium Punch Button"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Heavy Kick Button"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Heavy Kick Button"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Light Kick Button"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Special Kick Button"
-        },
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Special Punch Button"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Light Punch Button"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Medium Kick Button"
-        }
-      },
-      "examples": [
-        {
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "type": "arcadeButtons",
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ]
-    },
-    "Opacity": {
-      "description": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "type": "number",
-          "maximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Opacity",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "markdownDescription": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque."
-    },
-    "LayoutColors": {
-      "description": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            },
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Colors",
-      "examples": [
-        {},
-        {
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "markdownDescription": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes."
-    },
-    "_ControllerTriggerOutputType": {
-      "description": "Outputs values that map to the specified gamepad trigger.",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "Gamepad Analog Trigger Output",
-      "type": "string",
-      "markdownDescription": "Outputs values that map to the specified gamepad trigger."
-    },
-    "ButtonDefaultStyle": {
-      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Default Style",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled."
-    },
-    "_ControlTypeDirectionalPad": {
-      "description": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
-      "title": "Directional Pad Control Type",
-      "type": "string",
-      "const": "directionalPad",
-      "markdownDescription": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property."
-    },
-    "_ControlTypeTouchpad": {
-      "description": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
-      "title": "Touchpad Control Type",
-      "type": "string",
-      "const": "touchpad",
-      "markdownDescription": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping."
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "DirectionalPadInteraction": {
-      "description": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
-      "anyOf": [
-        {
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Interaction",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "markdownDescription": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information."
-    },
-    "_ControllerAction": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        }
-      ]
-    },
-    "LayerControl": {
-      "description": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Touch Layout Layer Control",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "markdownDescription": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one."
-    },
-    "AxisMapping3D": {
-      "description": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Three Dimensional Axis Mapping",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player."
-    },
-    "ActionType": {
-      "description": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
-      "title": "Control Action",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout."
-    },
-    "InputCurveType": {
-      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
-      "deprecated": true,
-      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
-      "title": "[DEPRECATED] Input Response Curve Type",
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ColorPaletteColor": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "TouchpadStyles": {
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "title": "Control Default Style",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled."
-            },
-            "idle": {
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "title": "Control Idle Style",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting."
-            },
-            "disabled": {
-              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "title": "Control Disabled Style",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled."
-            },
-            "activated": {
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "title": "Control Activated Style",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
-            },
-            "moving": {
-              "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
-              "title": "Control Moving Style",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Styles",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state."
-    },
-    "ButtonIdleStyle": {
-      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Idle Style",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with."
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "additionalProperties": false,
-      "properties": {
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "examples": [
-        {},
-        {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "type": "object",
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      }
-    },
-    "Control": {
-      "description": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Touch Layout Control",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "markdownDescription": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose."
-    },
-    "_ControllerButtonOutputType": {
-      "description": "Outputs a gamepad button press.",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "Gamepad Button Output",
-      "type": "string",
-      "markdownDescription": "Outputs a gamepad button press."
-    },
-    "ButtonToggledStyle": {
-      "description": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Toggled Style",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled."
-    },
-    "_RelativeMouse2DOutputType": {
-      "description": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
-      "title": "Relative Mouse Two Dimensional Output",
-      "type": "string",
-      "const": "relativeMouse",
-      "markdownDescription": "This output type takes two dimensional control inputs and translates them to relative mouse movements."
-    },
-    "_ControlTypeArcadeButtons": {
-      "description": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
-      "title": "Arcade Buttons Control Type",
-      "type": "string",
-      "const": "arcadeButtons",
-      "markdownDescription": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos."
+      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "title": "Definable Types"
     },
     "LayoutControlWheel": {
-      "description": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
+      "markdownDescription": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            },
             "inner": {
               "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Touch Layout Control Wheel",
+      "description": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
       "examples": [
         {},
         {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "output": "leftJoystick",
+                "input": "axisXY"
+              }
+            }
+          ],
           "outer": [
             null,
             [
@@ -1815,818 +4426,148 @@
               "type": "button",
               "action": "gamepadY"
             }
-          ],
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "input": "axisXY",
-                "output": "leftJoystick"
-              }
-            }
           ]
         },
         {
           "$ref": "#/definitions/commonControlWheel"
         }
       ],
-      "markdownDescription": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls."
+      "title": "Touch Layout Control Wheel"
     },
-    "Reference": {
-      "additionalProperties": false,
-      "properties": {
-        "$ref": {
-          "description": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
-          "exmaples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ],
-          "type": "string",
-          "format": "uri-reference",
-          "markdownDescription": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information."
-        }
-      },
-      "type": "object",
-      "required": [
-        "$ref"
-      ]
-    },
-    "LayerUpperRightContent": {
-      "description": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Upper Layer Right Content",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "markdownDescription": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one."
-    },
-    "LayoutStyles": {
-      "description": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
-      "title": "Layout Styles",
-      "$ref": "#/$defs/_LayoutStyles",
-      "markdownDescription": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file."
-    },
-    "OuterWheelControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Control"
-        },
-        {
-          "$ref": "#/$defs/ControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonStyles": {
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "properties": {
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Styles",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state."
-    },
-    "JoystickMovingStyle": {
-      "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Moving Style",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction."
-    },
-    "LayoutActionTarget": {
-      "description": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Layout Action Target",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "markdownDescription": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content."
-    },
-    "DirectionalPadStyles": {
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "title": "Control Default Style",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled."
-            },
-            "idle": {
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
-              "title": "Control Idle Style",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with."
-            },
-            "disabled": {
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "title": "Control Activated Style",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
-            },
-            "activated": {
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "title": "Control Activated Style",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Styles",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state."
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "AssetReference": {
-      "description": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Asset Reference Styling Component",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "markdownDescription": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution."
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "description": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
-      "title": "Throttle Control Type",
+    "_RelativeMouse2DOutputType": {
+      "const": "relativeMouse",
+      "markdownDescription": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
       "type": "string",
-      "const": "throttle",
-      "markdownDescription": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc."
+      "description": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
+      "title": "Relative Mouse Two Dimensional Output"
     },
-    "_Null": {
-      "description": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
-      "title": "Null",
-      "examples": [
-        null
-      ],
-      "type": "null",
-      "markdownDescription": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content."
-    },
-    "_SystemColorAccentPrimary": {
-      "description": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
-      "title": "Accent Primary System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel."
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ArcadeButtonStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ],
+    "LayerControl": {
+      "markdownDescription": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Deadzone2D": {
-      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ]
+          "$ref": "#/$defs/_LayerControlBase"
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Two Dimensional Deadzone",
+      "description": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
       "examples": [
         {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
+          "$ref": "#/definitions/commonLayerButtonControl"
         }
       ],
-      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used."
+      "title": "Touch Layout Layer Control"
     },
-    "DirectionalPadIdleStyle": {
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "description": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          }
-        }
-      ],
-      "title": "Two Dimensional Axis Mapping",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change."
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "OuterLayerControlWheel": {
-      "description": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Outer",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group."
-    },
-    "FillColor": {
-      "description": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
-      "title": "Fill",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information."
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_InputAxisMagnitudinal": {
-      "description": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "Axis Magnitudinal Input Mapping",
-      "type": "string",
-      "markdownDescription": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible."
-    },
-    "_LayoutStyles": {
-      "examples": [
-        {},
-        {
-          "colors": {
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "description": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+    "Sensitivity": {
+      "markdownDescription": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
       "anyOf": [
         {
           "type": "number",
-          "minimum": 0
+          "exclusiveMinimum": 0
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Action Threshold",
+      "description": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
       "examples": [
-        1,
+        10,
         1.5,
-        0,
+        0.5,
         {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
         }
       ],
-      "markdownDescription": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action."
+      "title": "Sensitivity"
     },
-    "ControlVisibility": {
-      "description": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+    "InnerLayerControlWheel": {
+      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
       "anyOf": [
         {
-          "type": "boolean"
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Visible",
+      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
       "examples": [
-        true,
-        false,
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
         {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "markdownDescription": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown."
+      "title": "Inner"
     },
-    "_BackgroundAsset": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "A custom asset used to style the background.",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "A custom asset used to style the background."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        }
-      },
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
+    "_Joystick": {
       "type": "object",
       "required": [
         "type",
-        "value"
-      ]
-    },
-    "Gradient": {
-      "description": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+        "axis"
       ],
-      "title": "Gradient",
       "examples": [
         {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          },
+          "type": "joystick",
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
           }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
         }
       ],
-      "markdownDescription": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value."
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "additionalProperties": false
     },
     "InputCurve": {
-      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
-      "deprecated": true,
-      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
-      "title": "[DEPRECATED] Input Response Curve",
       "examples": [
         {
           "type": "circular",
@@ -2646,8 +4587,15 @@
           "$ref": "#/$defs/commonJoystickResponseCurve"
         }
       ],
+      "title": "[DEPRECATED] Input Response Curve",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
       "anyOf": [
         {
+          "type": "object",
+          "required": [
+            "range",
+            "type"
+          ],
           "properties": {
             "type": {
               "$ref": "#/$defs/InputCurveType"
@@ -2656,247 +4604,61 @@
               "$ref": "#/$defs/InputCurveRange"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerLowerContent": {
-      "description": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Lower Layer Content",
+      "deprecated": true,
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used."
+    },
+    "AxisMapping3D": {
+      "markdownDescription": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
       "examples": [
         {
-          "center": {
-            "type": "blank"
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
           }
-        },
+        ],
         {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+          "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one."
-    },
-    "_InputAxis1D": {
-      "anyOf": [
-        {
-          "description": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
-          "title": "X Axis Input Mapping",
-          "type": "string",
-          "const": "axisX",
-          "markdownDescription": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping."
-        },
-        {
-          "description": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
-          "title": "Y Axis Input Mapping",
-          "type": "string",
-          "const": "axisY",
-          "markdownDescription": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping."
-        }
-      ]
-    },
-    "Toggle": {
-      "description": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Toggle",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "markdownDescription": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state."
-    },
-    "_Joystick": {
-      "additionalProperties": false,
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeJoystick"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "styles": {
-          "$ref": "#/$defs/JoystickStyles"
-        },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          },
-          "type": "joystick",
-          "styles": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "icon",
-                  "value": "walk"
-                }
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "JoystickActivatedStyle": {
-      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Activated Style",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
-    },
-    "TouchpadStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
+      "title": "Three Dimensional Axis Mapping"
     },
     "_RelativeMouseMagnitudinalOutputType": {
+      "markdownDescription": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
+      "type": "string",
       "description": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
       "enum": [
         "relativeMouseUp",
@@ -2904,39 +4666,60 @@
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "Relative Mouse Directional Directional Output",
-      "type": "string",
-      "markdownDescription": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right."
+      "title": "Relative Mouse Directional Directional Output"
     },
-    "JoystickOutlineWithIndicator": {
-      "description": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+    "_InputAxisMagnitudinal": {
+      "markdownDescription": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
+      "type": "string",
+      "description": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "title": "Axis Magnitudinal Input Mapping"
+    },
+    "_InputAxis1D": {
       "anyOf": [
         {
+          "const": "axisX",
+          "markdownDescription": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "type": "string",
+          "description": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "title": "X Axis Input Mapping"
+        },
+        {
+          "const": "axisY",
+          "markdownDescription": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "type": "string",
+          "description": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "title": "Y Axis Input Mapping"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "markdownDescription": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             },
             "stroke": {
               "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Outline Styling Component",
+      "description": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
       "examples": [
         {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
           "stroke": {
             "type": "solid",
             "color": "#0099ffaa"
@@ -2946,158 +4729,15 @@
           "$ref": "#/definitions/commonOutlineStyling"
         }
       ],
-      "markdownDescription": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states."
-    },
-    "_ControlTypeJoystick": {
-      "description": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
-      "title": "Joystick Control Type",
-      "type": "string",
-      "const": "joystick",
-      "markdownDescription": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting."
-    },
-    "ColorPaletteDefaultVariant": {
-      "description": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "title": "Default Colors",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes."
-    },
-    "InnerLayoutControlWheel": {
-      "description": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Inner",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "input": "axisXY",
-              "output": "leftJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls."
-    },
-    "SensorControl": {
-      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
-      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ]
-        }
-      },
-      "title": "Sensor Control",
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_BackgroundColor": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
-          "type": "string",
-          "const": "color",
-          "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/Color"
-        }
-      },
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
+      "title": "Outline Styling Component"
     },
     "ThrottleStyleBase": {
-      "examples": [
-        {
-          "axisUp": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "axisDown": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          }
-        }
-      ],
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
+            "knob": {
+              "$ref": "#/$defs/Knob"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
@@ -3108,214 +4748,59 @@
             "axisDown": {
               "$ref": "#/$defs/ThrottleAxisStyle"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Sticky": {
-      "description": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
-      "anyOf": [
-        {
-          "type": "boolean"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Sticky",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "markdownDescription": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used."
-    },
-    "RenderAsButton": {
-      "description": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Render As Button",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "markdownDescription": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used."
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "type": "string",
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ]
-        }
-      ]
-    },
-    "_Button": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
       "examples": [
         {
-          "action": "gamepadA",
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
+          "axisUp": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "axisDown": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
             }
           }
         }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "action"
       ]
-    },
-    "JoystickDirectionIndicator": {
-      "description": "The visual styling for an indicator of the direction of the interaction",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "Property used to specify that the direction indicator is of color type whose value can be customized.",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "Property used to specify that the direction indicator is of color type whose value can be customized."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Direction Indicator Styling Component",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "markdownDescription": "The visual styling for an indicator of the direction of the interaction"
-    },
-    "Color": {
-      "description": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
-      "title": "Color",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information."
-    },
-    "OuterLayoutControlWheel": {
-      "description": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Outer",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added."
     },
     "_AxisMapping3DItem": {
-      "description": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "markdownDescription": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
       "anyOf": [
         {
           "$ref": "#/$defs/_InputMapping3DTo2DOutput"
@@ -3324,7 +4809,7 @@
           "$ref": "#/$defs/_AxisMapping2DItem"
         }
       ],
-      "title": "Three Dimensional Axis Mapping Item",
+      "description": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
       "examples": [
         {
           "sensitivity": 0.3,
@@ -3332,43 +4817,85 @@
           "input": "axisXY"
         },
         {
-          "input": "axisUp",
-          "output": "rightTrigger"
+          "output": "rightTrigger",
+          "input": "axisUp"
         },
         {
           "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player."
+      "title": "Three Dimensional Axis Mapping Item"
     },
-    "_RelativeMouse1DOutputType": {
-      "description": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "Relative Mouse One Dimensional Output",
-      "type": "string",
-      "markdownDescription": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis."
+    "ActionType": {
+      "markdownDescription": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "description": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "Control Action"
     },
-    "_InputMapping1D": {
+    "Layers": {
+      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+          "type": "object",
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          },
+          "additionalProperties": false
         },
         {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
+      ],
+      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "sticky": true,
+                  "type": "throttle",
+                  "axisDown": "leftTrigger",
+                  "axisUp": "rightTrigger"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "title": "Touch Layout Layers"
     },
-    "ArcadeButton": {
-      "description": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
+    "DeadzoneRadial": {
+      "markdownDescription": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
       "anyOf": [
         {
+          "type": "boolean"
+        }
+      ],
+      "description": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "title": "Radial"
+    },
+    "ArcadeButton": {
+      "markdownDescription": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "action"
+          ],
           "properties": {
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            },
             "enabled": {
               "$ref": "#/$defs/ControlEnabled"
             },
@@ -3377,18 +4904,18 @@
             },
             "styles": {
               "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "action": {
+              "$ref": "#/$defs/ActionType"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "action"
-          ]
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
+      "description": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
       "examples": [
         {
           "action": "gamepadX",
@@ -3404,277 +4931,13 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ],
-      "markdownDescription": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement."
-    },
-    "Deadzone1D": {
-      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "One Dimensional Deadzone",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used."
-    },
-    "Layer": {
-      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
-      "anyOf": [
-        {
-          "properties": {
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "$ref": "#/$defs/LayerControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Touch Layout Layers",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "axisUp": "rightTrigger",
-                "type": "throttle",
-                "axisDown": "leftTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control."
-    },
-    "LayerControlWheel": {
-      "description": "A set of layer controls organized in a circle or wheel shape.",
-      "anyOf": [
-        {
-          "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            },
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Touch Layout Layer Control Wheel",
-      "examples": [
-        {
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "markdownDescription": "A set of layer controls organized in a circle or wheel shape."
-    },
-    "_Accelerometer": {
-      "additionalProperties": false,
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "description": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
-          "title": "Accelerometer Control Type",
-          "type": "string",
-          "const": "accelerometer",
-          "markdownDescription": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input."
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
       ]
     },
-    "ButtonPulledStyle": {
-      "description": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+    "JoystickMovingStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Pulled Style",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed."
-    },
-    "Scale": {
-      "description": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "type": "number",
-          "maximum": 2
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Scale",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "markdownDescription": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used."
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "description": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
-      "anyOf": [
-        {
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Outline Styling Component",
-      "examples": [
-        {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "markdownDescription": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction."
-    },
-    "JoystickDefaultStyle": {
-      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-      "anyOf": [
-        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
@@ -3689,29 +4952,28 @@
               "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Control Default Style",
+      "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
       "examples": [
         {},
         {
           "knob": {
-            "background": {
+            "faceImage": {
               "type": "asset",
-              "value": "CustomKnobBackgroundImage"
+              "value": "CustomKnobFaceImage"
             },
             "stroke": {
               "type": "solid",
               "color": "#0099ffaa"
             },
-            "faceImage": {
+            "background": {
               "type": "asset",
-              "value": "CustomKnobFaceImage"
+              "value": "CustomKnobBackgroundImage"
             }
           },
           "background": {
@@ -3723,24 +4985,334 @@
           "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled."
+      "title": "Control Moving Style"
+    },
+    "DirectionalPadInteractionActivationType": {
+      "markdownDescription": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "title": "Activation Type"
+    },
+    "_HexColor": {
+      "type": "string",
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_FaceImageAsset": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "A custom asset used as the foreground graphic for the control component.",
+          "type": "string",
+          "description": "A custom asset used as the foreground graphic for the control component.",
+          "title": "Face Image Asset Styling Component"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object",
+      "examples": [
+        {},
+        {
+          "myColor": "#ff00ffff",
+          "system_contentPrimary": "#ffffffff"
+        }
+      ],
+      "properties": {
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        }
+      },
+      "additionalProperties": false
     },
     "TurboActionInterval": {
-      "markdownDescription": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
-      "description": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
-      "exclusiveMinimum": 0,
-      "title": "Interval",
       "examples": [
         500,
         1000
       ],
+      "title": "Interval",
+      "description": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
+      "exclusiveMinimum": 0,
+      "markdownDescription": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
       "type": "number"
     },
+    "_ControlTypeJoystick": {
+      "const": "joystick",
+      "markdownDescription": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
+      "type": "string",
+      "description": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
+      "title": "Joystick Control Type"
+    },
+    "JoystickDisabledStyle": {
+      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "Control Disabled Style"
+    },
+    "Opacity": {
+      "markdownDescription": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
+      "anyOf": [
+        {
+          "minimum": 0,
+          "maximum": 1,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "title": "Opacity"
+    },
+    "_ControlTypeArcadeButtons": {
+      "const": "arcadeButtons",
+      "markdownDescription": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
+      "type": "string",
+      "description": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
+      "title": "Arcade Buttons Control Type"
+    },
+    "_Touchpad": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "axis": [
+            {
+              "output": "relativeMouse",
+              "input": "axisXY"
+            }
+          ],
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerUpperContent": {
+      "markdownDescription": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "title": "Upper Layer Content"
+    },
     "InputCurveRange": {
-      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
-      "deprecated": true,
-      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
-      "title": "[DEPRECATED] Input Curve Range",
       "examples": [
         [
           0,
@@ -3762,1672 +5334,103 @@
           }
         ]
       ],
+      "title": "[DEPRECATED] Input Curve Range",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
       "anyOf": [
         {
-          "maxItems": 2,
-          "minItems": 2,
           "items": {
             "anyOf": [
               {
                 "minimum": -1,
-                "type": "number",
-                "maximum": 1
+                "maximum": 1,
+                "type": "number"
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1."
+    },
+    "_ActionTypeBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
           "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayoutContent": {
-      "description": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
-      "anyOf": [
-        {
-          "properties": {
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "center": {
-              "$ref": "#/$defs/LayoutControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "Layout Content",
       "examples": [
-        {},
+        "gamepadB",
         {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "input": "axisXY",
-                  "output": "leftJoystick"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "markdownDescription": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays."
-    },
-    "LayoutLowerContent": {
-      "description": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "../../context.json#/state/jumpControllerMapping"
         },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Lower Layout Content",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "markdownDescription": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps."
-    },
-    "_AxisMapping2DItem": {
-      "description": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Two Dimensional Axis Mapping Item",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisUp",
-          "output": "rightTrigger"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change."
-    },
-    "DeadzoneThreshold": {
-      "description": "The normalized, input value needed in order to produce output values.",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Threshold",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "markdownDescription": "The normalized, input value needed in order to produce output values."
-    },
-    "JoystickDisabledStyle": {
-      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Disabled Style",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled."
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "RelativeInteraction": {
-      "description": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Relative",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "markdownDescription": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point."
-    },
-    "FaceImageIconValue": {
-      "description": "This property is used to select which built-in icon to use for this component.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Face Image Icon",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "markdownDescription": "This property is used to select which built-in icon to use for this component."
-    },
-    "LayoutUpperRightContent": {
-      "description": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Upper Right Layout Content",
-      "examples": [
         [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "markdownDescription": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen."
-    },
-    "_Throttle": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "sticky": true,
-          "axisUp": "rightTrigger",
-          "type": "throttle",
-          "axisDown": "leftTrigger"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
+          "gamepadA",
+          "leftTrigger"
+        ]
       ]
     },
-    "_FaceImageIcon": {
-      "properties": {
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "description": "A built-in icon used as the foreground graphic for the control component.",
-          "title": "Face Image Icon Styling Component",
-          "type": "string",
-          "const": "icon",
-          "markdownDescription": "A built-in icon used as the foreground graphic for the control component."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "_SystemColorAccentSecondary": {
-      "description": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
-      "title": "Accent Secondary System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel."
-    },
-    "_ControllerAnalog2DOutputType": {
-      "description": "Outputs values along the entirety of both gamepad joystick axes.",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "Gamepad Analog Joystick Output",
-      "type": "string",
-      "markdownDescription": "Outputs values along the entirety of both gamepad joystick axes."
-    },
-    "_SystemColorContentPrimary": {
-      "description": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
-      "title": "Content Primary System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients."
-    },
-    "_DirectionalPad": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        }
-      },
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "Stroke": {
-      "description": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
-      "title": "Stroke Styling Component",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component."
-    },
-    "ThrottleAxisStyle": {
-      "description": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+    "_ControllerAction": {
       "anyOf": [
         {
-          "properties": {
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "#/$defs/_ControllerButtonOutputType"
         },
         {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Throttle Axis Styling Component",
-      "examples": [
-        {
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        }
-      ],
-      "markdownDescription": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down."
-    },
-    "_SystemColorContrastPrimary": {
-      "description": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
-      "title": "Contrast Primary System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates."
-    },
-    "_FaceImageAsset": {
-      "properties": {
-        "type": {
-          "description": "A custom asset used as the foreground graphic for the control component.",
-          "title": "Face Image Asset Styling Component",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "A custom asset used as the foreground graphic for the control component."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_Blank": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
-          "title": "Blank Control Type",
-          "type": "string",
-          "const": "blank",
-          "markdownDescription": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components."
-        }
-      },
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "_SystemColorGamepadActionColor": {
-      "description": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
-      "title": "Gamepad Action System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`."
-    },
-    "ThrottleStyles": {
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "properties": {
-            "idleUp": {
-              "description": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
-              "title": "Control Idle Up Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`."
-            },
-            "disabled": {
-              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "title": "Control Disabled Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled."
-            },
-            "activatedUp": {
-              "description": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
-              "title": "Control Activated Up Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center."
-            },
-            "idle": {
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "title": "Control Idle Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting."
-            },
-            "activated": {
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "title": "Control Activated Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
-            },
-            "activatedDown": {
-              "description": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
-              "title": "Control Activated Down Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center."
-            },
-            "default": {
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "title": "Control Default Style",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Styles",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "axisDown": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state."
-    },
-    "LayoutSensorContent": {
-      "description": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Sensors Layout Content",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "markdownDescription": "This property defines a container of layout content that uses the device's sensor inputs as interactions."
-    },
-    "AxisCapColor": {
-      "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
-              "title": "Axis Cap Styling Component",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Axis Cap Styling Component",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis."
-    },
-    "_StrokeBase": {
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "description": "This styling component is used to specify a solid stroke with customizable color and opacity.",
-              "type": "string",
-              "const": "solid",
-              "markdownDescription": "This styling component is used to specify a solid stroke with customizable color and opacity."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
         }
       ]
     },
-    "Background": {
-      "description": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+    "OuterWheelControlGroup": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_BackgroundColor"
+          "$ref": "#/$defs/Control"
         },
         {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Background Styling Component",
-      "markdownDescription": "The visual styling of the background of the control component. The background can be a `color` or `asset`."
-    },
-    "_ControllerAnalog1DOutputType": {
-      "description": "Outputs values along the entirety of the specified gamepad joystick axis.",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "Gamepad Analog Joystick Output",
-      "type": "string",
-      "markdownDescription": "Outputs values along the entirety of the specified gamepad joystick axis."
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "Knob": {
-      "description": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Knob Styling Component",
-      "examples": [
-        {
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "markdownDescription": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance."
-    },
-    "DirectionalPadInteractionActivationType": {
-      "description": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "exclusive",
-            "allowNeighboring"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Activation Type",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "markdownDescription": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used."
-    },
-    "FaceImageIconLabel": {
-      "description": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "action",
-                "none"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Face Image Icon Label Styling Component",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "markdownDescription": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used."
-    },
-    "SensorLayerControl": {
-      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ]
-        }
-      },
-      "title": "Layer Sensor Control",
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
+          "$ref": "#/$defs/ControlGroup"
         },
         {
           "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ]
-    },
-    "ButtonDisabledStyle": {
-      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Disabled Style",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled."
-    },
-    "Layers": {
-      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Touch Layout Layers",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "axisUp": "rightTrigger",
-                  "type": "throttle",
-                  "axisDown": "leftTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control."
-    },
-    "_SystemColorContentSecondary": {
-      "description": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
-      "title": "Content Secondary System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the secondary system color used for styling components such as backgrounds and fills."
-    },
-    "_LayoutAction": {
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "additionalProperties": false,
-      "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-      "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-      "required": [
-        "type",
-        "target"
-      ],
-      "title": "Layout Action",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-          "title": "Layout Action",
-          "type": "string",
-          "const": "layer",
-          "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed."
-        }
-      },
-      "type": "object"
-    },
-    "InnerLayerControlWheel": {
-      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Inner",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden."
-    },
-    "ArcadeButtonStyles": {
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "title": "Control Default Style",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled."
-            },
-            "idle": {
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "title": "Control Idle Style",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting."
-            },
-            "disabled": {
-              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "title": "Control Disabled Style",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled."
-            },
-            "activated": {
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "title": "Control Activated Style",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed."
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Styles",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          },
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state."
-    },
-    "LayoutLowerArrayContent": {
-      "description": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Lower Layout Array Content",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one."
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "LayerUpperContent": {
-      "description": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Upper Layer Content",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
-        }
-      ],
-      "markdownDescription": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one."
-    },
-    "JoystickIdleStyle": {
-      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Control Idle Style",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting."
-    },
-    "DeadzoneDirectionalPad": {
-      "description": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
-      "anyOf": [
-        {
-          "exclusiveMinimum": 0,
-          "type": "number",
-          "exclusiveMaximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Directional Pad Deadzone",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "markdownDescription": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size."
-    },
-    "Sensitivity": {
-      "description": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Sensitivity",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "markdownDescription": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used."
-    },
-    "_InputAxisZY": {
-      "description": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
-      "title": "Z and Y Axis Input Mapping",
-      "type": "string",
-      "const": "axisZY",
-      "markdownDescription": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping."
-    },
-    "_Touchpad": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
-      "examples": [
-        {
-          "axis": [
-            {
-              "input": "axisXY",
-              "output": "relativeMouse"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "_SystemColorActionColor": {
-      "description": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
-      "title": "Action System Color Override",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action."
-    },
-    "LayoutUpperContent": {
-      "description": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Upper Layout Content",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "markdownDescription": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments."
-    },
-    "DeadzoneRadial": {
-      "description": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "title": "Radial",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "markdownDescription": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually."
     }
   },
-  "type": "object"
+  "description": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+  "properties": {
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "content"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "title": "Touch Adaptation Bundle Layout Schema",
+  "markdownDescription": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases."
 }

--- a/touch-adaptation-kit/schemas/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/layout/v4.0/layout.json
@@ -1,4069 +1,15 @@
 {
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "additionalProperties": false,
-  "type": "object",
+  "title": "Touch Adaptation Bundle Layout Schema",
+  "description": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+  "markdownDescription": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
   "$defs": {
-    "_StrokeBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "solid",
-              "markdownDescription": "This styling component is used to specify a solid stroke with customizable color and opacity.",
-              "type": "string",
-              "description": "This styling component is used to specify a solid stroke with customizable color and opacity."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ]
-    },
-    "_SystemColorContentPrimary": {
-      "markdownDescription": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
-      "description": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Content Primary System Color Override"
-    },
-    "_ControlTypeDirectionalPad": {
-      "const": "directionalPad",
-      "markdownDescription": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
-      "type": "string",
-      "description": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
-      "title": "Directional Pad Control Type"
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "JoystickDirectionIndicator": {
-      "markdownDescription": "The visual styling for an indicator of the direction of the interaction",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "Property used to specify that the direction indicator is of color type whose value can be customized.",
-              "type": "string",
-              "description": "Property used to specify that the direction indicator is of color type whose value can be customized."
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling for an indicator of the direction of the interaction",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "title": "Direction Indicator Styling Component"
-    },
-    "LayerSensorContent": {
-      "markdownDescription": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
-        }
-      ],
-      "title": "Sensors Layer Content"
-    },
-    "Background": {
-      "markdownDescription": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
-      "title": "Background Styling Component"
-    },
-    "_Accelerometer": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "accelerometer",
-          "markdownDescription": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
-          "type": "string",
-          "description": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
-          "title": "Accelerometer Control Type"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "SensorControl": {
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "Sensor Control",
-      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_Null": {
-      "markdownDescription": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
-      "type": "null",
-      "description": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
-      "examples": [
-        null
-      ],
-      "title": "Null"
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "markdownDescription": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
-      "type": "string",
-      "description": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "Gamepad Analog Joystick Output"
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "PullIndicator": {
-      "markdownDescription": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "title": "Pull Indicator Styling Component"
-    },
-    "_SystemColorAccentPrimary": {
-      "markdownDescription": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
-      "description": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Accent Primary System Color Override"
-    },
-    "Scale": {
-      "markdownDescription": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "maximum": 2,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "title": "Scale"
-    },
-    "JoystickIdleStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "Control Idle Style"
-    },
-    "_AxisMapping2DItem": {
-      "markdownDescription": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "Two Dimensional Axis Mapping Item"
-    },
-    "TouchpadStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ]
-    },
-    "ButtonIdleStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "Control Idle Style"
-    },
-    "_LayoutStyles": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "colors": {
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ]
-    },
-    "DeadzoneDirectionalPad": {
-      "markdownDescription": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
-      "anyOf": [
-        {
-          "exclusiveMaximum": 1,
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "title": "Directional Pad Deadzone"
-    },
-    "Sticky": {
-      "markdownDescription": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "title": "Sticky"
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayoutContent": {
-      "markdownDescription": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
-      "examples": [
-        {},
-        {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "output": "leftJoystick",
-                  "input": "axisXY"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "title": "Layout Content"
-    },
-    "Reference": {
-      "type": "object",
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-          "format": "uri-reference",
-          "markdownDescription": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
-          "type": "string",
-          "description": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
-          "examples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerControlWheel": {
-      "markdownDescription": "A set of layer controls organized in a circle or wheel shape.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A set of layer controls organized in a circle or wheel shape.",
-      "examples": [
-        {
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ],
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "title": "Touch Layout Layer Control Wheel"
-    },
-    "_SystemColorAccentSecondary": {
-      "markdownDescription": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
-      "description": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Accent Secondary System Color Override"
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonToggledStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "Control Toggled Style"
-    },
-    "LayoutLowerArrayContent": {
-      "markdownDescription": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "title": "Lower Layout Array Content"
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "markdownDescription": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          },
-          "type": "array"
-        }
-      ],
-      "description": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "Two Dimensional Axis Mapping"
-    },
-    "ThrottleAxisOutput": {
-      "markdownDescription": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
-      "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
-        {
-          "$ref": "#/definitions/commonThrottleAxis"
-        }
-      ],
-      "title": "Throttle Axis"
-    },
-    "ColorPaletteDefaultVariant": {
-      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "description": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "Default Colors"
-    },
-    "Deadzone1D": {
-      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "One Dimensional Deadzone"
-    },
-    "JoystickOutlineWithIndicator": {
-      "markdownDescription": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
-      "examples": [
-        {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "title": "Outline Styling Component"
-    },
-    "_ControllerButtonOutputType": {
-      "markdownDescription": "Outputs a gamepad button press.",
-      "type": "string",
-      "description": "Outputs a gamepad button press.",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "Gamepad Button Output"
-    },
-    "ButtonActivatedStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "Control Activated Style"
-    },
-    "JoystickStyles": {
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "examples": [
-        {},
-        {
-          "default": {
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyles"
-        }
-      ],
-      "title": "Control Styles"
-    },
-    "ButtonDisabledStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "Control Disabled Style"
-    },
-    "LayoutActionTarget": {
-      "markdownDescription": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "title": "Layout Action Target"
-    },
-    "_ControlTypeButton": {
-      "const": "button",
-      "markdownDescription": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
-      "type": "string",
-      "description": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
-      "title": "Button Control Type"
-    },
-    "_ControllerAnalog1DOutputType": {
-      "markdownDescription": "Outputs values along the entirety of the specified gamepad joystick axis.",
-      "type": "string",
-      "description": "Outputs values along the entirety of the specified gamepad joystick axis.",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "Gamepad Analog Joystick Output"
-    },
-    "_LayoutAction": {
-      "type": "object",
-      "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "const": "layer",
-          "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-          "type": "string",
-          "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-          "title": "Layout Action"
-        }
-      },
-      "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "title": "Layout Action",
-      "required": [
-        "type",
-        "target"
-      ],
-      "additionalProperties": false
-    },
-    "InnerLayoutControlWheel": {
-      "markdownDescription": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "output": "leftJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "title": "Inner"
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "_ControllerTriggerOutputType": {
-      "markdownDescription": "Outputs values that map to the specified gamepad trigger.",
-      "type": "string",
-      "description": "Outputs values that map to the specified gamepad trigger.",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "Gamepad Analog Trigger Output"
-    },
-    "DirectionalPadStyles": {
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "Control Idle Style"
-            },
-            "disabled": {
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "Control Activated Style"
-            },
-            "activated": {
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "Control Activated Style"
-            },
-            "default": {
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "Control Default Style"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "title": "Control Styles"
-    },
-    "Indicator": {
-      "markdownDescription": "The visual styling for the stroke used to indicate the current value or placement of the control.",
-      "description": "The visual styling for the stroke used to indicate the current value or placement of the control.",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "Indicator Styling Component"
-    },
-    "Stroke": {
-      "markdownDescription": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
-      "description": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "Stroke Styling Component"
-    },
-    "Gradient": {
-      "markdownDescription": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
-      "examples": [
-        {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
-        }
-      ],
-      "title": "Gradient"
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "markdownDescription": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "title": "Gamepad Action"
-    },
-    "_DirectionalPad": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_TurboAction": {
-      "title": "Turbo Action",
-      "properties": {
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        },
-        "type": {
-          "const": "turbo",
-          "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
-          "type": "string",
-          "description": "Action that triggers on and off based on an interval instead of continuously.",
-          "title": "Turbo Action"
-        },
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        }
-      },
-      "description": "Action that triggers on and off based on an interval instead of continuously.",
-      "type": "object",
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
-      "additionalProperties": false
-    },
-    "ControlGroup": {
-      "markdownDescription": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/ControlGroupItem"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
-          },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "title": "Touch Layout Control Group"
-    },
-    "_SystemColorContrastPrimary": {
-      "markdownDescription": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
-      "description": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Contrast Primary System Color Override"
-    },
-    "ControlGroupItem": {
-      "markdownDescription": "A single item in the control group. Use `null` to skip a control in the arrangement.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A single item in the control group. Use `null` to skip a control in the arrangement.",
-      "title": "Touch Layout Control Group Item"
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "markdownDescription": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
-      "anyOf": [
-        {
-          "type": "number",
-          "minimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
-      "examples": [
-        1,
-        1.5,
-        0,
-        {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
-        }
-      ],
-      "title": "Action Threshold"
-    },
-    "ArcadeButtonStyles": {
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "Control Idle Style"
-            },
-            "disabled": {
-              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "Control Disabled Style"
-            },
-            "activated": {
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "Control Activated Style"
-            },
-            "default": {
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "Control Default Style"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "examples": [
-        {
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          },
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "title": "Control Styles"
-    },
-    "_BackgroundAsset": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "A custom asset used to style the background.",
-          "type": "string",
-          "description": "A custom asset used to style the background."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_FaceImageIcon": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        },
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "const": "icon",
-          "markdownDescription": "A built-in icon used as the foreground graphic for the control component.",
-          "type": "string",
-          "description": "A built-in icon used as the foreground graphic for the control component.",
-          "title": "Face Image Icon Styling Component"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1D": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
-        }
-      ]
-    },
-    "_InputMappingZY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
-        }
-      ]
-    },
-    "FaceImageIconValue": {
-      "markdownDescription": "This property is used to select which built-in icon to use for this component.",
-      "anyOf": [
-        {
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property is used to select which built-in icon to use for this component.",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "title": "Face Image Icon"
-    },
-    "Toggle": {
-      "markdownDescription": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "title": "Toggle"
-    },
-    "ArcadeButtonStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ]
-    },
-    "_ControlTypeTouchpad": {
-      "const": "touchpad",
-      "markdownDescription": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
-      "type": "string",
-      "description": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
-      "title": "Touchpad Control Type"
-    },
-    "ThrottleStyles": {
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Default Style"
-            },
-            "idleUp": {
-              "markdownDescription": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
-              "description": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Idle Up Style"
-            },
-            "activatedDown": {
-              "markdownDescription": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
-              "description": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Activated Down Style"
-            },
-            "disabled": {
-              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Disabled Style"
-            },
-            "activatedUp": {
-              "markdownDescription": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
-              "description": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Activated Up Style"
-            },
-            "idle": {
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Idle Style"
-            },
-            "activated": {
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "Control Activated Style"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "axisDown": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "title": "Control Styles"
-    },
-    "SensorLayerControl": {
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "Layer Sensor Control",
-      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_SystemColorActionColor": {
-      "markdownDescription": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
-      "description": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Action System Color Override"
-    },
-    "LayoutSensorContent": {
-      "markdownDescription": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "title": "Sensors Layout Content"
-    },
-    "LayoutColors": {
-      "markdownDescription": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            },
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "examples": [
-        {},
-        {
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "title": "Colors"
-    },
-    "LayoutUpperContent": {
-      "markdownDescription": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "title": "Upper Layout Content"
-    },
-    "_Color": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ]
-    },
-    "DirectionalPadDefaultStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "RelativeInteraction": {
-      "markdownDescription": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "title": "Relative"
-    },
-    "ButtonPulledStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "Control Pulled Style"
-    },
-    "InputCurveType": {
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "title": "[DEPRECATED] Input Response Curve Type",
-      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
-      "anyOf": [
-        {
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle."
-    },
-    "ThrottleAxisStyle": {
-      "markdownDescription": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
-      "examples": [
-        {
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          },
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        }
-      ],
-      "title": "Throttle Axis Styling Component"
-    },
-    "ButtonDefaultStyle": {
-      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "Control Default Style"
-    },
-    "_InputMapping1DToGamepad1DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FillColor": {
-      "markdownDescription": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
-      "description": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
-      "$ref": "#/$defs/_Color",
-      "title": "Fill"
-    },
-    "PullIndicatorBackground": {
-      "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "title": "Background Styling Component"
-    },
-    "_Button": {
-      "type": "object",
-      "required": [
-        "type",
-        "action"
-      ],
-      "examples": [
-        {
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
-            }
-          },
-          "action": "gamepadA"
-        }
-      ],
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        }
-      },
-      "additionalProperties": false
-    },
-    "DirectionalPadInteraction": {
-      "markdownDescription": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "title": "Interaction"
-    },
-    "ButtonStyles": {
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "title": "Control Styles"
-    },
-    "_CustomColorPaletteColor": {
-      "markdownDescription": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "description": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Custom Layout Color"
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "DeadzoneThreshold": {
-      "markdownDescription": "The normalized, input value needed in order to produce output values.",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The normalized, input value needed in order to produce output values.",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "title": "Threshold"
-    },
-    "_SystemColorContrastSecondary": {
-      "markdownDescription": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
-      "description": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Contrast Secondary System Color Override"
-    },
-    "_SystemColorGamepadActionColor": {
-      "markdownDescription": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
-      "description": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Gamepad Action System Color Override"
-    },
-    "AssetReference": {
-      "markdownDescription": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "title": "Asset Reference Styling Component"
-    },
-    "FaceImage": {
-      "markdownDescription": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
-        }
-      ],
-      "title": "Face Image Styling Component"
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      }
-    },
-    "JoystickActivatedStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "Control Activated Style"
-    },
-    "LayoutLowerContent": {
-      "markdownDescription": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "title": "Lower Layout Content"
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "ControlVisibility": {
-      "markdownDescription": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "Visible"
-    },
-    "LayerLowerArrayContent": {
-      "markdownDescription": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "title": "Lower Layer Array Content"
-    },
-    "OuterLayoutControlWheel": {
-      "markdownDescription": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "Outer"
-    },
-    "ControlEnabled": {
-      "markdownDescription": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "Enabled"
-    },
-    "ExpandInteraction": {
-      "markdownDescription": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "title": "Expand"
-    },
-    "Deadzone2D": {
-      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
-      "examples": [
-        {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "Two Dimensional Deadzone"
-    },
-    "_ColorPaletteColor": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ]
-    },
-    "_InputAxisZY": {
-      "const": "axisZY",
-      "markdownDescription": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
-      "type": "string",
-      "description": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
-      "title": "Z and Y Axis Input Mapping"
-    },
-    "DirectionalPadIdleStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/definitions/joystickAssetName"
-                  }
-                }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
-        }
-      ],
-      "title": "Definitions",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/LayoutDefinableType"
-        }
-      },
-      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "type": "object",
-      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
-      "additionalProperties": false
-    },
-    "_SystemColorContentSecondary": {
-      "markdownDescription": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
-      "description": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "Content Secondary System Color Override"
-    },
-    "Color": {
-      "markdownDescription": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
-      "description": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
-      "$ref": "#/$defs/_Color",
-      "title": "Color"
-    },
-    "_RelativeMouse1DOutputType": {
-      "markdownDescription": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
-      "type": "string",
-      "description": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "Relative Mouse One Dimensional Output"
-    },
-    "_ArcadeButtons": {
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ],
-      "examples": [
-        {
-          "type": "arcadeButtons",
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          },
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          }
-        }
-      ],
-      "properties": {
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Special Punch Button"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Heavy Kick Button"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Light Punch Button"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Light Kick Button"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Medium Kick Button"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Special Kick Button"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Heavy Kick Button"
-        },
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "Medium Punch Button"
-        }
-      },
-      "additionalProperties": false
-    },
-    "OuterLayerControlWheel": {
-      "markdownDescription": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "Outer"
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "const": "throttle",
-      "markdownDescription": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
-      "type": "string",
-      "description": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
-      "title": "Throttle Control Type"
-    },
-    "LayoutOrientation": {
-      "title": "[DEPRECATED] Layout Orientation",
-      "description": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
-      "enum": [
-        "landscape-left",
-        "landscape-right",
-        "landscape",
-        "portrait-up",
-        "portrait"
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
-      "type": "string"
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputAxisXY": {
-      "const": "axisXY",
-      "markdownDescription": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
-      "type": "string",
-      "description": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
-      "title": "X and Y Axis Input Mapping"
-    },
-    "PullActionType": {
-      "markdownDescription": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
-      "description": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "Control Pull Action"
-    },
-    "Knob": {
-      "markdownDescription": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "title": "Knob Styling Component"
-    },
-    "Control": {
-      "markdownDescription": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "title": "Touch Layout Control"
-    },
-    "LayerUpperRightContent": {
-      "markdownDescription": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "title": "Upper Layer Right Content"
-    },
-    "AxisCapColor": {
-      "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
-              "type": "string",
-              "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
-              "title": "Axis Cap Styling Component"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "title": "Axis Cap Styling Component"
-    },
-    "_Throttle": {
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
-      ],
-      "examples": [
-        {
-          "sticky": true,
-          "type": "throttle",
-          "axisDown": "leftTrigger",
-          "axisUp": "rightTrigger"
-        }
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Blank": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "properties": {
-        "type": {
-          "const": "blank",
-          "markdownDescription": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
-          "type": "string",
-          "description": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
-          "title": "Blank Control Type"
-        }
-      },
-      "additionalProperties": false
-    },
-    "RenderAsButton": {
-      "markdownDescription": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "title": "Render As Button"
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "_InputMappingXYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "ColorPaletteHighContrastVariant": {
-      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "description": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "High Contrast Colors"
-    },
-    "LayoutStyles": {
-      "markdownDescription": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
-      "description": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
-      "$ref": "#/$defs/_LayoutStyles",
-      "title": "Layout Styles"
-    },
-    "LayerControlGroup": {
-      "type": "array",
-      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "minItems": 1,
-      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          },
-          null
-        ]
-      ],
-      "maxItems": 4,
-      "title": "Touch Layout Layer Control Group",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      }
-    },
-    "_BackgroundColor": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/Color"
-        },
-        "type": {
-          "const": "color",
-          "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
-          "type": "string",
-          "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized."
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Gyroscope": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "output": "rightJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "gyroscope",
-          "markdownDescription": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
-          "type": "string",
-          "description": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
-          "title": "Gyroscope Control Type"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageIconLabel": {
-      "markdownDescription": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "action",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "title": "Face Image Icon Label Styling Component"
-    },
-    "TouchpadStyles": {
-      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "Control Idle Style"
-            },
-            "disabled": {
-              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "Control Disabled Style"
-            },
-            "activated": {
-              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "Control Activated Style"
-            },
-            "moving": {
-              "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
-              "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "Control Moving Style"
-            },
-            "default": {
-              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "Control Default Style"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "title": "Control Styles"
-    },
-    "Layer": {
-      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "type": "throttle",
-                "axisDown": "leftTrigger",
-                "axisUp": "rightTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "title": "Touch Layout Layers"
-    },
-    "LayerControlGroupItem": {
-      "markdownDescription": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "Touch Layout Layer Control Group Item"
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ],
-          "type": "string"
-        }
-      ]
-    },
-    "LayoutUpperRightContent": {
-      "markdownDescription": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "title": "Upper Right Layout Content"
-    },
-    "JoystickDefaultStyle": {
-      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "Control Default Style"
-    },
-    "_ControllerAnalog2DOutputType": {
-      "markdownDescription": "Outputs values along the entirety of both gamepad joystick axes.",
-      "type": "string",
-      "description": "Outputs values along the entirety of both gamepad joystick axes.",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "Gamepad Analog Joystick Output"
-    },
-    "LayerLowerContent": {
-      "markdownDescription": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
-      "examples": [
-        {
-          "center": {
-            "type": "blank"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
-        }
-      ],
-      "title": "Lower Layer Content"
-    },
     "LayoutDefinableType": {
+      "title": "Definable Types",
+      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -4377,153 +323,1116 @@
         {
           "$ref": "#/$defs/TouchpadStyles"
         }
-      ],
-      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
-      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
-      "title": "Definable Types"
+      ]
     },
-    "LayoutControlWheel": {
-      "markdownDescription": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayoutControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
+    "Definitions": {
+      "title": "Definitions",
+      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
       "examples": [
         {},
         {
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "output": "leftJoystick",
-                "input": "axisXY"
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
               }
             }
-          ],
-          "outer": [
-            null,
-            [
-              {
-                "type": "button",
-                "action": "gamepadX"
-              }
-            ],
-            {
-              "type": "button",
-              "action": "gamepadY"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonControlWheel"
-        }
-      ],
-      "title": "Touch Layout Control Wheel"
-    },
-    "_RelativeMouse2DOutputType": {
-      "const": "relativeMouse",
-      "markdownDescription": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
-      "type": "string",
-      "description": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
-      "title": "Relative Mouse Two Dimensional Output"
-    },
-    "LayerControl": {
-      "markdownDescription": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "Touch Layout Layer Control"
-    },
-    "Sensitivity": {
-      "markdownDescription": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "title": "Sensitivity"
-    },
-    "InnerLayerControlWheel": {
-      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
           }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "title": "Inner"
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
     },
-    "_Joystick": {
+    "Reference": {
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
+          "markdownDescription": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "Null",
+      "description": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
+      "markdownDescription": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "Accelerometer Control Type",
+          "description": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
+          "markdownDescription": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
       "required": [
         "type",
         "axis"
       ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
       "examples": [
         {
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
           },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "Heavy Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "Heavy Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "Light Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "Light Punch Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "Medium Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "Medium Punch Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "Special Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "Special Punch Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "Two Dimensional Axis Mapping Item",
+      "description": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "markdownDescription": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "Three Dimensional Axis Mapping Item",
+      "description": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "markdownDescription": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "A custom asset used to style the background.",
+          "markdownDescription": "A custom asset used to style the background.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+          "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Blank Control Type",
+          "description": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
+          "markdownDescription": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "Gamepad Analog Joystick Output",
+      "description": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
+      "markdownDescription": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "Gamepad Analog Joystick Output",
+      "description": "Outputs values along the entirety of the specified gamepad joystick axis.",
+      "markdownDescription": "Outputs values along the entirety of the specified gamepad joystick axis.",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "Gamepad Analog Joystick Output",
+      "description": "Outputs values along the entirety of both gamepad joystick axes.",
+      "markdownDescription": "Outputs values along the entirety of both gamepad joystick axes.",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "Gamepad Button Output",
+      "description": "Outputs a gamepad button press.",
+      "markdownDescription": "Outputs a gamepad button press.",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "Gamepad Analog Trigger Output",
+      "description": "Outputs values that map to the specified gamepad trigger.",
+      "markdownDescription": "Outputs values that map to the specified gamepad trigger.",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "Arcade Buttons Control Type",
+      "description": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
+      "markdownDescription": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "Button Control Type",
+      "description": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
+      "markdownDescription": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "Directional Pad Control Type",
+      "description": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
+      "markdownDescription": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "Joystick Control Type",
+      "description": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
+      "markdownDescription": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "Throttle Control Type",
+      "description": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
+      "markdownDescription": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "Touchpad Control Type",
+      "description": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
+      "markdownDescription": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "Custom Layout Color",
+      "description": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Face Image Asset Styling Component",
+          "description": "A custom asset used as the foreground graphic for the control component.",
+          "markdownDescription": "A custom asset used as the foreground graphic for the control component.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Face Image Icon Styling Component",
+          "description": "A built-in icon used as the foreground graphic for the control component.",
+          "markdownDescription": "A built-in icon used as the foreground graphic for the control component.",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "Gyroscope Control Type",
+          "description": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
+          "markdownDescription": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "Axis Magnitudinal Input Mapping",
+      "description": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
+      "markdownDescription": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X Axis Input Mapping",
+          "description": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "markdownDescription": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y Axis Input Mapping",
+          "description": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "markdownDescription": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X and Y Axis Input Mapping",
+      "description": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "markdownDescription": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z and Y Axis Input Mapping",
+      "description": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "markdownDescription": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
           "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
           "styles": {
             "default": {
               "knob": {
@@ -4536,24 +1445,22 @@
           }
         }
       ],
+      "additionalProperties": false,
       "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
+        "action": {
+          "$ref": "#/$defs/ActionType"
         },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
         },
         "axis": {
           "$ref": "#/$defs/AxisMapping2D"
         },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
         },
         "relative": {
           "$ref": "#/$defs/RelativeInteraction"
@@ -4561,361 +1468,374 @@
         "styles": {
           "$ref": "#/$defs/JoystickStyles"
         },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
         "type": {
           "$ref": "#/$defs/_ControlTypeJoystick"
         }
       },
-      "additionalProperties": false
-    },
-    "InputCurve": {
-      "examples": [
-        {
-          "type": "circular",
-          "range": [
-            0,
-            0.33
-          ]
-        },
-        {
-          "type": "circular-inverse",
-          "range": [
-            0,
-            1
-          ]
-        },
-        {
-          "$ref": "#/$defs/commonJoystickResponseCurve"
-        }
+      "required": [
+        "type",
+        "axis"
       ],
-      "title": "[DEPRECATED] Input Response Curve",
-      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
+      "type": "object"
+    },
+    "_LayerControlBase": {
       "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/InputCurveType"
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "Layout Action",
+      "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+      "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "Layout Action",
+          "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+          "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
             },
-            "range": {
-              "$ref": "#/$defs/InputCurveRange"
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used."
+      ]
     },
-    "AxisMapping3D": {
-      "markdownDescription": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+    "_RelativeMouse1DOutputType": {
+      "title": "Relative Mouse One Dimensional Output",
+      "description": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
+      "markdownDescription": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "description": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "Three Dimensional Axis Mapping"
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "Relative Mouse Two Dimensional Output",
+      "description": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
+      "markdownDescription": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
+      "const": "relativeMouse",
+      "type": "string"
     },
     "_RelativeMouseMagnitudinalOutputType": {
-      "markdownDescription": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
-      "type": "string",
+      "title": "Relative Mouse Directional Directional Output",
       "description": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
+      "markdownDescription": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
       "enum": [
         "relativeMouseUp",
         "relativeMouseDown",
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "Relative Mouse Directional Directional Output"
+      "type": "string"
     },
-    "_InputAxisMagnitudinal": {
-      "markdownDescription": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
-      "type": "string",
-      "description": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "Axis Magnitudinal Input Mapping"
-    },
-    "_InputAxis1D": {
+    "_SingleControlActionAssignableTypes": {
       "anyOf": [
         {
-          "const": "axisX",
-          "markdownDescription": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
-          "type": "string",
-          "description": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
-          "title": "X Axis Input Mapping"
+          "$ref": "#/$defs/_ControllerAction"
         },
         {
-          "const": "axisY",
-          "markdownDescription": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
-          "type": "string",
-          "description": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
-          "title": "Y Axis Input Mapping"
-        }
-      ]
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "markdownDescription": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
-      "anyOf": [
+          "$ref": "#/$defs/_LayoutAction"
+        },
         {
-          "type": "object",
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/_TurboAction"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
+      ]
+    },
+    "_StrokeBase": {
       "examples": [
         {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
         },
         {
-          "$ref": "#/definitions/commonOutlineStyling"
+          "$ref": "#/definitions/commonControlStroke"
         }
       ],
-      "title": "Outline Styling Component"
-    },
-    "ThrottleStyleBase": {
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "type": {
+              "description": "This styling component is used to specify a solid stroke with customizable color and opacity.",
+              "markdownDescription": "This styling component is used to specify a solid stroke with customizable color and opacity.",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
-            },
-            "axisUp": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "axisDown": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "type"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "examples": [
-        {
-          "axisUp": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "axisDown": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          }
-        }
       ]
     },
-    "_AxisMapping3DItem": {
-      "markdownDescription": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        }
-      ],
-      "description": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+    "_SystemColorContentPrimary": {
+      "title": "Content Primary System Color Override",
+      "description": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
+      "markdownDescription": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "Content Secondary System Color Override",
+      "description": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
+      "markdownDescription": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "Contrast Primary System Color Override",
+      "description": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
+      "markdownDescription": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "Contrast Secondary System Color Override",
+      "description": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
+      "markdownDescription": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "Action System Color Override",
+      "description": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
+      "markdownDescription": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "Gamepad Action System Color Override",
+      "description": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
+      "markdownDescription": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "Accent Primary System Color Override",
+      "description": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
+      "markdownDescription": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "Accent Secondary System Color Override",
+      "description": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
+      "markdownDescription": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
       "examples": [
         {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
         }
       ],
-      "title": "Three Dimensional Axis Mapping Item"
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "Turbo Action",
+      "description": "Action that triggers on and off based on an interval instead of continuously.",
+      "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "Turbo Action",
+          "description": "Action that triggers on and off based on an interval instead of continuously.",
+          "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "Action Threshold",
+      "description": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+      "markdownDescription": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "ActionType": {
-      "markdownDescription": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "title": "Control Action",
       "description": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "Control Action"
-    },
-    "Layers": {
-      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
-      "anyOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "type": "throttle",
-                  "axisDown": "leftTrigger",
-                  "axisUp": "rightTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "title": "Touch Layout Layers"
-    },
-    "DeadzoneRadial": {
-      "markdownDescription": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "description": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "title": "Radial"
+      "markdownDescription": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "$ref": "#/$defs/_ActionTypeBase"
     },
     "ArcadeButton": {
-      "markdownDescription": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "enabled": {
-              "$ref": "#/$defs/ControlEnabled"
-            },
-            "visible": {
-              "$ref": "#/$defs/ControlVisibility"
-            },
-            "styles": {
-              "$ref": "#/$defs/ArcadeButtonStyles"
-            },
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
       "description": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
+      "markdownDescription": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
       "examples": [
         {
           "action": "gamepadX",
@@ -4931,64 +1851,993 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ]
-    },
-    "JoystickMovingStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+      ],
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
+            "action": {
+              "$ref": "#/$defs/ActionType"
             },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
             },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "action"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+      ]
+    },
+    "ArcadeButtonStyleBase": {
       "examples": [
-        {},
         {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
           "background": {
             "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyle"
+          "$ref": "#/definitions/commonArcadeButtonStyle"
         }
       ],
-      "title": "Control Moving Style"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "Control Disabled Style",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "Asset Reference Styling Component",
+      "description": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
+      "markdownDescription": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "Axis Cap Styling Component",
+      "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+      "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "Axis Cap Styling Component",
+              "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+              "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "Two Dimensional Axis Mapping",
+      "description": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "markdownDescription": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "Three Dimensional Axis Mapping",
+      "description": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "markdownDescription": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "Background Styling Component",
+      "description": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+      "markdownDescription": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "Control Activated Style",
+      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "Control Default Style",
+      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "Control Disabled Style",
+      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "Control Idle Style",
+      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
+      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "Control Toggled Style",
+      "description": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
+      "markdownDescription": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "Control Pulled Style",
+      "description": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+      "markdownDescription": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "Color",
+      "description": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "markdownDescription": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "Default Colors",
+      "description": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "High Contrast Colors",
+      "description": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "Touch Layout Control",
+      "description": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
+      "markdownDescription": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "Enabled",
+      "description": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
+      "markdownDescription": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "Touch Layout Control Group",
+      "description": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
+      "markdownDescription": "A set of 1 to 4 controls arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "Touch Layout Control Group Item",
+      "description": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+      "markdownDescription": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "Gamepad Action",
+      "description": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
+      "markdownDescription": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "Visible",
+      "description": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+      "markdownDescription": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "One Dimensional Deadzone",
+      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
+      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "Two Dimensional Deadzone",
+      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
+      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "Directional Pad Deadzone",
+      "description": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
+      "markdownDescription": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "Threshold",
+      "description": "The normalized, input value needed in order to produce output values.",
+      "markdownDescription": "The normalized, input value needed in order to produce output values.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "Radial",
+      "description": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
+      "markdownDescription": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "Interaction",
+      "description": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
+      "markdownDescription": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "DirectionalPadInteractionActivationType": {
+      "title": "Activation Type",
+      "description": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
       "markdownDescription": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
       "anyOf": [
         {
           "type": "string",
@@ -5000,319 +2849,458 @@
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "title": "Activation Type"
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
       ]
     },
-    "_FaceImageAsset": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "A custom asset used as the foreground graphic for the control component.",
-          "type": "string",
-          "description": "A custom asset used as the foreground graphic for the control component.",
-          "title": "Face Image Asset Styling Component"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      },
-      "type": "object",
+    "DirectionalPadStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
       "examples": [
         {},
         {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "properties": {
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "additionalProperties": false
-    },
-    "TurboActionInterval": {
-      "examples": [
-        500,
-        1000
-      ],
-      "title": "Interval",
-      "description": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
-      "exclusiveMinimum": 0,
-      "markdownDescription": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
-      "type": "number"
-    },
-    "_ControlTypeJoystick": {
-      "const": "joystick",
-      "markdownDescription": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
-      "type": "string",
-      "description": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
-      "title": "Joystick Control Type"
-    },
-    "JoystickDisabledStyle": {
-      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
+          "default": {
             "stroke": {
               "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
               "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "Control Disabled Style"
-    },
-    "Opacity": {
-      "markdownDescription": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "maximum": 1,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "title": "Opacity"
-    },
-    "_ControlTypeArcadeButtons": {
-      "const": "arcadeButtons",
-      "markdownDescription": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
-      "type": "string",
-      "description": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
-      "title": "Arcade Buttons Control Type"
-    },
-    "_Touchpad": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "axis": [
-            {
-              "output": "relativeMouse",
-              "input": "axisXY"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
             }
           }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
         }
       ],
-      "properties": {
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerUpperContent": {
-      "markdownDescription": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "Expand",
+      "description": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
+      "markdownDescription": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
       "examples": [
+        true,
+        false,
         {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
         }
       ],
-      "title": "Upper Layer Content"
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "Face Image Styling Component",
+      "description": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+      "markdownDescription": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "Face Image Icon Label Styling Component",
+      "description": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
+      "markdownDescription": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "Face Image Icon",
+      "description": "This property is used to select which built-in icon to use for this component.",
+      "markdownDescription": "This property is used to select which built-in icon to use for this component.",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "Fill",
+      "description": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "markdownDescription": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "Gradient",
+      "description": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
+      "markdownDescription": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "Indicator Styling Component",
+      "description": "The visual styling for the stroke used to indicate the current value or placement of the control.",
+      "markdownDescription": "The visual styling for the stroke used to indicate the current value or placement of the control.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "Inner",
+      "description": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
+      "markdownDescription": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "Inner",
+      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "InputCurveRange": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Input Curve Range",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
       "examples": [
         [
           0,
@@ -5334,63 +3322,1480 @@
           }
         ]
       ],
-      "title": "[DEPRECATED] Input Curve Range",
-      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
       "anyOf": [
         {
           "items": {
             "anyOf": [
               {
+                "type": "number",
                 "minimum": -1,
-                "maximum": 1,
-                "type": "number"
+                "maximum": 1
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
-          "type": "array",
           "maxItems": 2,
-          "minItems": 2
+          "minItems": 2,
+          "type": "array"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1."
-    },
-    "_ActionTypeBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          },
-          "type": "array"
-        }
-      ],
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
       ]
     },
-    "_ControllerAction": {
-      "anyOf": [
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Input Response Curve",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
+      "examples": [
         {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
         },
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Input Response Curve Type",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "Control Activated Style",
+      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "Control Default Style",
+      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "Direction Indicator Styling Component",
+      "description": "The visual styling for an indicator of the direction of the interaction",
+      "markdownDescription": "The visual styling for an indicator of the direction of the interaction",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "Property used to specify that the direction indicator is of color type whose value can be customized.",
+              "markdownDescription": "Property used to specify that the direction indicator is of color type whose value can be customized.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "Control Disabled Style",
+      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "Control Idle Style",
+      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "Control Moving Style",
+      "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+      "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "Outline Styling Component",
+      "description": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+      "markdownDescription": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "Outline Styling Component",
+      "description": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
+      "markdownDescription": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "Knob Styling Component",
+      "description": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
+      "markdownDescription": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "Touch Layout Layers",
+      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "Touch Layout Layers",
+      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "Touch Layout Layer Control",
+      "description": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
+      "markdownDescription": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "Touch Layout Layer Control Group",
+      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "Touch Layout Layer Control Group Item",
+      "description": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
+      "markdownDescription": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "Touch Layout Layer Control Wheel",
+      "description": "A set of layer controls organized in a circle or wheel shape.",
+      "markdownDescription": "A set of layer controls organized in a circle or wheel shape.",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "Lower Layer Array Content",
+      "description": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "Lower Layer Content",
+      "description": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "Sensors Layer Content",
+      "description": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "Upper Layer Content",
+      "description": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "Upper Layer Right Content",
+      "description": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "Layout Action Target",
+      "description": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
+      "markdownDescription": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "Colors",
+      "description": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "Layout Content",
+      "description": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
+      "markdownDescription": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "Touch Layout Control Wheel",
+      "description": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
+      "markdownDescription": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Layout Orientation",
+      "description": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
+      "markdownDescription": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "Lower Layout Array Content",
+      "description": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "Lower Layout Content",
+      "description": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
+      "markdownDescription": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "Sensors Layout Content",
+      "description": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
+      "markdownDescription": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "Layout Styles",
+      "description": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "markdownDescription": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "Upper Layout Content",
+      "description": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
+      "markdownDescription": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "Upper Right Layout Content",
+      "description": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
+      "markdownDescription": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "Opacity",
+      "description": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
+      "markdownDescription": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "Outer",
+      "description": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
+      "markdownDescription": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "Outer",
+      "description": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
+      "markdownDescription": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
         }
       ]
     },
@@ -5406,31 +4811,626 @@
           "$ref": "#/$defs/_Null"
         }
       ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "Control Pull Action",
+      "description": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "markdownDescription": "This property allows either a single action or array of actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "PullIndicator": {
+      "title": "Pull Indicator Styling Component",
+      "description": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
+      "markdownDescription": "The visual styling for the indicator that control is currently being pulled. The color of this can be customized to indicate the semantics of pulling the control.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "Background Styling Component",
+      "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+      "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "Relative",
+      "description": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
+      "markdownDescription": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "Render As Button",
+      "description": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
+      "markdownDescription": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "Scale",
+      "description": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
+      "markdownDescription": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "Sensitivity",
+      "description": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
+      "markdownDescription": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "Sensor Control",
+      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
+      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "Layer Sensor Control",
+      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "Sticky",
+      "description": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
+      "markdownDescription": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "Stroke Styling Component",
+      "description": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
+      "markdownDescription": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "Throttle Axis",
+      "description": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+      "markdownDescription": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "Throttle Axis Styling Component",
+      "description": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+      "markdownDescription": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "Control Activated Up Style",
+              "description": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
+              "markdownDescription": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "Control Activated Down Style",
+              "description": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
+              "markdownDescription": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "Control Disabled Style",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "Control Idle Up Style",
+              "description": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
+              "markdownDescription": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "Toggle",
+      "description": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
+      "markdownDescription": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "Control Disabled Style",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "Control Moving Style",
+              "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+              "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "Interval",
+      "description": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
+      "markdownDescription": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
     }
   },
-  "description": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
   "properties": {
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
+    "$schema": {
+      "type": "string"
     },
     "content": {
       "$ref": "#/$defs/LayoutContent"
     },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
     "styles": {
       "$ref": "#/$defs/LayoutStyles"
     },
-    "$schema": {
-      "type": "string"
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
     }
   },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "required": [
     "content"
   ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
-  "title": "Touch Adaptation Bundle Layout Schema",
-  "markdownDescription": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases."
+  "type": "object"
 }

--- a/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json
@@ -1,155 +1,9 @@
 {
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
-      "markdownDescription": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
-      "required": [
-        "path"
-      ],
-      "title": "Touch Adaptation Bundle Context File Configuration",
-      "properties": {
-        "path": {
-          "markdownDescription": "This property defines the relative path from this file to the context file.",
-          "description": "This property defines the relative path from this file to the context file.",
-          "title": "Touch Adaptation Bundle Context File Path",
-          "examples": [
-            "./context.json"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "versionName": {
-      "description": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "title": "Touch Adaptation Bundle Version Name",
-      "examples": [
-        "DLC 2"
-      ],
-      "type": "string",
-      "markdownDescription": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion."
-    },
-    "assets": {
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
-      "markdownDescription": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
-      "required": [
-        "path"
-      ],
-      "title": "Touch Adaptation Bundle Assets Configuration",
-      "properties": {
-        "path": {
-          "markdownDescription": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
-          "description": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
-          "title": "Touch Adaptation Bundle Assets Path",
-          "examples": [
-            "./assets"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "languages": {
-      "markdownDescription": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "description": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
-      "title": "Touch Adaptation Bundle Languages Configuration",
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "type": "array"
-    },
-    "version": {
-      "markdownDescription": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "description": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "title": "Touch Adaptation Bundle Version",
-      "examples": [
-        "1.0.0.0"
-      ],
-      "type": "string"
-    },
-    "layouts": {
-      "examples": [
-        {
-          "path": "./layouts"
-        },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
-      "markdownDescription": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
-      "required": [
-        "path"
-      ],
-      "title": "Touch Adaptation Bundle Layouts Configuration",
-      "properties": {
-        "default": {
-          "description": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
-          "title": "Touch Adaptation Bundle Default Layout",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "type": "string",
-          "markdownDescription": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used."
-        },
-        "path": {
-          "markdownDescription": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
-          "description": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
-          "title": "Touch Adaptation Bundle Layouts Path",
-          "examples": [
-            "./layouts"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    }
-  },
-  "title": "Touch Adaptation Bundle Configuration File Schema",
-  "description": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
-  "markdownDescription": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v4.0/takxconfig.json",
+  "type": "object",
   "$defs": {
     "LanguageItem": {
+      "markdownDescription": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports.",
       "description": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports.",
       "enum": [
         "ar",
@@ -213,9 +67,155 @@
         "zh-CN",
         "zh-TW"
       ],
-      "title": "IETF Language Tag",
-      "markdownDescription": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports."
+      "title": "IETF Language Tag"
     }
   },
-  "type": "object"
+  "description": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+  "properties": {
+    "versionName": {
+      "markdownDescription": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+      "type": "string",
+      "description": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+      "examples": [
+        "DLC 2"
+      ],
+      "title": "Touch Adaptation Bundle Version Name"
+    },
+    "layouts": {
+      "type": "object",
+      "markdownDescription": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
+      "properties": {
+        "default": {
+          "markdownDescription": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
+          "type": "string",
+          "description": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
+          "examples": [
+            "cinematic",
+            "menu",
+            "firstPerson"
+          ],
+          "title": "Touch Adaptation Bundle Default Layout"
+        },
+        "path": {
+          "examples": [
+            "./layouts"
+          ],
+          "title": "Touch Adaptation Bundle Layouts Path",
+          "format": "uri-reference",
+          "description": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
+          "markdownDescription": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
+          "type": "string"
+        }
+      },
+      "description": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
+      "examples": [
+        {
+          "path": "./layouts"
+        },
+        {
+          "default": "cinematic",
+          "path": "./layouts"
+        }
+      ],
+      "title": "Touch Adaptation Bundle Layouts Configuration",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "version": {
+      "examples": [
+        "1.0.0.0"
+      ],
+      "title": "Touch Adaptation Bundle Version",
+      "description": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
+      "markdownDescription": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+      "type": "string"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "context": {
+      "type": "object",
+      "markdownDescription": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
+      "properties": {
+        "path": {
+          "examples": [
+            "./context.json"
+          ],
+          "title": "Touch Adaptation Bundle Context File Path",
+          "format": "uri-reference",
+          "description": "This property defines the relative path from this file to the context file.",
+          "markdownDescription": "This property defines the relative path from this file to the context file.",
+          "type": "string"
+        }
+      },
+      "description": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
+      "examples": [
+        {
+          "path": "./context.json"
+        }
+      ],
+      "title": "Touch Adaptation Bundle Context File Configuration",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "languages": {
+      "examples": [
+        [],
+        [
+          "en-US"
+        ],
+        [
+          "en",
+          "fr-FR"
+        ]
+      ],
+      "title": "Touch Adaptation Bundle Languages Configuration",
+      "description": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
+      "items": {
+        "$ref": "#/$defs/LanguageItem"
+      },
+      "markdownDescription": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
+      "type": "array"
+    },
+    "assets": {
+      "type": "object",
+      "markdownDescription": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
+      "properties": {
+        "path": {
+          "examples": [
+            "./assets"
+          ],
+          "title": "Touch Adaptation Bundle Assets Path",
+          "format": "uri-reference",
+          "description": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
+          "markdownDescription": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
+          "type": "string"
+        }
+      },
+      "description": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
+      "examples": [
+        {
+          "path": "./assets"
+        }
+      ],
+      "title": "Touch Adaptation Bundle Assets Configuration",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "layouts",
+    "version"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+  "title": "Touch Adaptation Bundle Configuration File Schema",
+  "markdownDescription": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases."
 }

--- a/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json
@@ -1,221 +1,221 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "LanguageItem": {
-      "markdownDescription": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports.",
-      "description": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports.",
-      "enum": [
-        "ar",
-        "ar-SA",
-        "cs",
-        "cs-CZ",
-        "da",
-        "da-DK",
-        "de",
-        "de-DE",
-        "el",
-        "el-GR",
-        "en",
-        "en-US",
-        "en-GB",
-        "es",
-        "es-ES",
-        "es-MX",
-        "fi",
-        "fi-FI",
-        "fil",
-        "fil-PH",
-        "fr",
-        "fr-FR",
-        "he",
-        "he-IL",
-        "hu",
-        "hu-HU",
-        "id",
-        "id-ID",
-        "it",
-        "it-IT",
-        "ja",
-        "ja-JP",
-        "ko",
-        "ko-KR",
-        "ms",
-        "ms-MY",
-        "nb",
-        "nb-NO",
-        "nl",
-        "nl-NL",
-        "pl",
-        "pl-PL",
-        "pt",
-        "pt-BR",
-        "pt-PT",
-        "ru",
-        "ru-RU",
-        "sk",
-        "sk-SK",
-        "sv",
-        "sv-SE",
-        "th",
-        "th-TH",
-        "tr",
-        "tr-TR",
-        "vi",
-        "vi-VN",
-        "zh",
-        "zh-CN",
-        "zh-TW"
-      ],
-      "title": "IETF Language Tag"
-    }
-  },
-  "description": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
-  "properties": {
-    "versionName": {
-      "markdownDescription": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "type": "string",
-      "description": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "examples": [
-        "DLC 2"
-      ],
-      "title": "Touch Adaptation Bundle Version Name"
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Touch Adaptation Bundle Configuration File Schema",
+    "description": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+    "markdownDescription": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+    "$defs": {
+        "LanguageItem": {
+            "title": "IETF Language Tag",
+            "description": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports.",
+            "markdownDescription": "A single language tag that defines a language, in addition to the neutral language, that the bundle supports.",
+            "enum": [
+                "ar",
+                "ar-SA",
+                "cs",
+                "cs-CZ",
+                "da",
+                "da-DK",
+                "de",
+                "de-DE",
+                "el",
+                "el-GR",
+                "en",
+                "en-US",
+                "en-GB",
+                "es",
+                "es-ES",
+                "es-MX",
+                "fi",
+                "fi-FI",
+                "fil",
+                "fil-PH",
+                "fr",
+                "fr-FR",
+                "he",
+                "he-IL",
+                "hu",
+                "hu-HU",
+                "id",
+                "id-ID",
+                "it",
+                "it-IT",
+                "ja",
+                "ja-JP",
+                "ko",
+                "ko-KR",
+                "ms",
+                "ms-MY",
+                "nb",
+                "nb-NO",
+                "nl",
+                "nl-NL",
+                "pl",
+                "pl-PL",
+                "pt",
+                "pt-BR",
+                "pt-PT",
+                "ru",
+                "ru-RU",
+                "sk",
+                "sk-SK",
+                "sv",
+                "sv-SE",
+                "th",
+                "th-TH",
+                "tr",
+                "tr-TR",
+                "vi",
+                "vi-VN",
+                "zh",
+                "zh-CN",
+                "zh-TW"
+            ]
+        }
     },
-    "layouts": {
-      "type": "object",
-      "markdownDescription": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
-      "properties": {
-        "default": {
-          "markdownDescription": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
-          "type": "string",
-          "description": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "title": "Touch Adaptation Bundle Default Layout"
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
         },
-        "path": {
-          "examples": [
-            "./layouts"
-          ],
-          "title": "Touch Adaptation Bundle Layouts Path",
-          "format": "uri-reference",
-          "description": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
-          "markdownDescription": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
-          "type": "string"
-        }
-      },
-      "description": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
-      "examples": [
-        {
-          "path": "./layouts"
+        "layouts": {
+            "title": "Touch Adaptation Bundle Layouts Configuration",
+            "description": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
+            "markdownDescription": "This property defines bundle properties related to layout files, like where on disk layout files are located and which layout file should be used as the default layout.",
+            "examples": [
+                {
+                    "path": "./layouts"
+                },
+                {
+                    "path": "./layouts",
+                    "default": "cinematic"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "Touch Adaptation Bundle Layouts Path",
+                    "description": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
+                    "markdownDescription": "This property defines the relative path from this file to the directory containing all the layouts for this bundle.",
+                    "examples": [
+                        "./layouts"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "default": {
+                    "title": "Touch Adaptation Bundle Default Layout",
+                    "description": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
+                    "markdownDescription": "This property defines the starting active layout of the touch bundle. To specify the default layout, use the name of the layout file without the file extension. The active layout may be later changed via the api calls described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient. If omitted, no starting layout will be used.",
+                    "examples": [
+                        "cinematic",
+                        "menu",
+                        "firstPerson"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ]
         },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
+        "assets": {
+            "title": "Touch Adaptation Bundle Assets Configuration",
+            "description": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
+            "markdownDescription": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
+            "examples": [
+                {
+                    "path": "./assets"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "Touch Adaptation Bundle Assets Path",
+                    "description": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
+                    "markdownDescription": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
+                    "examples": [
+                        "./assets"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "context": {
+            "title": "Touch Adaptation Bundle Context File Configuration",
+            "description": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
+            "markdownDescription": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
+            "examples": [
+                {
+                    "path": "./context.json"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "Touch Adaptation Bundle Context File Path",
+                    "description": "This property defines the relative path from this file to the context file.",
+                    "markdownDescription": "This property defines the relative path from this file to the context file.",
+                    "examples": [
+                        "./context.json"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "languages": {
+            "title": "Touch Adaptation Bundle Languages Configuration",
+            "description": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
+            "markdownDescription": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
+            "examples": [
+                [],
+                [
+                    "en-US"
+                ],
+                [
+                    "en",
+                    "fr-FR"
+                ]
+            ],
+            "items": {
+                "$ref": "#/$defs/LanguageItem"
+            },
+            "type": "array"
+        },
+        "version": {
+            "title": "Touch Adaptation Bundle Version",
+            "description": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+            "markdownDescription": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+            "examples": [
+                "1.0.0.0"
+            ],
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+        },
+        "versionName": {
+            "title": "Touch Adaptation Bundle Version Name",
+            "description": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+            "markdownDescription": "This property defines a descriptive name that represents this version of the touch bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
+            "examples": [
+                "DLC 2"
+            ],
+            "type": "string"
         }
-      ],
-      "title": "Touch Adaptation Bundle Layouts Configuration",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
     },
-    "version": {
-      "examples": [
-        "1.0.0.0"
-      ],
-      "title": "Touch Adaptation Bundle Version",
-      "description": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "markdownDescription": "This property defines the version number of the touch bundle. While the version is composed of major, minor, build, and revision components, these particular semantics are not interpreted by the touch bundle runtime. Instead, the highest versioned bundle that the runtime is capable of loading will be used. A bundle's ability to be loaded is determined by the max layout schema version used within the bundle. This property can be queried via the apis described at https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion.",
-      "type": "string"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "type": "object",
-      "markdownDescription": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
-      "properties": {
-        "path": {
-          "examples": [
-            "./context.json"
-          ],
-          "title": "Touch Adaptation Bundle Context File Path",
-          "format": "uri-reference",
-          "description": "This property defines the relative path from this file to the context file.",
-          "markdownDescription": "This property defines the relative path from this file to the context file.",
-          "type": "string"
-        }
-      },
-      "description": "This property defines bundle properties related to the context file, like where on disk the file is located. If omitted, the bundle will not contain a context file.",
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "title": "Touch Adaptation Bundle Context File Configuration",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    },
-    "languages": {
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "title": "Touch Adaptation Bundle Languages Configuration",
-      "description": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "markdownDescription": "This property defines bundle properties related to the supported languages for the bundle. If omitted, the bundle will support all inferred languages from the directory structure of the layouts and assets folders. A neutral language is always included in the bundle regardless of this property's value.",
-      "type": "array"
-    },
-    "assets": {
-      "type": "object",
-      "markdownDescription": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
-      "properties": {
-        "path": {
-          "examples": [
-            "./assets"
-          ],
-          "title": "Touch Adaptation Bundle Assets Path",
-          "format": "uri-reference",
-          "description": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
-          "markdownDescription": "This property defines the relative path from this file to the directory containing all the assets, like image files, for this bundle.",
-          "type": "string"
-        }
-      },
-      "description": "This property defines bundle properties related to asset files, like where on disk asset files are located.",
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "title": "Touch Adaptation Bundle Assets Configuration",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
-  "title": "Touch Adaptation Bundle Configuration File Schema",
-  "markdownDescription": "A touch adaptation bundle configuration file (i.e. `takxconfig.json`) is the file that acts as the project file for the bundle and defines all of the bundle metadata and properties in a reusable, consistent manner. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases."
+    "additionalProperties": false,
+    "required": [
+      "layouts",
+      "version"
+    ]
 }

--- a/touch-adaptation-kit/schemas/zh-CN/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/zh-CN/context/v4.0/context.json
@@ -1,163 +1,163 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "AllowedStateValues": {
-      "examples": [
-        {},
-        {
-          "inventorySlotForegroundImage": [
-            "InventoryForegroundFireballSpell",
-            "InventoryForegroundLightningBoltSpell"
-          ],
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          }
-        }
-      ],
-      "title": "触摸捆绑包允许的状态值",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/StateType"
-              }
-            },
-            {
-              "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
-            }
-          ]
-        }
-      },
-      "description": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
-      "type": "object",
-      "markdownDescription": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
-      "additionalProperties": false
-    },
-    "State": {
-      "examples": [
-        {},
-        {
-          "inventorySlotBackgroundImage": "InventoryBackground",
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground"
-        }
-      ],
-      "title": "触摸捆绑包状态",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "description": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
-      "type": "object",
-      "markdownDescription": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
-      "additionalProperties": false
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/$defs/joystickAssetName"
-                  }
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "触摸适配捆绑包上下文架构",
+    "description": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+    "markdownDescription": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "触摸捆绑包允许的状态值",
+            "description": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
+            "markdownDescription": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
                 }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/v4.0/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "可定义类型",
+            "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+            "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "定义",
+            "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+            "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "触摸捆绑包状态",
+            "description": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
+            "markdownDescription": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "触摸捆绑包状态项",
+            "description": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
+            "markdownDescription": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "样式",
+            "description": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+            "markdownDescription": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+            "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles"
         }
-      ],
-      "title": "定义",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/ContextDefinableType"
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
         }
-      },
-      "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
-      "type": "object",
-      "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
-      "additionalProperties": false
     },
-    "StateType": {
-      "markdownDescription": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "description": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "title": "触摸捆绑包状态项"
-    },
-    "ContextDefinableType": {
-      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
-      "title": "可定义类型"
-    },
-    "ContextStyles": {
-      "markdownDescription": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
-      "description": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "title": "样式"
-    }
-  },
-  "description": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
-  "properties": {
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    },
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "$schema": {
-      "type": "string"
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
-  "title": "触摸适配捆绑包上下文架构",
-  "markdownDescription": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。"
+    "additionalProperties": false
 }

--- a/touch-adaptation-kit/schemas/zh-CN/context/v4.0/context.json
+++ b/touch-adaptation-kit/schemas/zh-CN/context/v4.0/context.json
@@ -1,116 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "allowedStateValues": {
-      "$ref": "#/$defs/AllowedStateValues"
-    },
-    "state": {
-      "$ref": "#/$defs/State"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "styles": {
-      "$ref": "#/$defs/ContextStyles"
-    }
-  },
-  "title": "触摸适配捆绑包上下文架构",
-  "description": "触控适应捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
-  "markdownDescription": "触控适应捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "type": "object",
   "$defs": {
-    "State": {
-      "markdownDescription": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
-      "additionalProperties": false,
-      "description": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
-      "title": "触摸捆绑包状态",
-      "examples": [
-        {},
-        {
-          "inventorySlotEnabled": true,
-          "inventorySlotForegroundImage": "InventoryForeground",
-          "inventorySlotBackgroundImage": "InventoryBackground"
-        }
-      ],
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/StateType"
-        }
-      },
-      "type": "object"
-    },
-    "StateType": {
-      "description": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        }
-      ],
-      "title": "触摸捆绑包状态项",
-      "examples": [
-        "customAssetName",
-        false,
-        true,
-        1,
-        0
-      ],
-      "markdownDescription": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。"
-    },
-    "ContextStyles": {
-      "description": "此属性定义可重用样式，可在此触控适配捆绑包的布局中引用这些样式以用于样式。如果在给定布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
-      "title": "风格",
-      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
-      "markdownDescription": "此属性定义可重用样式，可在此触控适配捆绑包的布局中引用这些样式以用于样式。如果在给定布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。"
-    },
-    "ContextDefinableType": {
-      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
-      "anyOf": [
-        {
-          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
-        },
-        {
-          "$ref": "#/$defs/StateType"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/StateType"
-          }
-        }
-      ],
-      "title": "可定义类型",
-      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分"
-    },
     "AllowedStateValues": {
-      "markdownDescription": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
-      "additionalProperties": false,
-      "description": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
-      "title": "触摸捆绑包允许的状态值",
       "examples": [
         {},
         {
-          "inventorySlotBackgroundImage": {
-            "$ref": "#/definitions/AllowedBackgroundImages"
-          },
           "inventorySlotForegroundImage": [
             "InventoryForegroundFireballSpell",
             "InventoryForegroundLightningBoltSpell"
-          ]
+          ],
+          "inventorySlotBackgroundImage": {
+            "$ref": "#/definitions/AllowedBackgroundImages"
+          }
         }
       ],
+      "title": "触摸捆绑包允许的状态值",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "anyOf": [
@@ -126,13 +31,32 @@
           ]
         }
       },
-      "type": "object"
+      "description": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
+      "type": "object",
+      "markdownDescription": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
+      "additionalProperties": false
+    },
+    "State": {
+      "examples": [
+        {},
+        {
+          "inventorySlotBackgroundImage": "InventoryBackground",
+          "inventorySlotEnabled": true,
+          "inventorySlotForegroundImage": "InventoryForeground"
+        }
+      ],
+      "title": "触摸捆绑包状态",
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/StateType"
+        }
+      },
+      "description": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
+      "type": "object",
+      "markdownDescription": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
+      "additionalProperties": false
     },
     "Definitions": {
-      "markdownDescription": "可用于包含触控布局的可重用组件和值的节。以后可以使用 “{ ”$ref“ 之类的JSON引用来引用这些定义： ”#/definitions/joystickKnobStyle“ }”。几乎布局架构的每个部分都支持JSON引用，这些部分使通用元素（如在多个控件中使用的常用按钮背景）得到因式分解和重用。请注意，上下文文件还支持`definitions`属性以及`state`跨布局重复使用组件。",
-      "additionalProperties": false,
-      "description": "可用于包含触控布局的可重用组件和值的节。以后可以使用 “{ ”$ref“ 之类的JSON引用来引用这些定义： ”#/definitions/joystickKnobStyle“ }”。几乎布局架构的每个部分都支持JSON引用，这些部分使通用元素（如在多个控件中使用的常用按钮背景）得到因式分解和重用。请注意，上下文文件还支持`definitions`属性以及`state`跨布局重复使用组件。",
-      "title": "定义",
       "examples": [
         {},
         {
@@ -151,13 +75,89 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "定义",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/ContextDefinableType"
         }
       },
-      "type": "object"
+      "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "type": "object",
+      "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "additionalProperties": false
+    },
+    "StateType": {
+      "markdownDescription": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ],
+      "description": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
+      "examples": [
+        "customAssetName",
+        false,
+        true,
+        1,
+        0
+      ],
+      "title": "触摸捆绑包状态项"
+    },
+    "ContextDefinableType": {
+      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "anyOf": [
+        {
+          "$ref": "../../layout/v4.0/layout.json#/$defs/LayoutDefinableType"
+        },
+        {
+          "$ref": "#/$defs/StateType"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StateType"
+          }
+        }
+      ],
+      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "title": "可定义类型"
+    },
+    "ContextStyles": {
+      "markdownDescription": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "description": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "$ref": "../../layout/v4.0/layout.json#/$defs/_LayoutStyles",
+      "title": "样式"
     }
   },
-  "type": "object"
+  "description": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+  "properties": {
+    "state": {
+      "$ref": "#/$defs/State"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/ContextStyles"
+    },
+    "allowedStateValues": {
+      "$ref": "#/$defs/AllowedStateValues"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.0/context.json",
+  "title": "触摸适配捆绑包上下文架构",
+  "markdownDescription": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。"
 }

--- a/touch-adaptation-kit/schemas/zh-CN/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/zh-CN/layout/v4.0/layout.json
@@ -1,32 +1,2268 @@
 {
-  "required": [
-    "content"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "styles": {
-      "$ref": "#/$defs/LayoutStyles"
-    },
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
-    "content": {
-      "$ref": "#/$defs/LayoutContent"
-    }
-  },
-  "title": "触摸适配捆绑包布局架构",
-  "description": "触控适应捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
-  "markdownDescription": "触控适应捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "type": "object",
   "$defs": {
+    "_StrokeBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "solid",
+              "markdownDescription": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
+              "type": "string",
+              "description": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "color": "#0099ff",
+          "type": "solid",
+          "opacity": 1
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "markdownDescription": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
+      "description": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "内容主系统颜色替代"
+    },
+    "_ControlTypeDirectionalPad": {
+      "const": "directionalPad",
+      "markdownDescription": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
+      "type": "string",
+      "description": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
+      "title": "方向盘控件类型"
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JoystickDirectionIndicator": {
+      "markdownDescription": "指示交互方向的视觉样式",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
+              "type": "string",
+              "description": "用于指定方向指示器是可以自定义其值的颜色类型的属性。"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "指示交互方向的视觉样式",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "title": "方向指示器样式设置组件"
+    },
+    "LayerSensorContent": {
+      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "title": "传感器层内容"
+    },
+    "Background": {
+      "markdownDescription": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+      "title": "背景样式组件"
+    },
+    "_Accelerometer": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "const": "accelerometer",
+          "markdownDescription": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
+          "type": "string",
+          "description": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
+          "title": "加速计控件类型"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "SensorControl": {
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "传感器控件",
+      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_Null": {
+      "markdownDescription": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
+      "type": "null",
+      "description": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
+      "examples": [
+        null
+      ],
+      "title": "Null"
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "markdownDescription": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
+      "type": "string",
+      "description": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "title": "游戏手柄模拟游戏杆输出"
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "PullIndicator": {
+      "markdownDescription": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "title": "拉动指示器样式组件"
+    },
+    "_SystemColorAccentPrimary": {
+      "markdownDescription": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
+      "description": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "重置主要系统颜色强调"
+    },
+    "Scale": {
+      "markdownDescription": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
+      "anyOf": [
+        {
+          "minimum": 0.5,
+          "maximum": 2,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "title": "扩展"
+    },
+    "JoystickIdleStyle": {
+      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "控制空闲样式"
+    },
+    "_AxisMapping2DItem": {
+      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "rightTrigger",
+          "input": "axisUp"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "二维轴映射项"
+    },
+    "TouchpadStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "控制空闲样式"
+    },
+    "_LayoutStyles": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "colors": {
+            "highContrast": {
+              "myColor": "#00ff00ff",
+              "system_contentPrimary": "#ffffffff"
+            },
+            "default": {
+              "myColor": "#ff0000ff",
+              "system_contentPrimary": "#ffffffff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "markdownDescription": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
+      "anyOf": [
+        {
+          "exclusiveMaximum": 1,
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "title": "方向板死区"
+    },
+    "Sticky": {
+      "markdownDescription": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "title": "精华"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayoutContent": {
+      "markdownDescription": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "output": "leftJoystick",
+                  "input": "axisXY"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "布局内容"
+    },
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "format": "uri-reference",
+          "markdownDescription": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
+          "type": "string",
+          "description": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerControlWheel": {
+      "markdownDescription": "一组以圆圈或滚轮形状组织的层控件。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "一组以圆圈或滚轮形状组织的层控件。",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "title": "触摸布局层控制轮"
+    },
+    "_SystemColorAccentSecondary": {
+      "markdownDescription": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
+      "description": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "重音次要系统颜色覆盖"
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "markdownDescription": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "控件切换样式"
+    },
+    "LayoutLowerArrayContent": {
+      "markdownDescription": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "title": "下层布局数组内容"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "examples": [
+        {
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "title": "二维轴映射"
+    },
+    "ThrottleAxisOutput": {
+      "markdownDescription": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "title": "限制轴"
+    },
+    "ColorPaletteDefaultVariant": {
+      "markdownDescription": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "description": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "默认颜色"
+    },
+    "Deadzone1D": {
+      "markdownDescription": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "一维死区"
+    },
+    "JoystickOutlineWithIndicator": {
+      "markdownDescription": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "title": "大纲样式组件"
+    },
+    "_ControllerButtonOutputType": {
+      "markdownDescription": "输出按下的游戏手柄按钮。",
+      "type": "string",
+      "description": "输出按下的游戏手柄按钮。",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "title": "游戏手柄按钮输出"
+    },
+    "ButtonActivatedStyle": {
+      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "控件激活样式"
+    },
+    "JoystickStyles": {
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "title": "控件样式"
+    },
+    "ButtonDisabledStyle": {
+      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "控件禁用样式"
+    },
+    "LayoutActionTarget": {
+      "markdownDescription": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "title": "布局操作目标"
+    },
+    "_ControlTypeButton": {
+      "const": "button",
+      "markdownDescription": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
+      "type": "string",
+      "description": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
+      "title": "按钮控件类型"
+    },
+    "_ControllerAnalog1DOutputType": {
+      "markdownDescription": "沿指定游戏手柄游戏杆轴的整个输出值。",
+      "type": "string",
+      "description": "沿指定游戏手柄游戏杆轴的整个输出值。",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "title": "游戏手柄模拟游戏杆输出"
+    },
+    "_LayoutAction": {
+      "type": "object",
+      "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "const": "layer",
+          "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
+          "type": "string",
+          "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
+          "title": "布局操作"
+        }
+      },
+      "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "title": "布局操作",
+      "required": [
+        "type",
+        "target"
+      ],
+      "additionalProperties": false
+    },
+    "InnerLayoutControlWheel": {
+      "markdownDescription": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "output": "leftJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "title": "内部"
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_ControllerTriggerOutputType": {
+      "markdownDescription": "输出映射到指定游戏手柄触发器的值。",
+      "type": "string",
+      "description": "输出映射到指定游戏手柄触发器的值。",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "title": "游戏手柄模拟触发器输出"
+    },
+    "DirectionalPadStyles": {
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "控制空闲样式"
+            },
+            "disabled": {
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle",
+              "title": "控件激活样式"
+            },
+            "activated": {
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "控件激活样式"
+            },
+            "default": {
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle",
+              "title": "控件默认样式"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "gradient": {
+              "color": "#0099ffaa"
+            },
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "title": "控件样式"
+    },
+    "Indicator": {
+      "markdownDescription": "用于指示控件的当前值或位置的笔划的视觉样式。",
+      "description": "用于指示控件的当前值或位置的笔划的视觉样式。",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "指示器样式组件"
+    },
+    "Stroke": {
+      "markdownDescription": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
+      "description": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
+      "$ref": "#/$defs/_StrokeBase",
+      "title": "笔划样式组件"
+    },
+    "Gradient": {
+      "markdownDescription": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "title": "渐变"
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "title": "游戏手柄操作"
+    },
+    "_DirectionalPad": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_TurboAction": {
+      "title": "Turbo 操作",
+      "properties": {
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "const": "turbo",
+          "markdownDescription": "根据时间间隔而不是连续触发的操作。",
+          "type": "string",
+          "description": "根据时间间隔而不是连续触发的操作。",
+          "title": "Turbo 操作"
+        },
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        }
+      },
+      "description": "根据时间间隔而不是连续触发的操作。",
+      "type": "object",
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "markdownDescription": "根据时间间隔而不是连续触发的操作。",
+      "additionalProperties": false
+    },
+    "ControlGroup": {
+      "markdownDescription": "租中排列的一组 1 到 4 个控件。系统确定如何在可用空间内最佳地排列组中的控件；只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "租中排列的一组 1 到 4 个控件。系统确定如何在可用空间内最佳地排列组中的控件；只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "title": "触摸布局控制组"
+    },
+    "_SystemColorContrastPrimary": {
+      "markdownDescription": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
+      "description": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "对比度主系统颜色替代"
+    },
+    "ControlGroupItem": {
+      "markdownDescription": "控制组中的单个项。使用`null`跳过排列中的控件。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控制组中的单个项。使用`null`跳过排列中的控件。",
+      "title": "触摸布局控件组项"
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionThreshold": {
+      "markdownDescription": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "title": "操作阈值"
+    },
+    "ArcadeButtonStyles": {
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "控制空闲样式"
+            },
+            "disabled": {
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "控件禁用样式"
+            },
+            "activated": {
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "控件激活样式"
+            },
+            "default": {
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase",
+              "title": "控件默认样式"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "activated": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            }
+          },
+          "default": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "title": "控件样式"
+    },
+    "_BackgroundAsset": {
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "用于设置背景样式的自定义资产。",
+          "type": "string",
+          "description": "用于设置背景样式的自定义资产。"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_FaceImageIcon": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        "type": {
+          "const": "icon",
+          "markdownDescription": "用作控件组件的前景图形的内置图标。",
+          "type": "string",
+          "description": "用作控件组件的前景图形的内置图标。",
+          "title": "人脸图像图标样式组件"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "markdownDescription": "此属性用于选择要用于此组件的内置图标。",
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性用于选择要用于此组件的内置图标。",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "title": "人脸图像图标"
+    },
+    "Toggle": {
+      "markdownDescription": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "title": "切换"
+    },
+    "ArcadeButtonStyleBase": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ]
+    },
+    "_ControlTypeTouchpad": {
+      "const": "touchpad",
+      "markdownDescription": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
+      "type": "string",
+      "description": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
+      "title": "触摸板控件类型"
+    },
+    "ThrottleStyles": {
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控件默认样式"
+            },
+            "idleUp": {
+              "markdownDescription": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
+              "description": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控制空闲向上样式"
+            },
+            "activatedDown": {
+              "markdownDescription": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
+              "description": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控件已激活向下样式"
+            },
+            "disabled": {
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控件禁用样式"
+            },
+            "activatedUp": {
+              "markdownDescription": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
+              "description": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控件已激活向上样式"
+            },
+            "idle": {
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控制空闲样式"
+            },
+            "activated": {
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/ThrottleStyleBase",
+              "title": "控件激活样式"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "axisDown": {
+              "stroke": {
+                "color": "#0099ff",
+                "type": "solid",
+                "opacity": 1
+              },
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              }
+            },
+            "knob": {
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              },
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "title": "控件样式"
+    },
+    "SensorLayerControl": {
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "title": "层传感器控件",
+      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "_SystemColorActionColor": {
+      "markdownDescription": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
+      "description": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "操作系统颜色替代"
+    },
+    "LayoutSensorContent": {
+      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "output": "rightJoystick",
+              "input": "axisXY"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "title": "传感器布局内容"
+    },
+    "LayoutColors": {
+      "markdownDescription": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            },
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
+      "examples": [
+        {},
+        {
+          "highContrast": {
+            "myColor": "#00ff00ff",
+            "system_contentPrimary": "#ffffffff"
+          },
+          "default": {
+            "myColor": "#ff0000ff",
+            "system_contentPrimary": "#ffffffff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "title": "颜色"
+    },
+    "LayoutUpperContent": {
+      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "title": "上层布局内容"
+    },
+    "_Color": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ]
+    },
     "DirectionalPadDefaultStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
       "examples": [
         {},
         {
@@ -42,39 +2278,855 @@
         {
           "$ref": "#/definitions/commonDPadStyle"
         }
-      ],
+      ]
+    },
+    "RelativeInteraction": {
+      "markdownDescription": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "type": "boolean"
         },
         {
           "$ref": "#/$defs/Reference"
         }
+      ],
+      "description": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "title": "亲属"
+    },
+    "ButtonPulledStyle": {
+      "markdownDescription": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "控件拉取样式"
+    },
+    "InputCurveType": {
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "title": "[已弃用]输入响应曲线类型",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。",
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。"
+    },
+    "ThrottleAxisStyle": {
+      "markdownDescription": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+      "examples": [
+        {
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          },
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        }
+      ],
+      "title": "限制轴样式组件"
+    },
+    "ButtonDefaultStyle": {
+      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "title": "控件默认样式"
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FillColor": {
+      "markdownDescription": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "description": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "$ref": "#/$defs/_Color",
+      "title": "填充"
+    },
+    "PullIndicatorBackground": {
+      "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "title": "背景样式组件"
+    },
+    "_Button": {
+      "type": "object",
+      "required": [
+        "type",
+        "action"
+      ],
+      "examples": [
+        {
+          "type": "button",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          },
+          "action": "gamepadA"
+        }
+      ],
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DirectionalPadInteraction": {
+      "markdownDescription": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "title": "交互"
+    },
+    "ButtonStyles": {
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "title": "控件样式"
+    },
+    "_CustomColorPaletteColor": {
+      "markdownDescription": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
+      "description": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "自定义布局颜色"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "markdownDescription": "生成输出值所需的规范化输入值。",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "生成输出值所需的规范化输入值。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "title": "阈值"
+    },
+    "_SystemColorContrastSecondary": {
+      "markdownDescription": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
+      "description": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "对比度辅助系统颜色替代"
+    },
+    "_SystemColorGamepadActionColor": {
+      "markdownDescription": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
+      "description": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "游戏手柄操作系统颜色替代"
+    },
+    "AssetReference": {
+      "markdownDescription": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "title": "资产引用样式组件"
+    },
+    "FaceImage": {
+      "markdownDescription": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "title": "人脸图像样式设置组件"
+    },
+    "_ControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ],
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      }
+    },
+    "JoystickActivatedStyle": {
+      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "控件激活样式"
+    },
+    "LayoutLowerContent": {
+      "markdownDescription": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "title": "下层布局内容"
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ControlVisibility": {
+      "markdownDescription": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "可见"
+    },
+    "LayerLowerArrayContent": {
+      "markdownDescription": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "title": "下层数组内容"
+    },
+    "OuterLayoutControlWheel": {
+      "markdownDescription": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "title": "外部​​"
+    },
+    "ControlEnabled": {
+      "markdownDescription": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "title": "已启用"
+    },
+    "ExpandInteraction": {
+      "markdownDescription": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "title": "展开"
+    },
+    "Deadzone2D": {
+      "markdownDescription": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            },
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
+      "examples": [
+        {
+          "threshold": 0,
+          "radial": true
+        },
+        {
+          "threshold": 0.1,
+          "radial": false
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "title": "二维死区"
+    },
+    "_ColorPaletteColor": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ]
+    },
+    "_InputAxisZY": {
+      "const": "axisZY",
+      "markdownDescription": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "type": "string",
+      "description": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "title": "Z 轴和 Y 轴输入映射"
+    },
+    "DirectionalPadIdleStyle": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "examples": [
+        {},
+        {
+          "gradient": {
+            "color": "#0099ffaa"
+          },
+          "stroke": {
+            "color": "#0099ff",
+            "type": "solid",
+            "opacity": 1
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
       ]
     },
     "Definitions": {
-      "markdownDescription": "可用于包含触控布局的可重用组件和值的节。以后可以使用 “{ ”$ref“ 之类的JSON引用来引用这些定义： ”#/definitions/joystickKnobStyle“ }”。几乎布局架构的每个部分都支持JSON引用，这些部分使通用元素（如在多个控件中使用的常用按钮背景）得到因式分解和重用。请注意，上下文文件还支持`definitions`属性以及`state`跨布局重复使用组件。",
-      "additionalProperties": false,
-      "description": "可用于包含触控布局的可重用组件和值的节。以后可以使用 “{ ”$ref“ 之类的JSON引用来引用这些定义： ”#/definitions/joystickKnobStyle“ }”。几乎布局架构的每个部分都支持JSON引用，这些部分使通用元素（如在多个控件中使用的常用按钮背景）得到因式分解和重用。请注意，上下文文件还支持`definitions`属性以及`state`跨布局重复使用组件。",
-      "title": "定义",
       "examples": [
         {},
         {
@@ -93,95 +3145,184 @@
           "joystickAssetName": "exampleAssetName"
         }
       ],
+      "title": "定义",
       "patternProperties": {
         "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/$defs/LayoutDefinableType"
         }
       },
-      "type": "object"
+      "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "type": "object",
+      "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "additionalProperties": false
     },
-    "_InputAxisXY": {
-      "description": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-      "title": "X 轴和 Y 轴输入映射",
+    "_SystemColorContentSecondary": {
+      "markdownDescription": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
+      "description": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor",
+      "title": "内容辅助系统颜色替代"
+    },
+    "Color": {
+      "markdownDescription": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "description": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "$ref": "#/$defs/_Color",
+      "title": "颜色"
+    },
+    "_RelativeMouse1DOutputType": {
+      "markdownDescription": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
       "type": "string",
-      "const": "axisXY",
-      "markdownDescription": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。"
-    },
-    "LayerControlGroupItem": {
-      "description": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层()隐藏控件。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+      "description": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "title": "触摸布局层控制组项",
+      "title": "相对鼠标一维输出"
+    },
+    "_ArcadeButtons": {
+      "type": "object",
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
       "examples": [
         {
-          "$ref": "#/definitions/commonLayerButtonControl"
+          "type": "arcadeButtons",
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          }
         }
       ],
-      "markdownDescription": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层()隐藏控件。"
+      "properties": {
+        "specialPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "特殊拳击按钮"
+        },
+        "heavyPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "重踢按钮"
+        },
+        "lightPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "轻拳按键"
+        },
+        "lightKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "轻踢按钮"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        },
+        "mediumKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "中等力度踢按钮"
+        },
+        "specialKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "特殊踢出按钮"
+        },
+        "heavyKick": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "重踢按钮"
+        },
+        "mediumPunch": {
+          "$ref": "#/$defs/ArcadeButton",
+          "title": "中等拳击按钮"
+        }
+      },
+      "additionalProperties": false
     },
-    "Indicator": {
-      "description": "用于指示控件的当前值或位置的笔划的视觉样式。",
-      "title": "指示器样式组件",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "用于指示控件的当前值或位置的笔划的视觉样式。"
-    },
-    "FaceImage": {
-      "description": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+    "OuterLayerControlWheel": {
+      "markdownDescription": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "type": "array",
+          "maxItems": 8,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "人脸图像样式组件",
+      "description": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
       "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
         {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
+          "$ref": "#/definitions/commonLayerOuterWheel"
         }
       ],
-      "markdownDescription": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。"
+      "title": "外部​​"
     },
-    "ControlGroupItem": {
-      "description": "控制组中的单个项。使用`null`跳过排列中的控件。",
+    "_InputMapping3DTo2DOutput": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControlBase"
+          "$ref": "#/$defs/_InputMappingXY"
         },
         {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_InputMappingZY"
         }
-      ],
-      "title": "触摸布局控件组项",
-      "markdownDescription": "控制组中的单个项。使用`null`跳过排列中的控件。"
+      ]
+    },
+    "_ControlTypeThrottle": {
+      "const": "throttle",
+      "markdownDescription": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
+      "type": "string",
+      "description": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
+      "title": "限制控件类型"
     },
     "LayoutOrientation": {
-      "markdownDescription": "⚠️ 已弃用： 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
-      "deprecated": true,
+      "title": "[已弃用]布局方向",
+      "description": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
       "enum": [
         "landscape-left",
         "landscape-right",
@@ -189,202 +3330,291 @@
         "portrait-up",
         "portrait"
       ],
-      "description": "⚠️ 已弃用： 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
-      "title": "[已弃用]布局方向",
+      "deprecated": true,
+      "markdownDescription": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
       "type": "string"
     },
-    "PullIndicator": {
-      "description": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
             }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          ]
         },
-        {
-          "$ref": "#/$defs/Reference"
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
         }
-      ],
-      "title": "拉动指示器样式组件",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "markdownDescription": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。"
+      },
+      "additionalProperties": false
     },
-    "_ActionTypeBase": {
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          }
-        }
-      ]
-    },
-    "_CustomColorPaletteColor": {
-      "description": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
-      "title": "自定义布局颜色",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。"
-    },
-    "ColorPaletteHighContrastVariant": {
-      "description": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
-      "title": "高对比度色",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。"
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "description": "沿指定的游戏板游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "游戏板模拟游戏杆输出",
+    "_InputAxisXY": {
+      "const": "axisXY",
+      "markdownDescription": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
       "type": "string",
-      "markdownDescription": "沿指定的游戏板游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。"
+      "description": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "title": "X 轴和 Y 轴输入映射"
     },
-    "JoystickStyles": {
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+    "PullActionType": {
+      "markdownDescription": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "description": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "控制拉取操作"
+    },
+    "Knob": {
+      "markdownDescription": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
             },
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
             },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
+            "background": {
+              "$ref": "#/$defs/Background"
             },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "控件样式",
+      "description": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
       "examples": [
-        {},
         {
-          "default": {
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyles"
+          "$ref": "#/definitions/commonControlKnobStyling"
         }
       ],
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。"
+      "title": "Knob 样式设置组件"
     },
-    "_InputMappingZY": {
+    "Control": {
+      "markdownDescription": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+          "$ref": "#/$defs/_ControlBase"
         },
         {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
-    },
-    "LayerControlGroup": {
+      ],
+      "description": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
       "examples": [
-        [],
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "title": "触摸布局控件"
+    },
+    "LayerUpperRightContent": {
+      "markdownDescription": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
+      "examples": [
         [
-          null,
           {
             "type": "blank"
           },
-          null
-        ]
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
       ],
-      "description": "一组 1 到 4 层控件，包括`blank`控件，用于隐藏下层()下层的控件，排列在一个组中。系统确定如何在可用空间内最佳地排列组中的控件;只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过索引。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
-      "minItems": 1,
-      "title": "触摸布局层控制组",
-      "markdownDescription": "一组 1 到 4 层控件，包括`blank`控件，用于隐藏下层()下层的控件，排列在一个组中。系统确定如何在可用空间内最佳地排列组中的控件;只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过索引。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      },
-      "maxItems": 4
+      "title": "上层右侧内容"
     },
-    "ThrottleAxisOutput": {
-      "description": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+    "AxisCapColor": {
+      "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "type": {
+              "const": "color",
+              "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+              "type": "string",
+              "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+              "title": "坐标轴样式组件"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "限制轴",
+      "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
       "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
         {
-          "$ref": "#/definitions/commonThrottleAxis"
+          "type": "color",
+          "value": "#0099ffaa"
         }
       ],
-      "markdownDescription": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。"
+      "title": "坐标轴样式组件"
+    },
+    "_Throttle": {
+      "type": "object",
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "examples": [
+        {
+          "sticky": true,
+          "type": "throttle",
+          "axisDown": "leftTrigger",
+          "axisUp": "rightTrigger"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_Blank": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "properties": {
+        "type": {
+          "const": "blank",
+          "markdownDescription": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
+          "type": "string",
+          "description": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
+          "title": "空白控件类型"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RenderAsButton": {
+      "markdownDescription": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "title": "呈现为按钮"
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
     },
     "_InputMappingXYToMouse2DOutput": {
+      "type": "object",
+      "required": [
+        "input",
+        "output"
+      ],
       "properties": {
         "sensitivity": {
           "$ref": "#/$defs/Sensitivity"
@@ -396,374 +3626,444 @@
           "$ref": "#/$defs/_InputAxisXY"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": false
+    },
+    "ColorPaletteHighContrastVariant": {
+      "markdownDescription": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "description": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "$ref": "#/$defs/_ColorPaletteBase",
+      "title": "高对比度颜色"
+    },
+    "LayoutStyles": {
+      "markdownDescription": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "description": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "$ref": "#/$defs/_LayoutStyles",
+      "title": "布局样式"
+    },
+    "LayerControlGroup": {
+      "type": "array",
+      "markdownDescription": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
+      "minItems": 1,
+      "description": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "maxItems": 4,
+      "title": "触摸布局层控制组",
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      }
+    },
+    "_BackgroundColor": {
       "type": "object",
       "required": [
-        "input",
-        "output"
-      ]
+        "type",
+        "value"
+      ],
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "type": {
+          "const": "color",
+          "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+          "type": "string",
+          "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
     },
     "_Gyroscope": {
-      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "output": "rightJoystick",
+            "input": "axisXY"
+          }
+        }
+      ],
       "properties": {
         "axis": {
           "$ref": "#/$defs/AxisMapping3D"
         },
         "type": {
-          "description": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
-          "title": "陀螺仪控制类型",
-          "type": "string",
           "const": "gyroscope",
-          "markdownDescription": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。"
+          "markdownDescription": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
+          "type": "string",
+          "description": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
+          "title": "陀螺仪控件类型"
         },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         }
       },
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "input": "axisXY",
-            "output": "rightJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
+      "additionalProperties": false
     },
-    "LayerLowerArrayContent": {
-      "description": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方()层隐藏控件。",
+    "FaceImageIconLabel": {
+      "markdownDescription": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
       "anyOf": [
         {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "下层数组内容",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方()层隐藏控件。"
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "_SystemColorContrastSecondary": {
-      "description": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
-      "title": "对比度辅助系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。"
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "description": "此属性允许控件在处于`activated`状态时执行单个游戏板操作或游戏板操作数组。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "游戏板操作",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个游戏板操作或游戏板操作数组。"
-    },
-    "_Color": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ExpandInteraction": {
-      "description": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 “false”，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值 `true`。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "展开",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "markdownDescription": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 “false”，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值 `true`。"
-    },
-    "ControlEnabled": {
-      "description": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值 `true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "已启用",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "markdownDescription": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值 `true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。"
-    },
-    "_ControlTypeButton": {
-      "description": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
-      "title": "按钮控件类型",
-      "type": "string",
-      "const": "button",
-      "markdownDescription": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。"
-    },
-    "PullIndicatorBackground": {
-      "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "背景样式组件",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。"
-    },
-    "PullActionType": {
-      "description": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏板输入或更复杂的操作，例如在布局上显示新层。",
-      "title": "控制拉取操作",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏板输入或更复杂的操作，例如在布局上显示新层。"
-    },
-    "ControlGroup": {
-      "markdownDescription": "一组 1 到 4 个控件排列在一个组中。系统确定如何在可用空间内最佳地排列组中的控件;只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
-      "items": {
-        "$ref": "#/$defs/ControlGroupItem"
-      },
-      "description": "一组 1 到 4 个控件排列在一个组中。系统确定如何在可用空间内最佳地排列组中的控件;只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
-      "title": "触摸布局控制组",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
           },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerSensorContent": {
-      "description": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方)层(隐藏或关闭传感器控件。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "传感器层内容",
+      "description": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
       "examples": [
-        [
-          {
-            "type": "blank"
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "title": "人脸图像图标标签样式组件"
+    },
+    "TouchpadStyles": {
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "idle": {
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "控制空闲样式"
+            },
+            "disabled": {
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "控件禁用样式"
+            },
+            "activated": {
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "控件激活样式"
+            },
+            "moving": {
+              "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+              "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "控件移动样式"
+            },
+            "default": {
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/TouchpadStyleBase",
+              "title": "控件默认样式"
+            }
           },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
             }
           }
-        ],
+        },
         {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
+          "$ref": "#/definitions/commonTouchpadControlStyles"
         }
       ],
-      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方)层(隐藏或关闭传感器控件。"
+      "title": "控件样式"
     },
-    "ButtonActivatedStyle": {
-      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+    "Layer": {
+      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
       "anyOf": [
         {
+          "type": "object",
+          "properties": {
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "sticky": true,
+                "type": "throttle",
+                "axisDown": "leftTrigger",
+                "axisUp": "rightTrigger"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "title": "触摸布局层"
+    },
+    "LayerControlGroupItem": {
+      "markdownDescription": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "title": "触摸布局层控件组项"
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "markdownDescription": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "title": "右上角布局内容"
+    },
+    "JoystickDefaultStyle": {
+      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
             },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
             "opacity": {
               "$ref": "#/$defs/Opacity"
             },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "控件激活样式",
+      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
       "examples": [
         {},
         {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
           }
         },
         {
-          "$ref": "#/definitions/commonButtonStyle"
+          "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
+      "title": "控件默认样式"
     },
-    "_InputMapping1DToGamepad1DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
+    "_ControllerAnalog2DOutputType": {
+      "markdownDescription": "沿两个游戏手柄游戏杆轴的整个输出值。",
+      "type": "string",
+      "description": "沿两个游戏手柄游戏杆轴的整个输出值。",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "title": "游戏手柄模拟游戏杆输出"
+    },
+    "LayerLowerContent": {
+      "markdownDescription": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "additionalProperties": false
         },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
+        {
+          "$ref": "#/$defs/Reference"
         }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
+      ],
+      "description": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "title": "下层内容"
     },
     "LayoutDefinableType": {
-      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -1078,731 +4378,42 @@
           "$ref": "#/$defs/TouchpadStyles"
         }
       ],
-      "title": "可定义类型",
-      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分"
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_TurboAction": {
-      "markdownDescription": "根据时间间隔而不是连续触发的操作。",
-      "description": "根据时间间隔而不是连续触发的操作。",
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        },
-        "type": {
-          "description": "根据时间间隔而不是连续触发的操作。",
-          "title": "Turbo 操作",
-          "type": "string",
-          "const": "turbo",
-          "markdownDescription": "根据时间间隔而不是连续触发的操作。"
-        },
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        }
-      },
-      "title": "Turbo 操作",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "type": "object"
-    },
-    "_ArcadeButtons": {
-      "additionalProperties": false,
-      "properties": {
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "中等孔按钮"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "粗踢出按钮"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "粗踢出按钮"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "浅色踢出按钮"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "特殊踢出按钮"
-        },
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "特殊打孔按钮"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "浅色打孔按钮"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "中等踢出按钮"
-        }
-      },
-      "examples": [
-        {
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "type": "arcadeButtons",
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ]
-    },
-    "Opacity": {
-      "description": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "type": "number",
-          "maximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "不透明度",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "markdownDescription": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。"
-    },
-    "LayoutColors": {
-      "description": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            },
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "颜色",
-      "examples": [
-        {},
-        {
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "markdownDescription": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。"
-    },
-    "_ControllerTriggerOutputType": {
-      "description": "输出映射到指定游戏板触发器的值。",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "游戏板模拟触发器输出",
-      "type": "string",
-      "markdownDescription": "输出映射到指定游戏板触发器的值。"
-    },
-    "ButtonDefaultStyle": {
-      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件默认样式",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。"
-    },
-    "_ControlTypeDirectionalPad": {
-      "description": "方向板控件模仿在物理游戏板上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
-      "title": "方向板控件类型",
-      "type": "string",
-      "const": "directionalPad",
-      "markdownDescription": "方向板控件模仿在物理游戏板上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。"
-    },
-    "_ControlTypeTouchpad": {
-      "description": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
-      "title": "触摸板控件类型",
-      "type": "string",
-      "const": "touchpad",
-      "markdownDescription": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。"
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "DirectionalPadInteraction": {
-      "description": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
-      "anyOf": [
-        {
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "互动",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "markdownDescription": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。"
-    },
-    "_ControllerAction": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        }
-      ]
-    },
-    "LayerControl": {
-      "description": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层()的任何控件。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "触摸布局层控件",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "markdownDescription": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层()的任何控件。"
-    },
-    "AxisMapping3D": {
-      "description": "此属性定义从玩家与控件的三维模拟交互到一个或二维输出的映射或一组映射。对于三维交互，如设备传感器，坐标空间始终相对于游戏的视频。换言之，正 X 方向在视频右侧，正 Y 方向位于视频顶部，正 Z 方向超出了视频对播放器的方向。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "三维轴映射",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "此属性定义从玩家与控件的三维模拟交互到一个或二维输出的映射或一组映射。对于三维交互，如设备传感器，坐标空间始终相对于游戏的视频。换言之，正 X 方向在视频右侧，正 Y 方向位于视频顶部，正 Z 方向超出了视频对播放器的方向。"
-    },
-    "ActionType": {
-      "description": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏板输入或更复杂的操作，例如在布局上显示新层。",
-      "title": "控制操作",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏板输入或更复杂的操作，例如在布局上显示新层。"
-    },
-    "InputCurveType": {
-      "markdownDescription": "⚠️ 已弃用： 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。一种`circular`可用于映射具有圆圈右下象限形状的圆曲线的输入。值 `circular-inverse` 可用于映射具有与圆的左上象限形状匹配的圆曲线的输入。",
-      "deprecated": true,
-      "description": "⚠️ 已弃用： 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。一种`circular`可用于映射具有圆圈右下象限形状的圆曲线的输入。值 `circular-inverse` 可用于映射具有与圆的左上象限形状匹配的圆曲线的输入。",
-      "title": "[已弃用]输入响应曲线类型",
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ColorPaletteColor": {
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "TouchpadStyles": {
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "title": "控件默认样式",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。"
-            },
-            "idle": {
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "title": "控件空闲样式",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。"
-            },
-            "disabled": {
-              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "title": "禁用控件的样式",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。"
-            },
-            "activated": {
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "title": "控件激活样式",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
-            },
-            "moving": {
-              "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
-              "title": "控件移动样式",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件样式",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。"
-    },
-    "ButtonIdleStyle": {
-      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件空闲样式",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。"
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "additionalProperties": false,
-      "properties": {
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "examples": [
-        {},
-        {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "type": "object",
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      }
-    },
-    "Control": {
-      "description": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "触摸布局控件",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "markdownDescription": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。"
-    },
-    "_ControllerButtonOutputType": {
-      "description": "按下游戏板按钮输出。",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "游戏板按钮输出",
-      "type": "string",
-      "markdownDescription": "按下游戏板按钮输出。"
-    },
-    "ButtonToggledStyle": {
-      "description": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件切换样式",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。"
-    },
-    "_RelativeMouse2DOutputType": {
-      "description": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
-      "title": "相对鼠标二维输出",
-      "type": "string",
-      "const": "relativeMouse",
-      "markdownDescription": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。"
-    },
-    "_ControlTypeArcadeButtons": {
-      "description": "街机按钮控件。此控件是根据常见的 6 或 8 按钮街机柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
-      "title": "街机按钮控件类型",
-      "type": "string",
-      "const": "arcadeButtons",
-      "markdownDescription": "街机按钮控件。此控件是根据常见的 6 或 8 按钮街机柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。"
+      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "title": "可定义类型"
     },
     "LayoutControlWheel": {
-      "description": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
+      "markdownDescription": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            },
             "inner": {
               "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "触摸布局控制滚轮",
+      "description": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
       "examples": [
         {},
         {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "output": "leftJoystick",
+                "input": "axisXY"
+              }
+            }
+          ],
           "outer": [
             null,
             [
@@ -1815,818 +4426,148 @@
               "type": "button",
               "action": "gamepadY"
             }
-          ],
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "input": "axisXY",
-                "output": "leftJoystick"
-              }
-            }
           ]
         },
         {
           "$ref": "#/definitions/commonControlWheel"
         }
       ],
-      "markdownDescription": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。"
+      "title": "触摸布局控制轮"
     },
-    "Reference": {
-      "additionalProperties": false,
-      "properties": {
-        "$ref": {
-          "description": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
-          "exmaples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ],
-          "type": "string",
-          "format": "uri-reference",
-          "markdownDescription": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。"
-        }
-      },
-      "type": "object",
-      "required": [
-        "$ref"
-      ]
-    },
-    "LayerUpperRightContent": {
-      "description": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此(在此区域下方)层中的控件。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "上层右侧内容",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "markdownDescription": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此(在此区域下方)层中的控件。"
-    },
-    "LayoutStyles": {
-      "description": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
-      "title": "布局样式",
-      "$ref": "#/$defs/_LayoutStyles",
-      "markdownDescription": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。"
-    },
-    "OuterWheelControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Control"
-        },
-        {
-          "$ref": "#/$defs/ControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonStyles": {
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "properties": {
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件样式",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。"
-    },
-    "JoystickMovingStyle": {
-      "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件移动样式",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。"
-    },
-    "LayoutActionTarget": {
-      "description": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "布局操作目标",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "markdownDescription": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。"
-    },
-    "DirectionalPadStyles": {
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "title": "控件默认样式",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。"
-            },
-            "idle": {
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则“默认”样式配置中提供的值将与完全透明的渐变一起使用，以显示控件处于空闲状态且未与之交互。",
-              "title": "控件空闲样式",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则“默认”样式配置中提供的值将与完全透明的渐变一起使用，以显示控件处于空闲状态且未与之交互。"
-            },
-            "disabled": {
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "title": "控件激活样式",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
-            },
-            "activated": {
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "title": "控件激活样式",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件样式",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。"
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "AssetReference": {
-      "description": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "资产引用样式组件",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "markdownDescription": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。"
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "description": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气量、制动器等时显示精确的自定义。",
-      "title": "限制控件类型",
+    "_RelativeMouse2DOutputType": {
+      "const": "relativeMouse",
+      "markdownDescription": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
       "type": "string",
-      "const": "throttle",
-      "markdownDescription": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气量、制动器等时显示精确的自定义。"
+      "description": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
+      "title": "相对鼠标二维输出"
     },
-    "_Null": {
-      "description": "这是一个特殊值，可用于代替控件来跳过某个位置。这尤其在控件数组和层上可用于填充内容的位置。",
-      "title": "null",
-      "examples": [
-        null
-      ],
-      "type": "null",
-      "markdownDescription": "这是一个特殊值，可用于代替控件来跳过某个位置。这尤其在控件数组和层上可用于填充内容的位置。"
-    },
-    "_SystemColorAccentPrimary": {
-      "description": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
-      "title": "重音主要系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。"
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "ArcadeButtonStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ],
+    "LayerControl": {
+      "markdownDescription": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Deadzone2D": {
-      "description": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ]
+          "$ref": "#/$defs/_LayerControlBase"
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "二维死区",
+      "description": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
       "examples": [
         {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
+          "$ref": "#/definitions/commonLayerButtonControl"
         }
       ],
-      "markdownDescription": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。"
+      "title": "触摸布局层控件"
     },
-    "DirectionalPadIdleStyle": {
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "description": "此属性定义从玩家与控件的二维模拟交互到一个或两个维度输出的映射或一组映射。请注意，根据轴分配，控件的外观可能会更改。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          }
-        }
-      ],
-      "title": "二维轴映射",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisXY",
-          "output": "relativeMouse"
-        },
-        [
-          {
-            "input": "axisUp",
-            "output": "rightTrigger"
-          },
-          {
-            "input": "axisDown",
-            "output": "leftTrigger"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "此属性定义从玩家与控件的二维模拟交互到一个或两个维度输出的映射或一组映射。请注意，根据轴分配，控件的外观可能会更改。"
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "OuterLayerControlWheel": {
-      "description": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方)(层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "外",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方)(层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。"
-    },
-    "FillColor": {
-      "description": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照 `hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
-      "title": "填充",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照 `hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。"
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_InputAxisMagnitudinal": {
-      "description": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "坐标轴纵向输入映射",
-      "type": "string",
-      "markdownDescription": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。"
-    },
-    "_LayoutStyles": {
-      "examples": [
-        {},
-        {
-          "colors": {
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "description": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+    "Sensitivity": {
+      "markdownDescription": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
       "anyOf": [
         {
           "type": "number",
-          "minimum": 0
+          "exclusiveMinimum": 0
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "操作阈值",
+      "description": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
       "examples": [
-        1,
+        10,
         1.5,
-        0,
+        0.5,
         {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
         }
       ],
-      "markdownDescription": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。"
+      "title": "灵敏度"
     },
-    "ControlVisibility": {
-      "description": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值 `true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+    "InnerLayerControlWheel": {
+      "markdownDescription": "一组 1 到 4 层控件，包括`blank`控件，用于在下方层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
       "anyOf": [
         {
-          "type": "boolean"
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "可见",
+      "description": "一组 1 到 4 层控件，包括`blank`控件，用于在下方层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
       "examples": [
-        true,
-        false,
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
         {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "markdownDescription": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值 `true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。"
+      "title": "内部"
     },
-    "_BackgroundAsset": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "用于设置背景样式的自定义资产。",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "用于设置背景样式的自定义资产。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        }
-      },
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
+    "_Joystick": {
       "type": "object",
       "required": [
         "type",
-        "value"
-      ]
-    },
-    "Gradient": {
-      "description": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+        "axis"
       ],
-      "title": "梯度",
       "examples": [
         {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
+          "axis": {
+            "output": "leftJoystick",
+            "input": "axisXY"
+          },
+          "type": "joystick",
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
           }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
         }
       ],
-      "markdownDescription": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。"
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "additionalProperties": false
     },
     "InputCurve": {
-      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
-      "deprecated": true,
-      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
-      "title": "[已弃用]输入响应曲线",
       "examples": [
         {
           "type": "circular",
@@ -2646,8 +4587,15 @@
           "$ref": "#/$defs/commonJoystickResponseCurve"
         }
       ],
+      "title": "[已弃用]输入响应曲线",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
       "anyOf": [
         {
+          "type": "object",
+          "required": [
+            "range",
+            "type"
+          ],
           "properties": {
             "type": {
               "$ref": "#/$defs/InputCurveType"
@@ -2656,247 +4604,61 @@
               "$ref": "#/$defs/InputCurveRange"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayerLowerContent": {
-      "description": "此属性定义固定到可用显示空间的下边缘的层的内容。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方()层隐藏控件。",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "下层内容",
+      "deprecated": true,
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。"
+    },
+    "AxisMapping3D": {
+      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
       "examples": [
         {
-          "center": {
-            "type": "blank"
+          "sensitivity": 0.3,
+          "output": "rightJoystick",
+          "input": "axisXY"
+        },
+        {
+          "output": "relativeMouse",
+          "input": "axisXY"
+        },
+        [
+          {
+            "output": "rightTrigger",
+            "input": "axisUp"
+          },
+          {
+            "output": "leftTrigger",
+            "input": "axisDown"
           }
-        },
+        ],
         {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+          "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "此属性定义固定到可用显示空间的下边缘的层的内容。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方()层隐藏控件。"
-    },
-    "_InputAxis1D": {
-      "anyOf": [
-        {
-          "description": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-          "title": "X 轴输入映射",
-          "type": "string",
-          "const": "axisX",
-          "markdownDescription": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。"
-        },
-        {
-          "description": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-          "title": "Y 轴输入映射",
-          "type": "string",
-          "const": "axisY",
-          "markdownDescription": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。"
-        }
-      ]
-    },
-    "Toggle": {
-      "description": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "切换",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "markdownDescription": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。"
-    },
-    "_Joystick": {
-      "additionalProperties": false,
-      "properties": {
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeJoystick"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "styles": {
-          "$ref": "#/$defs/JoystickStyles"
-        },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          },
-          "type": "joystick",
-          "styles": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "icon",
-                  "value": "walk"
-                }
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "JoystickActivatedStyle": {
-      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件激活样式",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
-    },
-    "TouchpadStyleBase": {
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
+      "title": "三维轴映射"
     },
     "_RelativeMouseMagnitudinalOutputType": {
+      "markdownDescription": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
+      "type": "string",
       "description": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
       "enum": [
         "relativeMouseUp",
@@ -2904,39 +4666,60 @@
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "相对鼠标方向输出",
-      "type": "string",
-      "markdownDescription": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。"
+      "title": "相对鼠标方向输出"
     },
-    "JoystickOutlineWithIndicator": {
-      "description": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+    "_InputAxisMagnitudinal": {
+      "markdownDescription": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
+      "type": "string",
+      "description": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "title": "坐标轴输入映射"
+    },
+    "_InputAxis1D": {
       "anyOf": [
         {
+          "const": "axisX",
+          "markdownDescription": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "type": "string",
+          "description": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "title": "X 轴输入映射"
+        },
+        {
+          "const": "axisY",
+          "markdownDescription": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "type": "string",
+          "description": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "title": "Y 轴输入映射"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "markdownDescription": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
+      "anyOf": [
+        {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
             },
             "stroke": {
               "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "大纲样式组件",
+      "description": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
       "examples": [
         {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
           "stroke": {
             "type": "solid",
             "color": "#0099ffaa"
@@ -2946,158 +4729,15 @@
           "$ref": "#/definitions/commonOutlineStyling"
         }
       ],
-      "markdownDescription": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。"
-    },
-    "_ControlTypeJoystick": {
-      "description": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如有目标或射击。",
-      "title": "游戏杆控制类型",
-      "type": "string",
-      "const": "joystick",
-      "markdownDescription": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如有目标或射击。"
-    },
-    "ColorPaletteDefaultVariant": {
-      "description": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
-      "title": "默认颜色",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "markdownDescription": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。"
-    },
-    "InnerLayoutControlWheel": {
-      "description": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "内",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "input": "axisXY",
-              "output": "leftJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。"
-    },
-    "SensorControl": {
-      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ]
-        }
-      },
-      "title": "传感器控制",
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_BackgroundColor": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
-          "type": "string",
-          "const": "color",
-          "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/Color"
-        }
-      },
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
+      "title": "大纲样式组件"
     },
     "ThrottleStyleBase": {
-      "examples": [
-        {
-          "axisUp": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "axisDown": {
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          },
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          }
-        }
-      ],
       "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
+            "knob": {
+              "$ref": "#/$defs/Knob"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
@@ -3108,214 +4748,59 @@
             "axisDown": {
               "$ref": "#/$defs/ThrottleAxisStyle"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "Sticky": {
-      "description": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
-      "anyOf": [
-        {
-          "type": "boolean"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "精华",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "markdownDescription": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。"
-    },
-    "RenderAsButton": {
-      "description": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "呈现为按钮",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "markdownDescription": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。"
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "type": "string",
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ]
-        }
-      ]
-    },
-    "_Button": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
       "examples": [
         {
-          "action": "gamepadA",
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
+          "axisUp": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "axisDown": {
+            "stroke": {
+              "color": "#0099ff",
+              "type": "solid",
+              "opacity": 1
+            },
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
             }
           }
         }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "action"
       ]
-    },
-    "JoystickDirectionIndicator": {
-      "description": "指示交互方向的视觉样式",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "用于指定方向指示器是可以自定义其值的颜色类型的属性。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "方向指示器样式组件",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "markdownDescription": "指示交互方向的视觉样式"
-    },
-    "Color": {
-      "description": "此属性使用字符串表示形式定义颜色。颜色必须按照 `hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
-      "title": "颜色",
-      "$ref": "#/$defs/_Color",
-      "markdownDescription": "此属性使用字符串表示形式定义颜色。颜色必须按照 `hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。"
-    },
-    "OuterLayoutControlWheel": {
-      "description": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
-      "anyOf": [
-        {
-          "maxItems": 8,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Outer",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "markdownDescription": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。"
     },
     "_AxisMapping3DItem": {
-      "description": "此属性定义一个映射，从玩家与控件的三维模拟交互到一个或二维输出。对于三维交互，如设备传感器，坐标空间始终相对于游戏的视频。换言之，正 X 方向在视频右侧，正 Y 方向位于视频顶部，正 Z 方向超出了视频对播放器的方向。",
+      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
       "anyOf": [
         {
           "$ref": "#/$defs/_InputMapping3DTo2DOutput"
@@ -3324,7 +4809,7 @@
           "$ref": "#/$defs/_AxisMapping2DItem"
         }
       ],
-      "title": "三维轴映射项",
+      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
       "examples": [
         {
           "sensitivity": 0.3,
@@ -3332,43 +4817,85 @@
           "input": "axisXY"
         },
         {
-          "input": "axisUp",
-          "output": "rightTrigger"
+          "output": "rightTrigger",
+          "input": "axisUp"
         },
         {
           "$ref": "#/definitions/commonAxisMapping"
         }
       ],
-      "markdownDescription": "此属性定义一个映射，从玩家与控件的三维模拟交互到一个或二维输出。对于三维交互，如设备传感器，坐标空间始终相对于游戏的视频。换言之，正 X 方向在视频右侧，正 Y 方向位于视频顶部，正 Z 方向超出了视频对播放器的方向。"
+      "title": "三维轴映射项"
     },
-    "_RelativeMouse1DOutputType": {
-      "description": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "相对鼠标一维输出",
-      "type": "string",
-      "markdownDescription": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。"
+    "ActionType": {
+      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "description": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "$ref": "#/$defs/_ActionTypeBase",
+      "title": "控制操作"
     },
-    "_InputMapping1D": {
+    "Layers": {
+      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
       "anyOf": [
         {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+          "type": "object",
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          },
+          "additionalProperties": false
         },
         {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+          "$ref": "#/$defs/Reference"
         }
-      ]
+      ],
+      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "sticky": true,
+                  "type": "throttle",
+                  "axisDown": "leftTrigger",
+                  "axisUp": "rightTrigger"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "title": "触摸布局层"
     },
-    "ArcadeButton": {
-      "description": "`arcadeButtons`控件类型上的单个按钮。此按钮是“button”控件类型的简化版本，可在街机按钮排列中正常工作。",
+    "DeadzoneRadial": {
+      "markdownDescription": "是否沿径向输入组件或每个轴单独计算死区阈值。",
       "anyOf": [
         {
+          "type": "boolean"
+        }
+      ],
+      "description": "是否沿径向输入组件或每个轴单独计算死区阈值。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "title": "径向"
+    },
+    "ArcadeButton": {
+      "markdownDescription": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "action"
+          ],
           "properties": {
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            },
             "enabled": {
               "$ref": "#/$defs/ControlEnabled"
             },
@@ -3377,18 +4904,18 @@
             },
             "styles": {
               "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "action": {
+              "$ref": "#/$defs/ActionType"
             }
           },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "action"
-          ]
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
+      "description": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
       "examples": [
         {
           "action": "gamepadX",
@@ -3404,277 +4931,13 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ],
-      "markdownDescription": "`arcadeButtons`控件类型上的单个按钮。此按钮是“button”控件类型的简化版本，可在街机按钮排列中正常工作。"
-    },
-    "Deadzone1D": {
-      "description": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果省略，则不使用任何死区。",
-      "anyOf": [
-        {
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "threshold"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "一维死区",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "markdownDescription": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果省略，则不使用任何死区。"
-    },
-    "Layer": {
-      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
-      "anyOf": [
-        {
-          "properties": {
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "$ref": "#/$defs/LayerControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "触摸布局层",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "axisUp": "rightTrigger",
-                "type": "throttle",
-                "axisDown": "leftTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。"
-    },
-    "LayerControlWheel": {
-      "description": "以圆圈或滚轮形状组织起来的一组图层控件。",
-      "anyOf": [
-        {
-          "properties": {
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            },
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "触摸布局层控制滚轮",
-      "examples": [
-        {
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "markdownDescription": "以圆圈或滚轮形状组织起来的一组图层控件。"
-    },
-    "_Accelerometer": {
-      "additionalProperties": false,
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "description": "加速计控件。此控件允许从设备的运动，特别是其加速转换到游戏输入。",
-          "title": "加速计控制类型",
-          "type": "string",
-          "const": "accelerometer",
-          "markdownDescription": "加速计控件。此控件允许从设备的运动，特别是其加速转换到游戏输入。"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "input": "axisXY",
-            "output": "leftJoystick"
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
       ]
     },
-    "ButtonPulledStyle": {
-      "description": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+    "JoystickMovingStyle": {
+      "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
       "anyOf": [
         {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件拉取样式",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。"
-    },
-    "Scale": {
-      "description": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "type": "number",
-          "maximum": 2
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "扩展",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "markdownDescription": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。"
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "description": "控件轮廓的视觉样式。在控件正在交互的其他状态下，此属性还可以包括设置指示器的交互方向样式的能力。",
-      "anyOf": [
-        {
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Outline Styling Component",
-      "examples": [
-        {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "markdownDescription": "控件轮廓的视觉样式。在控件正在交互的其他状态下，此属性还可以包括设置指示器的交互方向样式的能力。"
-    },
-    "JoystickDefaultStyle": {
-      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-      "anyOf": [
-        {
+          "type": "object",
           "properties": {
             "background": {
               "$ref": "#/$defs/Background"
@@ -3689,29 +4952,28 @@
               "$ref": "#/$defs/Knob"
             }
           },
-          "additionalProperties": false,
-          "type": "object"
+          "additionalProperties": false
         },
         {
           "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "控件默认样式",
+      "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
       "examples": [
         {},
         {
           "knob": {
-            "background": {
+            "faceImage": {
               "type": "asset",
-              "value": "CustomKnobBackgroundImage"
+              "value": "CustomKnobFaceImage"
             },
             "stroke": {
               "type": "solid",
               "color": "#0099ffaa"
             },
-            "faceImage": {
+            "background": {
               "type": "asset",
-              "value": "CustomKnobFaceImage"
+              "value": "CustomKnobBackgroundImage"
             }
           },
           "background": {
@@ -3723,24 +4985,334 @@
           "$ref": "#/definitions/commonJoystickStyle"
         }
       ],
-      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。"
+      "title": "控件移动样式"
+    },
+    "DirectionalPadInteractionActivationType": {
+      "markdownDescription": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "title": "激活类型"
+    },
+    "_HexColor": {
+      "type": "string",
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_FaceImageAsset": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "type": {
+          "const": "asset",
+          "markdownDescription": "用作控件组件的前景图形的自定义资产。",
+          "type": "string",
+          "description": "用作控件组件的前景图形的自定义资产。",
+          "title": "人脸图像资产样式设置组件"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "additionalProperties": false
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object",
+      "examples": [
+        {},
+        {
+          "myColor": "#ff00ffff",
+          "system_contentPrimary": "#ffffffff"
+        }
+      ],
+      "properties": {
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        }
+      },
+      "additionalProperties": false
     },
     "TurboActionInterval": {
-      "markdownDescription": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
-      "description": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
-      "exclusiveMinimum": 0,
-      "title": "时间间隔\r\n  ",
       "examples": [
         500,
         1000
       ],
+      "title": "间隔",
+      "description": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
+      "exclusiveMinimum": 0,
+      "markdownDescription": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
       "type": "number"
     },
+    "_ControlTypeJoystick": {
+      "const": "joystick",
+      "markdownDescription": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
+      "type": "string",
+      "description": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
+      "title": "游戏杆控件类型"
+    },
+    "JoystickDisabledStyle": {
+      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "knob": {
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            },
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            }
+          },
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "title": "控件禁用样式"
+    },
+    "Opacity": {
+      "markdownDescription": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
+      "anyOf": [
+        {
+          "minimum": 0,
+          "maximum": 1,
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "title": "不透明度"
+    },
+    "_ControlTypeArcadeButtons": {
+      "const": "arcadeButtons",
+      "markdownDescription": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
+      "type": "string",
+      "description": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
+      "title": "Arcade 按钮控件类型"
+    },
+    "_Touchpad": {
+      "type": "object",
+      "required": [
+        "type",
+        "axis"
+      ],
+      "examples": [
+        {
+          "axis": [
+            {
+              "output": "relativeMouse",
+              "input": "axisXY"
+            }
+          ],
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LayerUpperContent": {
+      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "description": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "title": "上层内容"
+    },
     "InputCurveRange": {
-      "markdownDescription": "⚠️ 已弃用： 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
-      "deprecated": true,
-      "description": "⚠️ 已弃用： 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
-      "title": "[已弃用]输入曲线范围",
       "examples": [
         [
           0,
@@ -3762,1672 +5334,103 @@
           }
         ]
       ],
+      "title": "[已弃用]输入曲线范围",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
       "anyOf": [
         {
-          "maxItems": 2,
-          "minItems": 2,
           "items": {
             "anyOf": [
               {
                 "minimum": -1,
-                "type": "number",
-                "maximum": 1
+                "maximum": 1,
+                "type": "number"
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ],
+      "deprecated": true,
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。"
+    },
+    "_ActionTypeBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
           "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "LayoutContent": {
-      "description": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。“left”和“right”区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
-      "anyOf": [
-        {
-          "properties": {
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "center": {
-              "$ref": "#/$defs/LayoutControlWheel",
-              "deprecated": true
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ],
-      "title": "布局内容",
       "examples": [
-        {},
+        "gamepadB",
         {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "input": "axisXY",
-                  "output": "leftJoystick"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "markdownDescription": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。“left”和“right”区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。"
-    },
-    "LayoutLowerContent": {
-      "description": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
-      "anyOf": [
-        {
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "../../context.json#/state/jumpControllerMapping"
         },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "较低版式内容",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "markdownDescription": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。"
-    },
-    "_AxisMapping2DItem": {
-      "description": "此属性定义一个映射，从玩家与控件的二维模拟交互到一个或两个维度输出。请注意，根据轴分配，控件的外观可能会更改。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "二维轴映射项",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "input": "axisUp",
-          "output": "rightTrigger"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "markdownDescription": "此属性定义一个映射，从玩家与控件的二维模拟交互到一个或两个维度输出。请注意，根据轴分配，控件的外观可能会更改。"
-    },
-    "DeadzoneThreshold": {
-      "description": "生成输出值所需的规范化输入值。",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "阈 值",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "markdownDescription": "生成输出值所需的规范化输入值。"
-    },
-    "JoystickDisabledStyle": {
-      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "禁用控件的样式",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。"
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "RelativeInteraction": {
-      "description": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "相对",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "markdownDescription": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。"
-    },
-    "FaceImageIconValue": {
-      "description": "此属性用于选择要用于此组件的内置图标。",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "人脸图像图标",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "markdownDescription": "此属性用于选择要用于此组件的内置图标。"
-    },
-    "LayoutUpperRightContent": {
-      "description": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 5,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "右上角布局内容",
-      "examples": [
         [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "markdownDescription": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。"
-    },
-    "_Throttle": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "examples": [
-        {
-          "sticky": true,
-          "axisUp": "rightTrigger",
-          "type": "throttle",
-          "axisDown": "leftTrigger"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
+          "gamepadA",
+          "leftTrigger"
+        ]
       ]
     },
-    "_FaceImageIcon": {
-      "properties": {
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "description": "一个内置图标，用作控件组件的前景图形。",
-          "title": "人脸图像图标样式组件",
-          "type": "string",
-          "const": "icon",
-          "markdownDescription": "一个内置图标，用作控件组件的前景图形。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ]
-    },
-    "_SystemColorAccentSecondary": {
-      "description": "此属性将替代用于样式组件（如 ergo-edit 外部滚轮）的强调辅助系统颜色。",
-      "title": "强调辅助系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代用于样式组件（如 ergo-edit 外部滚轮）的强调辅助系统颜色。"
-    },
-    "_ControllerAnalog2DOutputType": {
-      "description": "沿两个游戏板游戏杆轴的整个输出值。",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "游戏板模拟游戏杆输出",
-      "type": "string",
-      "markdownDescription": "沿两个游戏板游戏杆轴的整个输出值。"
-    },
-    "_SystemColorContentPrimary": {
-      "description": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
-      "title": "内容主系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。"
-    },
-    "_DirectionalPad": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        }
-      },
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "Stroke": {
-      "description": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
-      "title": "笔划样式组件",
-      "$ref": "#/$defs/_StrokeBase",
-      "markdownDescription": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。"
-    },
-    "ThrottleAxisStyle": {
-      "description": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+    "_ControllerAction": {
       "anyOf": [
         {
-          "properties": {
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
+          "$ref": "#/$defs/_ControllerButtonOutputType"
         },
         {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "限制轴样式组件",
-      "examples": [
-        {
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        }
-      ],
-      "markdownDescription": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。"
-    },
-    "_SystemColorContrastPrimary": {
-      "description": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
-      "title": "对比度主系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。"
-    },
-    "_FaceImageAsset": {
-      "properties": {
-        "type": {
-          "description": "用作控件组件的前景图形的自定义资产。",
-          "title": "人脸图像资产样式组件",
-          "type": "string",
-          "const": "asset",
-          "markdownDescription": "用作控件组件的前景图形的自定义资产。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        },
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ]
-    },
-    "_Blank": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
-          "title": "空白控件类型",
-          "type": "string",
-          "const": "blank",
-          "markdownDescription": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。"
-        }
-      },
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ]
-    },
-    "_SystemColorGamepadActionColor": {
-      "description": "此属性将替代相应的游戏板操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
-      "title": "游戏板操作系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代相应的游戏板操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。"
-    },
-    "ThrottleStyles": {
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "properties": {
-            "idleUp": {
-              "description": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
-              "title": "控件空闲向上样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。"
-            },
-            "disabled": {
-              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "title": "禁用控件的样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。"
-            },
-            "activatedUp": {
-              "description": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态是与控件进行交互时，特别是在控件中心上方的区域中。",
-              "title": "控件已激活向上样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态是与控件进行交互时，特别是在控件中心上方的区域中。"
-            },
-            "idle": {
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "title": "控件空闲样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。"
-            },
-            "activated": {
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "title": "控件激活样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
-            },
-            "activatedDown": {
-              "description": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态是与控件进行交互时，特别是在控件中心下方的区域中。",
-              "title": "控件已激活下移样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态是与控件进行交互时，特别是在控件中心下方的区域中。"
-            },
-            "default": {
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "title": "控件默认样式",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件样式",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "axisDown": {
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              },
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              }
-            },
-            "knob": {
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。"
-    },
-    "LayoutSensorContent": {
-      "description": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "传感器布局内容",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "input": "axisXY",
-              "output": "rightJoystick"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的布局内容容器。"
-    },
-    "AxisCapColor": {
-      "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
-              "title": "坐标轴样式组件",
-              "type": "string",
-              "const": "color",
-              "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "value": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "坐标轴样式组件",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。"
-    },
-    "_StrokeBase": {
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "description": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
-              "type": "string",
-              "const": "solid",
-              "markdownDescription": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
         }
       ]
     },
-    "Background": {
-      "description": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+    "OuterWheelControlGroup": {
       "anyOf": [
         {
-          "$ref": "#/$defs/_BackgroundColor"
+          "$ref": "#/$defs/Control"
         },
         {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "背景样式组件",
-      "markdownDescription": "控件组件背景的视觉样式。背景可以是`color`或`asset`。"
-    },
-    "_ControllerAnalog1DOutputType": {
-      "description": "沿指定游戏板游戏杆轴的整个内容输出值。",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "Gamepad Analog Joystick Output",
-      "type": "string",
-      "markdownDescription": "沿指定游戏板游戏杆轴的整个内容输出值。"
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "Knob": {
-      "description": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "旋钮样式组件",
-      "examples": [
-        {
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "markdownDescription": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。"
-    },
-    "DirectionalPadInteractionActivationType": {
-      "description": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值 `allowNeighboring`。",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "exclusive",
-            "allowNeighboring"
-          ]
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "激活类型",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "markdownDescription": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值 `allowNeighboring`。"
-    },
-    "FaceImageIconLabel": {
-      "description": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值 `action`。",
-      "anyOf": [
-        {
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "action",
-                "none"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "人脸图像图标标签样式组件",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "markdownDescription": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值 `action`。"
-    },
-    "SensorLayerControl": {
-      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方)层(隐藏或关闭传感器控件。",
-      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方)层(隐藏或关闭传感器控件。",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ]
-        }
-      },
-      "title": "层传感器控件",
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
+          "$ref": "#/$defs/ControlGroup"
         },
         {
           "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
         }
       ]
-    },
-    "ButtonDisabledStyle": {
-      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "禁用控件的样式",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。"
-    },
-    "Layers": {
-      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "触摸布局层",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "axisUp": "rightTrigger",
-                  "type": "throttle",
-                  "axisDown": "leftTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。"
-    },
-    "_SystemColorContentSecondary": {
-      "description": "此属性将替代用于样式组件（如背景和填充）的辅助系统颜色。",
-      "title": "内容辅助系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代用于样式组件（如背景和填充）的辅助系统颜色。"
-    },
-    "_LayoutAction": {
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "additionalProperties": false,
-      "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
-      "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
-      "required": [
-        "type",
-        "target"
-      ],
-      "title": "布局操作",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
-          "title": "布局操作",
-          "type": "string",
-          "const": "layer",
-          "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。"
-        }
-      },
-      "type": "object"
-    },
-    "InnerLayerControlWheel": {
-      "description": "一组 1 到 4 层控件，包括`blank`控件，用于在下方()层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
-      "anyOf": [
-        {
-          "maxItems": 4,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "Inner",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "markdownDescription": "一组 1 到 4 层控件，包括`blank`控件，用于在下方()层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。"
-    },
-    "ArcadeButtonStyles": {
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "properties": {
-            "default": {
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "title": "控件默认样式",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。"
-            },
-            "idle": {
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "title": "控件空闲样式",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。"
-            },
-            "disabled": {
-              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "title": "禁用控件的样式",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。"
-            },
-            "activated": {
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "title": "控件激活样式",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件样式",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          },
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。"
-    },
-    "LayoutLowerArrayContent": {
-      "description": "此属性定义布局的内容，该布局是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方()层隐藏控件。",
-      "anyOf": [
-        {
-          "minItems": 1,
-          "maxItems": 4,
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "低布局数组内容",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "markdownDescription": "此属性定义布局的内容，该布局是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方()层隐藏控件。"
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "LayerUpperContent": {
-      "description": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "上层内容",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
-        }
-      ],
-      "markdownDescription": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one."
-    },
-    "JoystickIdleStyle": {
-      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-      "anyOf": [
-        {
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "控件空闲样式",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。"
-    },
-    "DeadzoneDirectionalPad": {
-      "description": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
-      "anyOf": [
-        {
-          "exclusiveMinimum": 0,
-          "type": "number",
-          "exclusiveMaximum": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "方向板死区",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "markdownDescription": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。"
-    },
-    "Sensitivity": {
-      "description": "用于更改控件敏感度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "敏感度",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "markdownDescription": "用于更改控件敏感度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。"
-    },
-    "_InputAxisZY": {
-      "description": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-      "title": "Z 轴和 Y 轴输入映射",
-      "type": "string",
-      "const": "axisZY",
-      "markdownDescription": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。"
-    },
-    "_Touchpad": {
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        }
-      },
-      "examples": [
-        {
-          "axis": [
-            {
-              "input": "axisXY",
-              "output": "relativeMouse"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ]
-    },
-    "_SystemColorActionColor": {
-      "description": "此属性将替代相应的操作系统颜色，该颜色用于在“操作”字段设置为非游戏板操作的控件上样式组件。",
-      "title": "操作系统颜色替代",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "markdownDescription": "此属性将替代相应的操作系统颜色，该颜色用于在“操作”字段设置为非游戏板操作的控件上样式组件。"
-    },
-    "LayoutUpperContent": {
-      "description": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
-      "anyOf": [
-        {
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "title": "上层布局内容",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。"
-    },
-    "DeadzoneRadial": {
-      "description": "是否按照径向输入组件或每个轴分别计算死区阈值。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "title": "径向",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "markdownDescription": "是否按照径向输入组件或每个轴分别计算死区阈值。"
     }
   },
-  "type": "object"
+  "description": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+  "properties": {
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "content"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "title": "触摸适配捆绑包布局架构",
+  "markdownDescription": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。"
 }

--- a/touch-adaptation-kit/schemas/zh-CN/layout/v4.0/layout.json
+++ b/touch-adaptation-kit/schemas/zh-CN/layout/v4.0/layout.json
@@ -1,4069 +1,15 @@
 {
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "additionalProperties": false,
-  "type": "object",
+  "title": "触摸适配捆绑包布局架构",
+  "description": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+  "markdownDescription": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
   "$defs": {
-    "_StrokeBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "solid",
-              "markdownDescription": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
-              "type": "string",
-              "description": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "color": "#0099ff",
-          "type": "solid",
-          "opacity": 1
-        },
-        {
-          "$ref": "#/definitions/commonControlStroke"
-        }
-      ]
-    },
-    "_SystemColorContentPrimary": {
-      "markdownDescription": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
-      "description": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "内容主系统颜色替代"
-    },
-    "_ControlTypeDirectionalPad": {
-      "const": "directionalPad",
-      "markdownDescription": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
-      "type": "string",
-      "description": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
-      "title": "方向盘控件类型"
-    },
-    "_InputMappingXYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "JoystickDirectionIndicator": {
-      "markdownDescription": "指示交互方向的视觉样式",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
-              "type": "string",
-              "description": "用于指定方向指示器是可以自定义其值的颜色类型的属性。"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "指示交互方向的视觉样式",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        },
-        {
-          "$ref": "#/definitions/commonIndicatorStyling"
-        }
-      ],
-      "title": "方向指示器样式设置组件"
-    },
-    "LayerSensorContent": {
-      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorLayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerSensors"
-        }
-      ],
-      "title": "传感器层内容"
-    },
-    "Background": {
-      "markdownDescription": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/_BackgroundAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
-      "title": "背景样式组件"
-    },
-    "_Accelerometer": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "accelerometer",
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "accelerometer",
-          "markdownDescription": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
-          "type": "string",
-          "description": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
-          "title": "加速计控件类型"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_LayerControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        }
-      ]
-    },
-    "SensorControl": {
-      "examples": [
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "传感器控件",
-      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_Null": {
-      "markdownDescription": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
-      "type": "null",
-      "description": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
-      "examples": [
-        null
-      ],
-      "title": "Null"
-    },
-    "_ControllerAnalogMagnitudinalJoystickOutputType": {
-      "markdownDescription": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
-      "type": "string",
-      "description": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
-      "enum": [
-        "leftJoystickRight",
-        "leftJoystickLeft",
-        "leftJoystickUp",
-        "leftJoystickDown",
-        "rightJoystickRight",
-        "rightJoystickLeft",
-        "rightJoystickUp",
-        "rightJoystickDown"
-      ],
-      "title": "游戏手柄模拟游戏杆输出"
-    },
-    "AxisCap": {
-      "$ref": "#/$defs/AxisCapColor"
-    },
-    "PullIndicator": {
-      "markdownDescription": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/PullIndicatorBackground"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
-      "examples": [
-        {
-          "background": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonPullIndicator"
-        }
-      ],
-      "title": "拉动指示器样式组件"
-    },
-    "_SystemColorAccentPrimary": {
-      "markdownDescription": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
-      "description": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "重置主要系统颜色强调"
-    },
-    "Scale": {
-      "markdownDescription": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
-      "anyOf": [
-        {
-          "minimum": 0.5,
-          "maximum": 2,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
-      "examples": [
-        1,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerControlSizePreference"
-        }
-      ],
-      "title": "扩展"
-    },
-    "JoystickIdleStyle": {
-      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "控制空闲样式"
-    },
-    "_AxisMapping2DItem": {
-      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping2D"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1D"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinal"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "二维轴映射项"
-    },
-    "TouchpadStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "look"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadStyling"
-        }
-      ]
-    },
-    "ButtonIdleStyle": {
-      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "控制空闲样式"
-    },
-    "_LayoutStyles": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "colors": {
-              "$ref": "#/$defs/LayoutColors"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "colors": {
-            "highContrast": {
-              "myColor": "#00ff00ff",
-              "system_contentPrimary": "#ffffffff"
-            },
-            "default": {
-              "myColor": "#ff0000ff",
-              "system_contentPrimary": "#ffffffff"
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonStyles"
-        }
-      ]
-    },
-    "DeadzoneDirectionalPad": {
-      "markdownDescription": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
-      "anyOf": [
-        {
-          "exclusiveMaximum": 1,
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/dpadDeadzone"
-        }
-      ],
-      "title": "方向板死区"
-    },
-    "Sticky": {
-      "markdownDescription": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerCruiseControlPreference"
-        }
-      ],
-      "title": "精华"
-    },
-    "_InputMappingZYToGamepad2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone2D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayoutContent": {
-      "markdownDescription": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "layers": {
-              "$ref": "#/$defs/Layers"
-            },
-            "upper": {
-              "$ref": "#/$defs/LayoutUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayoutLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayoutControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
-      "examples": [
-        {},
-        {
-          "left": {
-            "inner": [
-              {
-                "type": "joystick",
-                "axis": {
-                  "output": "leftJoystick",
-                  "input": "axisXY"
-                }
-              }
-            ]
-          },
-          "right": {
-            "outer": [
-              {
-                "type": "button",
-                "action": "gamepadY"
-              }
-            ]
-          }
-        }
-      ],
-      "title": "布局内容"
-    },
-    "Reference": {
-      "type": "object",
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-          "format": "uri-reference",
-          "markdownDescription": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
-          "type": "string",
-          "description": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
-          "examples": [
-            "#/definitions/layoutReusableItem",
-            "../../context.json#/state/dynamicStateValue",
-            "../../context.json#/definitions/globalReusableItem"
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerControlWheel": {
-      "markdownDescription": "一组以圆圈或滚轮形状组织的层控件。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayerControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "一组以圆圈或滚轮形状组织的层控件。",
-      "examples": [
-        {
-          "inner": [
-            null,
-            {
-              "type": "blank"
-            }
-          ],
-          "outer": [
-            {
-              "type": "blank"
-            },
-            [
-              null,
-              {
-                "type": "blank"
-              },
-              null
-            ],
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonWheelDefinitions"
-        }
-      ],
-      "title": "触摸布局层控制轮"
-    },
-    "_SystemColorAccentSecondary": {
-      "markdownDescription": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
-      "description": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "重音次要系统颜色覆盖"
-    },
-    "OuterWheelLayerControlGroup": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LayerControl"
-        },
-        {
-          "$ref": "#/$defs/LayerControlGroup"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        }
-      ]
-    },
-    "ButtonToggledStyle": {
-      "markdownDescription": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "控件切换样式"
-    },
-    "LayoutLowerArrayContent": {
-      "markdownDescription": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "dPadLeft"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
-        }
-      ],
-      "title": "下层布局数组内容"
-    },
-    "_SingleControlActionAssignableTypes": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/_LayoutAction"
-        },
-        {
-          "$ref": "#/$defs/_TurboAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "AxisMapping2D": {
-      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_AxisMapping2DItem"
-          },
-          "type": "array"
-        }
-      ],
-      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "二维轴映射"
-    },
-    "ThrottleAxisOutput": {
-      "markdownDescription": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
-      "examples": [
-        "rightTrigger",
-        "leftJoystickUp",
-        {
-          "$ref": "#/definitions/commonThrottleAxis"
-        }
-      ],
-      "title": "限制轴"
-    },
-    "ColorPaletteDefaultVariant": {
-      "markdownDescription": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
-      "description": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "默认颜色"
-    },
-    "Deadzone1D": {
-      "markdownDescription": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
-      "examples": [
-        {
-          "threshold": 0
-        },
-        {
-          "threshold": 0.1
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "一维死区"
-    },
-    "JoystickOutlineWithIndicator": {
-      "markdownDescription": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "indicator": {
-              "$ref": "#/$defs/JoystickDirectionIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
-      "examples": [
-        {
-          "indicator": {
-            "type": "color",
-            "value": "#0099ffaa"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonOutlineStyling"
-        }
-      ],
-      "title": "大纲样式组件"
-    },
-    "_ControllerButtonOutputType": {
-      "markdownDescription": "输出按下的游戏手柄按钮。",
-      "type": "string",
-      "description": "输出按下的游戏手柄按钮。",
-      "enum": [
-        "guide",
-        "gamepadA",
-        "gamepadB",
-        "gamepadX",
-        "gamepadY",
-        "view",
-        "menu",
-        "leftBumper",
-        "rightBumper",
-        "dPadLeft",
-        "dPadRight",
-        "dPadUp",
-        "dPadDown",
-        "leftThumb",
-        "rightThumb"
-      ],
-      "title": "游戏手柄按钮输出"
-    },
-    "ButtonActivatedStyle": {
-      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "控件激活样式"
-    },
-    "JoystickStyles": {
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "$ref": "#/$defs/JoystickIdleStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/JoystickDisabledStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/JoystickActivatedStyle"
-            },
-            "moving": {
-              "$ref": "#/$defs/JoystickMovingStyle"
-            },
-            "default": {
-              "$ref": "#/$defs/JoystickDefaultStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "examples": [
-        {},
-        {
-          "default": {
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomJoystickBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyles"
-        }
-      ],
-      "title": "控件样式"
-    },
-    "ButtonDisabledStyle": {
-      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "控件禁用样式"
-    },
-    "LayoutActionTarget": {
-      "markdownDescription": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
-      "examples": [
-        "WeaponSelectLayer",
-        "AdvancedDrivingLayer",
-        {
-          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
-        }
-      ],
-      "title": "布局操作目标"
-    },
-    "_ControlTypeButton": {
-      "const": "button",
-      "markdownDescription": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
-      "type": "string",
-      "description": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
-      "title": "按钮控件类型"
-    },
-    "_ControllerAnalog1DOutputType": {
-      "markdownDescription": "沿指定游戏手柄游戏杆轴的整个输出值。",
-      "type": "string",
-      "description": "沿指定游戏手柄游戏杆轴的整个输出值。",
-      "enum": [
-        "leftJoystickX",
-        "leftJoystickY",
-        "rightJoystickX",
-        "rightJoystickY"
-      ],
-      "title": "游戏手柄模拟游戏杆输出"
-    },
-    "_LayoutAction": {
-      "type": "object",
-      "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
-      "properties": {
-        "target": {
-          "$ref": "#/$defs/LayoutActionTarget"
-        },
-        "type": {
-          "const": "layer",
-          "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
-          "type": "string",
-          "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
-          "title": "布局操作"
-        }
-      },
-      "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
-      "examples": [
-        {
-          "type": "layer",
-          "target": "WeaponSelectLayer"
-        }
-      ],
-      "title": "布局操作",
-      "required": [
-        "type",
-        "target"
-      ],
-      "additionalProperties": false
-    },
-    "InnerLayoutControlWheel": {
-      "markdownDescription": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/Control"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
-      "examples": [
-        [],
-        [
-          {
-            "type": "joystick",
-            "axis": {
-              "output": "leftJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
-        }
-      ],
-      "title": "内部"
-    },
-    "_InputMapping2D": {
-      "$ref": "#/$defs/_InputMappingXY"
-    },
-    "_ControllerTriggerOutputType": {
-      "markdownDescription": "输出映射到指定游戏手柄触发器的值。",
-      "type": "string",
-      "description": "输出映射到指定游戏手柄触发器的值。",
-      "enum": [
-        "leftTrigger",
-        "rightTrigger"
-      ],
-      "title": "游戏手柄模拟触发器输出"
-    },
-    "DirectionalPadStyles": {
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "控制空闲样式"
-            },
-            "disabled": {
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "$ref": "#/$defs/DirectionalPadIdleStyle",
-              "title": "控件激活样式"
-            },
-            "activated": {
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "控件激活样式"
-            },
-            "default": {
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "$ref": "#/$defs/DirectionalPadDefaultStyle",
-              "title": "控件默认样式"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "examples": [
-        {},
-        {
-          "default": {
-            "gradient": {
-              "color": "#0099ffaa"
-            },
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyles"
-        }
-      ],
-      "title": "控件样式"
-    },
-    "Indicator": {
-      "markdownDescription": "用于指示控件的当前值或位置的笔划的视觉样式。",
-      "description": "用于指示控件的当前值或位置的笔划的视觉样式。",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "指示器样式组件"
-    },
-    "Stroke": {
-      "markdownDescription": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
-      "description": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
-      "$ref": "#/$defs/_StrokeBase",
-      "title": "笔划样式组件"
-    },
-    "Gradient": {
-      "markdownDescription": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "color": {
-              "$ref": "#/$defs/Color"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
-      "examples": [
-        {
-          "color": "#0099ffaa"
-        },
-        {
-          "color": {
-            "$ref": "#/definitions/commonColor"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonColorGradient"
-        }
-      ],
-      "title": "渐变"
-    },
-    "_InputMappingXY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
-        }
-      ]
-    },
-    "ControllerOnlyActionType": {
-      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerAction"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
-      ],
-      "title": "游戏手柄操作"
-    },
-    "_DirectionalPad": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "directionalPad"
-        }
-      ],
-      "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/DirectionalPadStyles"
-        },
-        "interaction": {
-          "$ref": "#/$defs/DirectionalPadInteraction"
-        },
-        "scale": {
-          "$ref": "#/$defs/Scale"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/DeadzoneDirectionalPad"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeDirectionalPad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_TurboAction": {
-      "title": "Turbo 操作",
-      "properties": {
-        "interval": {
-          "$ref": "#/$defs/TurboActionInterval"
-        },
-        "type": {
-          "const": "turbo",
-          "markdownDescription": "根据时间间隔而不是连续触发的操作。",
-          "type": "string",
-          "description": "根据时间间隔而不是连续触发的操作。",
-          "title": "Turbo 操作"
-        },
-        "action": {
-          "$ref": "#/$defs/ControllerOnlyActionType"
-        }
-      },
-      "description": "根据时间间隔而不是连续触发的操作。",
-      "type": "object",
-      "required": [
-        "type",
-        "action",
-        "interval"
-      ],
-      "markdownDescription": "根据时间间隔而不是连续触发的操作。",
-      "additionalProperties": false
-    },
-    "ControlGroup": {
-      "markdownDescription": "租中排列的一组 1 到 4 个控件。系统确定如何在可用空间内最佳地排列组中的控件；只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/ControlGroupItem"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "租中排列的一组 1 到 4 个控件。系统确定如何在可用空间内最佳地排列组中的控件；只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "gamepadX"
-          },
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonControlGroup"
-        }
-      ],
-      "title": "触摸布局控制组"
-    },
-    "_SystemColorContrastPrimary": {
-      "markdownDescription": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
-      "description": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "对比度主系统颜色替代"
-    },
-    "ControlGroupItem": {
-      "markdownDescription": "控制组中的单个项。使用`null`跳过排列中的控件。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控制组中的单个项。使用`null`跳过排列中的控件。",
-      "title": "触摸布局控件组项"
-    },
-    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxisMagnitudinal"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "ActionThreshold": {
-      "markdownDescription": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
-      "anyOf": [
-        {
-          "type": "number",
-          "minimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
-      "examples": [
-        1,
-        1.5,
-        0,
-        {
-          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
-        }
-      ],
-      "title": "操作阈值"
-    },
-    "ArcadeButtonStyles": {
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "控制空闲样式"
-            },
-            "disabled": {
-              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "控件禁用样式"
-            },
-            "activated": {
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "控件激活样式"
-            },
-            "default": {
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "$ref": "#/$defs/ArcadeButtonStyleBase",
-              "title": "控件默认样式"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "examples": [
-        {
-          "activated": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomActivatedArcadeButtonBackgroundImage"
-            }
-          },
-          "default": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonFaceImage"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomDefaultArcadeButtonBackgroundImage"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyles"
-        }
-      ],
-      "title": "控件样式"
-    },
-    "_BackgroundAsset": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageFileName"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/BackgroundAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "用于设置背景样式的自定义资产。",
-          "type": "string",
-          "description": "用于设置背景样式的自定义资产。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_FaceImageIcon": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageIconValue"
-        },
-        "label": {
-          "$ref": "#/$defs/FaceImageIconLabel"
-        },
-        "type": {
-          "const": "icon",
-          "markdownDescription": "用作控件组件的前景图形的内置图标。",
-          "type": "string",
-          "description": "用作控件组件的前景图形的内置图标。",
-          "title": "人脸图像图标样式组件"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1D": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
-        }
-      ]
-    },
-    "_InputMappingZY": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
-        }
-      ]
-    },
-    "FaceImageIconValue": {
-      "markdownDescription": "此属性用于选择要用于此组件的内置图标。",
-      "anyOf": [
-        {
-          "enum": [
-            "ability",
-            "ability2",
-            "ability3",
-            "abilityPowerPunch",
-            "abilityPowerUp",
-            "accept",
-            "add",
-            "aim",
-            "armor",
-            "arrow",
-            "arrowReload",
-            "attackBehind",
-            "barrel",
-            "block",
-            "bomb",
-            "book",
-            "bow",
-            "brakePedal",
-            "brightness",
-            "capture",
-            "character",
-            "characterSelect",
-            "characterSelect2",
-            "chat",
-            "climbStairs",
-            "close",
-            "compass",
-            "cover",
-            "crouch",
-            "cursor",
-            "dPad",
-            "dash",
-            "defendByShield",
-            "dodge",
-            "downArrow",
-            "downArrow2",
-            "downChevron",
-            "emotes",
-            "enterCar",
-            "enterDoor",
-            "exit",
-            "exitCar",
-            "exitDoor",
-            "fastForward",
-            "fire",
-            "firePunch",
-            "flag",
-            "gasPedal",
-            "glide",
-            "golf",
-            "grab",
-            "grenade",
-            "gyroscope",
-            "handbrake",
-            "handbrake2",
-            "health",
-            "heavyKick",
-            "heavyKick2",
-            "heavyKick3",
-            "heavyKick4",
-            "heavyPunch",
-            "heavyPunch2",
-            "heavyPunch3",
-            "heavySword",
-            "heavySword2",
-            "help",
-            "horn",
-            "hourglass",
-            "interact",
-            "internet",
-            "inventory",
-            "jump",
-            "kick",
-            "largeGridView",
-            "leftArrow",
-            "leftArrow2",
-            "leftChevron",
-            "leftRightArrows",
-            "lightKick",
-            "lightKick2",
-            "lightKick3",
-            "lightKick4",
-            "lightPunch",
-            "lightPunch2",
-            "lightPunch3",
-            "lightSword",
-            "lightSword2",
-            "look",
-            "lookBehind",
-            "lookBehind2",
-            "lookByHand",
-            "map",
-            "map2",
-            "medical",
-            "meditate",
-            "mediumKick",
-            "mediumKick2",
-            "mediumKick3",
-            "mediumKick4",
-            "mediumPunch",
-            "mediumPunch2",
-            "mediumPunch3",
-            "mediumSword",
-            "mediumSword2",
-            "microphone",
-            "mirror",
-            "moreActions",
-            "move",
-            "move2",
-            "notebook",
-            "parameters",
-            "pause",
-            "phone",
-            "pickAxe",
-            "placeholder",
-            "plane",
-            "planeFast",
-            "planeSlow",
-            "punch",
-            "punch2",
-            "radialMenu",
-            "radialMenu2",
-            "radio",
-            "ram",
-            "redo",
-            "reload",
-            "repeatRefresh",
-            "reset",
-            "rewind",
-            "rightArrow",
-            "rightArrow2",
-            "rightChevron",
-            "roll",
-            "run",
-            "select",
-            "selectAll",
-            "selectionWheel",
-            "sit",
-            "skateboard",
-            "skateboardGrab",
-            "skateboardGrind",
-            "skateboardJump",
-            "skateboardOllie",
-            "skateboardRampOver",
-            "slide",
-            "smallGridView",
-            "speaker",
-            "specialAbility",
-            "sprint",
-            "stealth",
-            "steering",
-            "stopwatch",
-            "subtract",
-            "surf",
-            "switchCamera",
-            "sword",
-            "sword2",
-            "sync",
-            "targetLock",
-            "team",
-            "teamAttack",
-            "throw",
-            "titleMenu",
-            "touch",
-            "undo",
-            "upArrow",
-            "upArrow2",
-            "upChevron",
-            "walk",
-            "waypoint",
-            "weaponSelect",
-            "zoomIn",
-            "zoomOut"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性用于选择要用于此组件的内置图标。",
-      "examples": [
-        "heavyPunch",
-        {
-          "$ref": "../../context.json#/definitions/commonIconForPunch"
-        }
-      ],
-      "title": "人脸图像图标"
-    },
-    "Toggle": {
-      "markdownDescription": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
-        }
-      ],
-      "title": "切换"
-    },
-    "ArcadeButtonStyleBase": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomArcadeButtonFaceImage"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomArcadeButtonBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonArcadeButtonStyle"
-        }
-      ]
-    },
-    "_ControlTypeTouchpad": {
-      "const": "touchpad",
-      "markdownDescription": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
-      "type": "string",
-      "description": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
-      "title": "触摸板控件类型"
-    },
-    "ThrottleStyles": {
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控件默认样式"
-            },
-            "idleUp": {
-              "markdownDescription": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
-              "description": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控制空闲向上样式"
-            },
-            "activatedDown": {
-              "markdownDescription": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
-              "description": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控件已激活向下样式"
-            },
-            "disabled": {
-              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控件禁用样式"
-            },
-            "activatedUp": {
-              "markdownDescription": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
-              "description": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控件已激活向上样式"
-            },
-            "idle": {
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控制空闲样式"
-            },
-            "activated": {
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "$ref": "#/$defs/ThrottleStyleBase",
-              "title": "控件激活样式"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "examples": [
-        {
-          "default": {
-            "axisUp": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "axisDown": {
-              "stroke": {
-                "color": "#0099ff",
-                "type": "solid",
-                "opacity": 1
-              },
-              "cap": {
-                "type": "color",
-                "value": "#0099ffaa"
-              }
-            },
-            "knob": {
-              "faceImage": {
-                "type": "asset",
-                "value": "CustomKnobFaceImage"
-              },
-              "stroke": {
-                "type": "solid",
-                "color": "#0099ffaa"
-              },
-              "background": {
-                "type": "asset",
-                "value": "CustomKnobBackgroundImage"
-              }
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonThrottleStyles"
-        }
-      ],
-      "title": "控件样式"
-    },
-    "SensorLayerControl": {
-      "examples": [
-        {
-          "type": "blank"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
-        }
-      ],
-      "title": "层传感器控件",
-      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Accelerometer"
-        },
-        {
-          "$ref": "#/$defs/_Gyroscope"
-        },
-        {
-          "$ref": "#/$defs/_Blank"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
-      "properties": {
-        "type": {
-          "enum": [
-            "accelerometer",
-            "gyroscope",
-            "blank"
-          ],
-          "type": "string"
-        }
-      }
-    },
-    "_SystemColorActionColor": {
-      "markdownDescription": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
-      "description": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "操作系统颜色替代"
-    },
-    "LayoutSensorContent": {
-      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SensorControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
-      "examples": [
-        [
-          {
-            "type": "gyroscope",
-            "axis": {
-              "output": "rightJoystick",
-              "input": "axisXY"
-            }
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonSensors"
-        }
-      ],
-      "title": "传感器布局内容"
-    },
-    "LayoutColors": {
-      "markdownDescription": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "highContrast": {
-              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
-            },
-            "default": {
-              "$ref": "#/$defs/ColorPaletteDefaultVariant"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
-      "examples": [
-        {},
-        {
-          "highContrast": {
-            "myColor": "#00ff00ff",
-            "system_contentPrimary": "#ffffffff"
-          },
-          "default": {
-            "myColor": "#ff0000ff",
-            "system_contentPrimary": "#ffffffff"
-          }
-        },
-        {
-          "$ref": "#/definitions/myColors"
-        }
-      ],
-      "title": "颜色"
-    },
-    "LayoutUpperContent": {
-      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "right": {
-              "$ref": "#/$defs/LayoutUpperRightContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
-      "examples": [
-        {
-          "right": [
-            {
-              "type": "button",
-              "action": "menu"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperControls"
-        }
-      ],
-      "title": "上层布局内容"
-    },
-    "_Color": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/_ColorReference"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        "colors/system_contentPrimary",
-        "colors/myColor",
-        {
-          "$ref": "#/definitions/commonAccentColor"
-        }
-      ]
-    },
-    "DirectionalPadDefaultStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "gradient": {
-              "$ref": "#/$defs/Gradient"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "RelativeInteraction": {
-      "markdownDescription": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerRelativeControlPreference"
-        }
-      ],
-      "title": "亲属"
-    },
-    "ButtonPulledStyle": {
-      "markdownDescription": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "控件拉取样式"
-    },
-    "InputCurveType": {
-      "examples": [
-        "circular",
-        "circular-inverse",
-        {
-          "$ref": "#/definitions/commonJoystickResponseCurve"
-        }
-      ],
-      "title": "[已弃用]输入响应曲线类型",
-      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。",
-      "anyOf": [
-        {
-          "enum": [
-            "circular",
-            "circular-inverse"
-          ],
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。"
-    },
-    "ThrottleAxisStyle": {
-      "markdownDescription": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "cap": {
-              "$ref": "#/$defs/AxisCap"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
-      "examples": [
-        {
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          },
-          "cap": {
-            "type": "color",
-            "value": "#0099ffaa"
-          }
-        }
-      ],
-      "title": "限制轴样式组件"
-    },
-    "ButtonDefaultStyle": {
-      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "pullIndicator": {
-              "$ref": "#/$defs/PullIndicator"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-      "examples": [
-        {},
-        {
-          "faceImage": {
-            "type": "icon",
-            "value": "interact"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyle"
-        }
-      ],
-      "title": "控件默认样式"
-    },
-    "_InputMapping1DToGamepad1DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxis1D"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FillColor": {
-      "markdownDescription": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
-      "description": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
-      "$ref": "#/$defs/_Color",
-      "title": "填充"
-    },
-    "PullIndicatorBackground": {
-      "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_BackgroundColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonPullIndicatorBackground"
-        }
-      ],
-      "title": "背景样式组件"
-    },
-    "_Button": {
-      "type": "object",
-      "required": [
-        "type",
-        "action"
-      ],
-      "examples": [
-        {
-          "type": "button",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "interact"
-              }
-            }
-          },
-          "action": "gamepadA"
-        }
-      ],
-      "properties": {
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "styles": {
-          "$ref": "#/$defs/ButtonStyles"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeButton"
-        },
-        "toggle": {
-          "$ref": "#/$defs/Toggle"
-        },
-        "pullAction": {
-          "$ref": "#/$defs/PullActionType"
-        }
-      },
-      "additionalProperties": false
-    },
-    "DirectionalPadInteraction": {
-      "markdownDescription": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "activationType": {
-              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
-      "examples": [
-        {
-          "activationType": "exclusive"
-        },
-        {
-          "activationType": "allowNeighboring"
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonDPadInteraction"
-        }
-      ],
-      "title": "交互"
-    },
-    "ButtonStyles": {
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "default": {
-              "$ref": "#/$defs/ButtonDefaultStyle"
-            },
-            "pulled": {
-              "$ref": "#/$defs/ButtonPulledStyle"
-            },
-            "disabled": {
-              "$ref": "#/$defs/ButtonDisabledStyle"
-            },
-            "toggled": {
-              "$ref": "#/$defs/ButtonToggledStyle"
-            },
-            "idle": {
-              "$ref": "#/$defs/ButtonIdleStyle"
-            },
-            "activated": {
-              "$ref": "#/$defs/ButtonActivatedStyle"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "examples": [
-        {},
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "interact"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonButtonStyles"
-        }
-      ],
-      "title": "控件样式"
-    },
-    "_CustomColorPaletteColor": {
-      "markdownDescription": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
-      "description": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "自定义布局颜色"
-    },
-    "_InputMappingMagnitudinal": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
-        }
-      ]
-    },
-    "DeadzoneThreshold": {
-      "markdownDescription": "生成输出值所需的规范化输入值。",
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "生成输出值所需的规范化输入值。",
-      "examples": [
-        0.5,
-        1,
-        0,
-        {
-          "$ref": "#/definitions/commonDeadzoneThreshold"
-        }
-      ],
-      "title": "阈值"
-    },
-    "_SystemColorContrastSecondary": {
-      "markdownDescription": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
-      "description": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "对比度辅助系统颜色替代"
-    },
-    "_SystemColorGamepadActionColor": {
-      "markdownDescription": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
-      "description": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "游戏手柄操作系统颜色替代"
-    },
-    "AssetReference": {
-      "markdownDescription": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+$"
-        },
-        {
-          "type": "string",
-          "pattern": "^[^/\\.]+/[A-Za-z0-9_]+$"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
-      "examples": [
-        "JumpImage",
-        "SpitesheetTextureFileName/Jump",
-        {
-          "$ref": "#/definitions/buttonBackgroundAssetValue"
-        }
-      ],
-      "title": "资产引用样式组件"
-    },
-    "FaceImage": {
-      "markdownDescription": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_FaceImageIcon"
-        },
-        {
-          "$ref": "#/$defs/_FaceImageAsset"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
-      "examples": [
-        {
-          "type": "asset",
-          "value": "CustomImageForJumpButtonFace"
-        },
-        {
-          "type": "icon",
-          "value": "interact"
-        },
-        {
-          "$ref": "#/definitions/commonFaceImageStyling"
-        }
-      ],
-      "title": "人脸图像样式设置组件"
-    },
-    "_ControlBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_Button"
-        },
-        {
-          "$ref": "#/$defs/_Joystick"
-        },
-        {
-          "$ref": "#/$defs/_DirectionalPad"
-        },
-        {
-          "$ref": "#/$defs/_Touchpad"
-        },
-        {
-          "$ref": "#/$defs/_Throttle"
-        },
-        {
-          "$ref": "#/$defs/_ArcadeButtons"
-        }
-      ],
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControlTypeArcadeButtons"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeButton"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeDirectionalPad"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeJoystick"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeThrottle"
-            },
-            {
-              "$ref": "#/$defs/_ControlTypeTouchpad"
-            }
-          ]
-        }
-      }
-    },
-    "JoystickActivatedStyle": {
-      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "控件激活样式"
-    },
-    "LayoutLowerContent": {
-      "markdownDescription": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/Control"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayoutLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
-      "examples": [
-        {
-          "center": {
-            "type": "button",
-            "action": "dPadDown"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "button",
-              "action": "dPadLeft"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "button",
-              "action": "dPadRight"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
-        }
-      ],
-      "title": "下层布局内容"
-    },
-    "_InputMappingZYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisZY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "ControlVisibility": {
-      "markdownDescription": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "可见"
-    },
-    "LayerLowerArrayContent": {
-      "markdownDescription": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
-        }
-      ],
-      "title": "下层数组内容"
-    },
-    "OuterLayoutControlWheel": {
-      "markdownDescription": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
-      "examples": [
-        [],
-        [
-          null,
-          [
-            {
-              "type": "button",
-              "action": "gamepadX"
-            }
-          ],
-          {
-            "type": "button",
-            "action": "gamepadY"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "外部​​"
-    },
-    "ControlEnabled": {
-      "markdownDescription": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/hasSpellEquipped"
-        }
-      ],
-      "title": "已启用"
-    },
-    "ExpandInteraction": {
-      "markdownDescription": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "../../context.json#/state/playerExpandControlPreference"
-        }
-      ],
-      "title": "展开"
-    },
-    "Deadzone2D": {
-      "markdownDescription": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "threshold",
-            "radial"
-          ],
-          "properties": {
-            "threshold": {
-              "$ref": "#/$defs/DeadzoneThreshold"
-            },
-            "radial": {
-              "$ref": "#/$defs/DeadzoneRadial"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
-      "examples": [
-        {
-          "threshold": 0,
-          "radial": true
-        },
-        {
-          "threshold": 0.1,
-          "radial": false
-        },
-        {
-          "$ref": "#/definitions/commonDeadzone"
-        }
-      ],
-      "title": "二维死区"
-    },
-    "_ColorPaletteColor": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_HexColor"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        "#0099ff",
-        "#0099ffaa",
-        "#09f",
-        "#09fa",
-        {
-          "$ref": "#/definitions/myColor"
-        }
-      ]
-    },
-    "_InputAxisZY": {
-      "const": "axisZY",
-      "markdownDescription": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-      "type": "string",
-      "description": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-      "title": "Z 轴和 Y 轴输入映射"
-    },
-    "DirectionalPadIdleStyle": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "fill": {
-              "$ref": "#/$defs/FillColor"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "examples": [
-        {},
-        {
-          "gradient": {
-            "color": "#0099ffaa"
-          },
-          "stroke": {
-            "color": "#0099ff",
-            "type": "solid",
-            "opacity": 1
-          }
-        },
-        {
-          "$ref": "#/definitions/commonDPadStyle"
-        }
-      ]
-    },
-    "Definitions": {
-      "examples": [
-        {},
-        {
-          "joystickKnob": {
-            "default": {
-              "knob": {
-                "faceImage": {
-                  "type": "asset",
-                  "value": {
-                    "$ref": "#/definitions/joystickAssetName"
-                  }
-                }
-              }
-            }
-          },
-          "joystickAssetName": "exampleAssetName"
-        }
-      ],
-      "title": "定义",
-      "patternProperties": {
-        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/LayoutDefinableType"
-        }
-      },
-      "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
-      "type": "object",
-      "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
-      "additionalProperties": false
-    },
-    "_SystemColorContentSecondary": {
-      "markdownDescription": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
-      "description": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
-      "$ref": "#/$defs/_ColorPaletteColor",
-      "title": "内容辅助系统颜色替代"
-    },
-    "Color": {
-      "markdownDescription": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
-      "description": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
-      "$ref": "#/$defs/_Color",
-      "title": "颜色"
-    },
-    "_RelativeMouse1DOutputType": {
-      "markdownDescription": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
-      "type": "string",
-      "description": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
-      "enum": [
-        "relativeMouseX",
-        "relativeMouseY"
-      ],
-      "title": "相对鼠标一维输出"
-    },
-    "_ArcadeButtons": {
-      "type": "object",
-      "required": [
-        "type",
-        "lightKick",
-        "mediumKick",
-        "heavyKick",
-        "lightPunch",
-        "mediumPunch",
-        "heavyPunch"
-      ],
-      "examples": [
-        {
-          "type": "arcadeButtons",
-          "heavyPunch": {
-            "action": "leftBumper"
-          },
-          "lightPunch": {
-            "action": "gamepady"
-          },
-          "lightKick": {
-            "action": "gamepadA"
-          },
-          "specialPunch": {
-            "action": [
-              "gamepadX",
-              "gamepadY"
-            ]
-          },
-          "mediumKick": {
-            "action": "gamepadB"
-          },
-          "specialKick": {
-            "action": [
-              "gamepadA",
-              "gamepadB"
-            ]
-          },
-          "heavyKick": {
-            "action": "gamepadX"
-          },
-          "mediumPunch": {
-            "action": "rightBumper"
-          }
-        }
-      ],
-      "properties": {
-        "specialPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "特殊拳击按钮"
-        },
-        "heavyPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "重踢按钮"
-        },
-        "lightPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "轻拳按键"
-        },
-        "lightKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "轻踢按钮"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeArcadeButtons"
-        },
-        "mediumKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "中等力度踢按钮"
-        },
-        "specialKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "特殊踢出按钮"
-        },
-        "heavyKick": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "重踢按钮"
-        },
-        "mediumPunch": {
-          "$ref": "#/$defs/ArcadeButton",
-          "title": "中等拳击按钮"
-        }
-      },
-      "additionalProperties": false
-    },
-    "OuterLayerControlWheel": {
-      "markdownDescription": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/OuterWheelLayerControlGroup"
-          },
-          "type": "array",
-          "maxItems": 8,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
-      "examples": [
-        [],
-        [
-          {
-            "type": "blank"
-          },
-          [
-            null,
-            {
-              "type": "blank"
-            },
-            null
-          ],
-          {
-            "type": "button",
-            "action": "gamepadX"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonLayerOuterWheel"
-        }
-      ],
-      "title": "外部​​"
-    },
-    "_InputMapping3DTo2DOutput": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMappingXY"
-        },
-        {
-          "$ref": "#/$defs/_InputMappingZY"
-        }
-      ]
-    },
-    "_ControlTypeThrottle": {
-      "const": "throttle",
-      "markdownDescription": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
-      "type": "string",
-      "description": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
-      "title": "限制控件类型"
-    },
-    "LayoutOrientation": {
-      "title": "[已弃用]布局方向",
-      "description": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
-      "enum": [
-        "landscape-left",
-        "landscape-right",
-        "landscape",
-        "portrait-up",
-        "portrait"
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
-      "type": "string"
-    },
-    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "responseCurve": {
-          "$ref": "#/$defs/InputCurve"
-        },
-        "deadzone": {
-          "$ref": "#/$defs/Deadzone1D"
-        },
-        "output": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
-            },
-            {
-              "$ref": "#/$defs/Reference"
-            }
-          ]
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisMagnitudinal"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputAxisXY": {
-      "const": "axisXY",
-      "markdownDescription": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-      "type": "string",
-      "description": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-      "title": "X 轴和 Y 轴输入映射"
-    },
-    "PullActionType": {
-      "markdownDescription": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
-      "description": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "控制拉取操作"
-    },
-    "Knob": {
-      "markdownDescription": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "faceImage": {
-              "$ref": "#/$defs/FaceImage"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            },
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
-      "examples": [
-        {
-          "faceImage": {
-            "type": "asset",
-            "value": "CustomKnobFaceImage"
-          },
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomKnobBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonControlKnobStyling"
-        }
-      ],
-      "title": "Knob 样式设置组件"
-    },
-    "Control": {
-      "markdownDescription": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonButtonControl"
-        }
-      ],
-      "title": "触摸布局控件"
-    },
-    "LayerUpperRightContent": {
-      "markdownDescription": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LayerControl"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
-      "examples": [
-        [
-          {
-            "type": "blank"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
-        }
-      ],
-      "title": "上层右侧内容"
-    },
-    "AxisCapColor": {
-      "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "value": {
-              "$ref": "#/$defs/Color"
-            },
-            "type": {
-              "const": "color",
-              "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
-              "type": "string",
-              "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
-              "title": "坐标轴样式组件"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "title": "坐标轴样式组件"
-    },
-    "_Throttle": {
-      "type": "object",
-      "required": [
-        "type",
-        "axisDown",
-        "axisUp"
-      ],
-      "examples": [
-        {
-          "sticky": true,
-          "type": "throttle",
-          "axisDown": "leftTrigger",
-          "axisUp": "rightTrigger"
-        }
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/_ControlTypeThrottle"
-        },
-        "axisDown": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "relative": {
-          "$ref": "#/$defs/RelativeInteraction"
-        },
-        "axisUp": {
-          "$ref": "#/$defs/ThrottleAxisOutput"
-        },
-        "styles": {
-          "$ref": "#/$defs/ThrottleStyles"
-        },
-        "sticky": {
-          "$ref": "#/$defs/Sticky"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Blank": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "examples": [
-        {
-          "type": "blank"
-        }
-      ],
-      "properties": {
-        "type": {
-          "const": "blank",
-          "markdownDescription": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
-          "type": "string",
-          "description": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
-          "title": "空白控件类型"
-        }
-      },
-      "additionalProperties": false
-    },
-    "RenderAsButton": {
-      "markdownDescription": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/commonRenderAsButton"
-        }
-      ],
-      "title": "呈现为按钮"
-    },
-    "BackgroundAssetValue": {
-      "$ref": "#/$defs/AssetReference"
-    },
-    "_InputMappingXYToMouse2DOutput": {
-      "type": "object",
-      "required": [
-        "input",
-        "output"
-      ],
-      "properties": {
-        "sensitivity": {
-          "$ref": "#/$defs/Sensitivity"
-        },
-        "output": {
-          "$ref": "#/$defs/_RelativeMouse2DOutputType"
-        },
-        "input": {
-          "$ref": "#/$defs/_InputAxisXY"
-        }
-      },
-      "additionalProperties": false
-    },
-    "ColorPaletteHighContrastVariant": {
-      "markdownDescription": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
-      "description": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
-      "$ref": "#/$defs/_ColorPaletteBase",
-      "title": "高对比度颜色"
-    },
-    "LayoutStyles": {
-      "markdownDescription": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
-      "description": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
-      "$ref": "#/$defs/_LayoutStyles",
-      "title": "布局样式"
-    },
-    "LayerControlGroup": {
-      "type": "array",
-      "markdownDescription": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
-      "minItems": 1,
-      "description": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
-          },
-          null
-        ]
-      ],
-      "maxItems": 4,
-      "title": "触摸布局层控制组",
-      "items": {
-        "$ref": "#/$defs/LayerControlGroupItem"
-      }
-    },
-    "_BackgroundColor": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "examples": [
-        {
-          "type": "color",
-          "value": "#0099ffaa"
-        }
-      ],
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/Color"
-        },
-        "type": {
-          "const": "color",
-          "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
-          "type": "string",
-          "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_Gyroscope": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "type": "gyroscope",
-          "axis": {
-            "output": "rightJoystick",
-            "input": "axisXY"
-          }
-        }
-      ],
-      "properties": {
-        "axis": {
-          "$ref": "#/$defs/AxisMapping3D"
-        },
-        "type": {
-          "const": "gyroscope",
-          "markdownDescription": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
-          "type": "string",
-          "description": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
-          "title": "陀螺仪控件类型"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "FaceImageIconLabel": {
-      "markdownDescription": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "action",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
-      "examples": [
-        {
-          "type": "action"
-        },
-        {
-          "type": "none"
-        },
-        {
-          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
-        }
-      ],
-      "title": "人脸图像图标标签样式组件"
-    },
-    "TouchpadStyles": {
-      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idle": {
-              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "控制空闲样式"
-            },
-            "disabled": {
-              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "控件禁用样式"
-            },
-            "activated": {
-              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "控件激活样式"
-            },
-            "moving": {
-              "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
-              "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "控件移动样式"
-            },
-            "default": {
-              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-              "$ref": "#/$defs/TouchpadStyleBase",
-              "title": "控件默认样式"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
-      "examples": [
-        {
-          "default": {
-            "faceImage": {
-              "type": "icon",
-              "value": "look"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/commonTouchpadControlStyles"
-        }
-      ],
-      "title": "控件样式"
-    },
-    "Layer": {
-      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "upper": {
-              "$ref": "#/$defs/LayerUpperContent"
-            },
-            "lower": {
-              "$ref": "#/$defs/LayerLowerContent"
-            },
-            "sensors": {
-              "$ref": "#/$defs/LayerSensorContent"
-            },
-            "left": {
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "center": {
-              "deprecated": true,
-              "$ref": "#/$defs/LayerControlWheel"
-            },
-            "right": {
-              "$ref": "#/$defs/LayerControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
-      "examples": [
-        {
-          "left": {
-            "inner": [
-              {
-                "sticky": true,
-                "type": "throttle",
-                "axisDown": "leftTrigger",
-                "axisUp": "rightTrigger"
-              }
-            ]
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
-        }
-      ],
-      "title": "触摸布局层"
-    },
-    "LayerControlGroupItem": {
-      "markdownDescription": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/_Null"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "触摸布局层控件组项"
-    },
-    "_ColorReference": {
-      "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^colors/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
-        },
-        {
-          "enum": [
-            "colors/system_contentPrimary",
-            "colors/system_contentSecondary",
-            "colors/system_contrastPrimary",
-            "colors/system_contrastSecondary",
-            "colors/system_actionColorDefault",
-            "colors/system_actionColorA",
-            "colors/system_actionColorB",
-            "colors/system_actionColorX",
-            "colors/system_actionColorY",
-            "colors/system_accentPrimary",
-            "colors/system_accentSecondary"
-          ],
-          "type": "string"
-        }
-      ]
-    },
-    "LayoutUpperRightContent": {
-      "markdownDescription": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Control"
-              },
-              {
-                "$ref": "#/$defs/_Null"
-              }
-            ]
-          },
-          "type": "array",
-          "maxItems": 5,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
-      "examples": [
-        [
-          {
-            "type": "button",
-            "action": "menu"
-          },
-          {
-            "type": "button",
-            "action": "view"
-          }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonUpperRightControls"
-        }
-      ],
-      "title": "右上角布局内容"
-    },
-    "JoystickDefaultStyle": {
-      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "控件默认样式"
-    },
-    "_ControllerAnalog2DOutputType": {
-      "markdownDescription": "沿两个游戏手柄游戏杆轴的整个输出值。",
-      "type": "string",
-      "description": "沿两个游戏手柄游戏杆轴的整个输出值。",
-      "enum": [
-        "rightJoystick",
-        "leftJoystick"
-      ],
-      "title": "游戏手柄模拟游戏杆输出"
-    },
-    "LayerLowerContent": {
-      "markdownDescription": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "center": {
-              "$ref": "#/$defs/LayerControl"
-            },
-            "leftCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            },
-            "rightCenter": {
-              "$ref": "#/$defs/LayerLowerArrayContent"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
-      "examples": [
-        {
-          "center": {
-            "type": "blank"
-          }
-        },
-        {
-          "leftCenter": [
-            {
-              "type": "blank"
-            }
-          ],
-          "rightCenter": [
-            {
-              "type": "blank"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
-        }
-      ],
-      "title": "下层内容"
-    },
     "LayoutDefinableType": {
+      "title": "可定义类型",
+      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
       "anyOf": [
         {
           "$ref": "#/$defs/ActionThreshold"
@@ -4377,153 +323,1116 @@
         {
           "$ref": "#/$defs/TouchpadStyles"
         }
-      ],
-      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
-      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
-      "title": "可定义类型"
+      ]
     },
-    "LayoutControlWheel": {
-      "markdownDescription": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "inner": {
-              "$ref": "#/$defs/InnerLayoutControlWheel"
-            },
-            "outer": {
-              "$ref": "#/$defs/OuterLayoutControlWheel"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
+    "Definitions": {
+      "title": "定义",
+      "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
       "examples": [
         {},
         {
-          "inner": [
-            {
-              "type": "joystick",
-              "axis": {
-                "output": "leftJoystick",
-                "input": "axisXY"
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
               }
             }
-          ],
-          "outer": [
-            null,
-            [
-              {
-                "type": "button",
-                "action": "gamepadX"
-              }
-            ],
-            {
-              "type": "button",
-              "action": "gamepadY"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/commonControlWheel"
-        }
-      ],
-      "title": "触摸布局控制轮"
-    },
-    "_RelativeMouse2DOutputType": {
-      "const": "relativeMouse",
-      "markdownDescription": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
-      "type": "string",
-      "description": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
-      "title": "相对鼠标二维输出"
-    },
-    "LayerControl": {
-      "markdownDescription": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_LayerControlBase"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
-      "examples": [
-        {
-          "$ref": "#/definitions/commonLayerButtonControl"
-        }
-      ],
-      "title": "触摸布局层控件"
-    },
-    "Sensitivity": {
-      "markdownDescription": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
-      "anyOf": [
-        {
-          "type": "number",
-          "exclusiveMinimum": 0
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
-      "examples": [
-        10,
-        1.5,
-        0.5,
-        {
-          "$ref": "../../context.json#/state/playerSensitivityPreference"
-        }
-      ],
-      "title": "灵敏度"
-    },
-    "InnerLayerControlWheel": {
-      "markdownDescription": "一组 1 到 4 层控件，包括`blank`控件，用于在下方层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
-      "anyOf": [
-        {
-          "items": {
-            "$ref": "#/$defs/LayerControl"
-          },
-          "type": "array",
-          "maxItems": 4,
-          "minItems": 1
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "一组 1 到 4 层控件，包括`blank`控件，用于在下方层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
-      "examples": [
-        [],
-        [
-          null,
-          {
-            "type": "blank"
           }
-        ],
-        {
-          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
         }
       ],
-      "title": "内部"
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
     },
-    "_Joystick": {
+    "Reference": {
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
+          "markdownDescription": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "Null",
+      "description": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
+      "markdownDescription": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "加速计控件类型",
+          "description": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
+          "markdownDescription": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
       "required": [
         "type",
         "axis"
       ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
       "examples": [
         {
-          "axis": {
-            "output": "leftJoystick",
-            "input": "axisXY"
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
           },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "重踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "重踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "轻踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "轻拳按键",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "中等力度踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "中等拳击按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "特殊踢出按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "特殊拳击按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "二维轴映射项",
+      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "三维轴映射项",
+      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "用于设置背景样式的自定义资产。",
+          "markdownDescription": "用于设置背景样式的自定义资产。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+          "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "空白控件类型",
+          "description": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
+          "markdownDescription": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "游戏手柄模拟游戏杆输出",
+      "description": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
+      "markdownDescription": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "游戏手柄模拟游戏杆输出",
+      "description": "沿指定游戏手柄游戏杆轴的整个输出值。",
+      "markdownDescription": "沿指定游戏手柄游戏杆轴的整个输出值。",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "游戏手柄模拟游戏杆输出",
+      "description": "沿两个游戏手柄游戏杆轴的整个输出值。",
+      "markdownDescription": "沿两个游戏手柄游戏杆轴的整个输出值。",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "游戏手柄按钮输出",
+      "description": "输出按下的游戏手柄按钮。",
+      "markdownDescription": "输出按下的游戏手柄按钮。",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "游戏手柄模拟触发器输出",
+      "description": "输出映射到指定游戏手柄触发器的值。",
+      "markdownDescription": "输出映射到指定游戏手柄触发器的值。",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "Arcade 按钮控件类型",
+      "description": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
+      "markdownDescription": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "按钮控件类型",
+      "description": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
+      "markdownDescription": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "方向盘控件类型",
+      "description": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
+      "markdownDescription": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "游戏杆控件类型",
+      "description": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
+      "markdownDescription": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "限制控件类型",
+      "description": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
+      "markdownDescription": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "触摸板控件类型",
+      "description": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
+      "markdownDescription": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "自定义布局颜色",
+      "description": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
+      "markdownDescription": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "人脸图像资产样式设置组件",
+          "description": "用作控件组件的前景图形的自定义资产。",
+          "markdownDescription": "用作控件组件的前景图形的自定义资产。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "人脸图像图标样式组件",
+          "description": "用作控件组件的前景图形的内置图标。",
+          "markdownDescription": "用作控件组件的前景图形的内置图标。",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "陀螺仪控件类型",
+          "description": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
+          "markdownDescription": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "坐标轴输入映射",
+      "description": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
+      "markdownDescription": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X 轴输入映射",
+          "description": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "markdownDescription": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y 轴输入映射",
+          "description": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "markdownDescription": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X 轴和 Y 轴输入映射",
+      "description": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "markdownDescription": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z 轴和 Y 轴输入映射",
+      "description": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "markdownDescription": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
           "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
           "styles": {
             "default": {
               "knob": {
@@ -4536,24 +1445,22 @@
           }
         }
       ],
+      "additionalProperties": false,
       "properties": {
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
+        "action": {
+          "$ref": "#/$defs/ActionType"
         },
-        "expand": {
-          "$ref": "#/$defs/ExpandInteraction"
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
         },
         "axis": {
           "$ref": "#/$defs/AxisMapping2D"
         },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
         "enabled": {
           "$ref": "#/$defs/ControlEnabled"
         },
-        "actionThreshold": {
-          "$ref": "#/$defs/ActionThreshold"
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
         },
         "relative": {
           "$ref": "#/$defs/RelativeInteraction"
@@ -4561,361 +1468,374 @@
         "styles": {
           "$ref": "#/$defs/JoystickStyles"
         },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
         "type": {
           "$ref": "#/$defs/_ControlTypeJoystick"
         }
       },
-      "additionalProperties": false
-    },
-    "InputCurve": {
-      "examples": [
-        {
-          "type": "circular",
-          "range": [
-            0,
-            0.33
-          ]
-        },
-        {
-          "type": "circular-inverse",
-          "range": [
-            0,
-            1
-          ]
-        },
-        {
-          "$ref": "#/$defs/commonJoystickResponseCurve"
-        }
+      "required": [
+        "type",
+        "axis"
       ],
-      "title": "[已弃用]输入响应曲线",
-      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
+      "type": "object"
+    },
+    "_LayerControlBase": {
       "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "range",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/InputCurveType"
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "布局操作",
+      "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
+      "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "布局操作",
+          "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
+          "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
             },
-            "range": {
-              "$ref": "#/$defs/InputCurveRange"
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。"
+      ]
     },
-    "AxisMapping3D": {
-      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_InputMapping2D"
-          },
-          "type": "array"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
+    "_RelativeMouse1DOutputType": {
+      "title": "相对鼠标一维输出",
+      "description": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
+      "markdownDescription": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
       ],
-      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
-      "examples": [
-        {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "relativeMouse",
-          "input": "axisXY"
-        },
-        [
-          {
-            "output": "rightTrigger",
-            "input": "axisUp"
-          },
-          {
-            "output": "leftTrigger",
-            "input": "axisDown"
-          }
-        ],
-        {
-          "$ref": "#/definitions/commonAxisMapping"
-        }
-      ],
-      "title": "三维轴映射"
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "相对鼠标二维输出",
+      "description": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
+      "markdownDescription": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
+      "const": "relativeMouse",
+      "type": "string"
     },
     "_RelativeMouseMagnitudinalOutputType": {
-      "markdownDescription": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
-      "type": "string",
+      "title": "相对鼠标方向输出",
       "description": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
+      "markdownDescription": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
       "enum": [
         "relativeMouseUp",
         "relativeMouseDown",
         "relativeMouseLeft",
         "relativeMouseRight"
       ],
-      "title": "相对鼠标方向输出"
+      "type": "string"
     },
-    "_InputAxisMagnitudinal": {
-      "markdownDescription": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
-      "type": "string",
-      "description": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
-      "enum": [
-        "axisRight",
-        "axisLeft",
-        "axisUp",
-        "axisDown"
-      ],
-      "title": "坐标轴输入映射"
-    },
-    "_InputAxis1D": {
+    "_SingleControlActionAssignableTypes": {
       "anyOf": [
         {
-          "const": "axisX",
-          "markdownDescription": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-          "type": "string",
-          "description": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-          "title": "X 轴输入映射"
+          "$ref": "#/$defs/_ControllerAction"
         },
         {
-          "const": "axisY",
-          "markdownDescription": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-          "type": "string",
-          "description": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
-          "title": "Y 轴输入映射"
-        }
-      ]
-    },
-    "JoystickOutlineWithoutIndicator": {
-      "markdownDescription": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
-      "anyOf": [
+          "$ref": "#/$defs/_LayoutAction"
+        },
         {
-          "type": "object",
-          "properties": {
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "stroke": {
-              "$ref": "#/$defs/Stroke"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/_TurboAction"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
+      ]
+    },
+    "_StrokeBase": {
       "examples": [
         {
-          "stroke": {
-            "type": "solid",
-            "color": "#0099ffaa"
-          }
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
         },
         {
-          "$ref": "#/definitions/commonOutlineStyling"
+          "$ref": "#/definitions/commonControlStroke"
         }
       ],
-      "title": "大纲样式组件"
-    },
-    "ThrottleStyleBase": {
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "type": {
+              "description": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
+              "markdownDescription": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
             },
             "opacity": {
               "$ref": "#/$defs/Opacity"
-            },
-            "axisUp": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "axisDown": {
-              "$ref": "#/$defs/ThrottleAxisStyle"
-            },
-            "indicator": {
-              "$ref": "#/$defs/Indicator"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "type"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "examples": [
-        {
-          "axisUp": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "axisDown": {
-            "stroke": {
-              "color": "#0099ff",
-              "type": "solid",
-              "opacity": 1
-            },
-            "cap": {
-              "type": "color",
-              "value": "#0099ffaa"
-            }
-          },
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          }
-        }
       ]
     },
-    "_AxisMapping3DItem": {
-      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
-        },
-        {
-          "$ref": "#/$defs/_AxisMapping2DItem"
-        }
-      ],
-      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+    "_SystemColorContentPrimary": {
+      "title": "内容主系统颜色替代",
+      "description": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
+      "markdownDescription": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "内容辅助系统颜色替代",
+      "description": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
+      "markdownDescription": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "对比度主系统颜色替代",
+      "description": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
+      "markdownDescription": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "对比度辅助系统颜色替代",
+      "description": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
+      "markdownDescription": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "操作系统颜色替代",
+      "description": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
+      "markdownDescription": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "游戏手柄操作系统颜色替代",
+      "description": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
+      "markdownDescription": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "重置主要系统颜色强调",
+      "description": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
+      "markdownDescription": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "重音次要系统颜色覆盖",
+      "description": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
+      "markdownDescription": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
       "examples": [
         {
-          "sensitivity": 0.3,
-          "output": "rightJoystick",
-          "input": "axisXY"
-        },
-        {
-          "output": "rightTrigger",
-          "input": "axisUp"
-        },
-        {
-          "$ref": "#/definitions/commonAxisMapping"
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
         }
       ],
-      "title": "三维轴映射项"
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "Turbo 操作",
+      "description": "根据时间间隔而不是连续触发的操作。",
+      "markdownDescription": "根据时间间隔而不是连续触发的操作。",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "Turbo 操作",
+          "description": "根据时间间隔而不是连续触发的操作。",
+          "markdownDescription": "根据时间间隔而不是连续触发的操作。",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "操作阈值",
+      "description": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+      "markdownDescription": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "ActionType": {
-      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "title": "控制操作",
       "description": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
-      "$ref": "#/$defs/_ActionTypeBase",
-      "title": "控制操作"
-    },
-    "Layers": {
-      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
-      "anyOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
-              "$ref": "#/$defs/Layer"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
-      "examples": [
-        {
-          "AdvancedDrivingLayer": {
-            "left": {
-              "inner": [
-                {
-                  "sticky": true,
-                  "type": "throttle",
-                  "axisDown": "leftTrigger",
-                  "axisUp": "rightTrigger"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
-        }
-      ],
-      "title": "触摸布局层"
-    },
-    "DeadzoneRadial": {
-      "markdownDescription": "是否沿径向输入组件或每个轴单独计算死区阈值。",
-      "anyOf": [
-        {
-          "type": "boolean"
-        }
-      ],
-      "description": "是否沿径向输入组件或每个轴单独计算死区阈值。",
-      "examples": [
-        true,
-        false,
-        {
-          "$ref": "#/definitions/radialConfig"
-        }
-      ],
-      "title": "径向"
+      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "$ref": "#/$defs/_ActionTypeBase"
     },
     "ArcadeButton": {
-      "markdownDescription": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "enabled": {
-              "$ref": "#/$defs/ControlEnabled"
-            },
-            "visible": {
-              "$ref": "#/$defs/ControlVisibility"
-            },
-            "styles": {
-              "$ref": "#/$defs/ArcadeButtonStyles"
-            },
-            "action": {
-              "$ref": "#/$defs/ActionType"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
       "description": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
+      "markdownDescription": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
       "examples": [
         {
           "action": "gamepadX",
@@ -4931,64 +1851,993 @@
         {
           "$ref": "../../context.json#/definitions/commonFightingButtons"
         }
-      ]
-    },
-    "JoystickMovingStyle": {
-      "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+      ],
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
+            "action": {
+              "$ref": "#/$defs/ActionType"
             },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
             },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
             },
-            "knob": {
-              "$ref": "#/$defs/Knob"
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
             }
           },
-          "additionalProperties": false
+          "required": [
+            "action"
+          ],
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+      ]
+    },
+    "ArcadeButtonStyleBase": {
       "examples": [
-        {},
         {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
-            "stroke": {
-              "type": "solid",
-              "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
           "background": {
             "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
           }
         },
         {
-          "$ref": "#/definitions/commonJoystickStyle"
+          "$ref": "#/definitions/commonArcadeButtonStyle"
         }
       ],
-      "title": "控件移动样式"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "控件禁用样式",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "资产引用样式组件",
+      "description": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
+      "markdownDescription": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "坐标轴样式组件",
+      "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+      "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "坐标轴样式组件",
+              "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+              "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "二维轴映射",
+      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "三维轴映射",
+      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "背景样式组件",
+      "description": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+      "markdownDescription": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "控件激活样式",
+      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "控件默认样式",
+      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "控件禁用样式",
+      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "控制空闲样式",
+      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
+      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "控件切换样式",
+      "description": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
+      "markdownDescription": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "控件拉取样式",
+      "description": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+      "markdownDescription": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "颜色",
+      "description": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "markdownDescription": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "默认颜色",
+      "description": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "markdownDescription": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "高对比度颜色",
+      "description": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "markdownDescription": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "触摸布局控件",
+      "description": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "markdownDescription": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "已启用",
+      "description": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
+      "markdownDescription": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "触摸布局控制组",
+      "description": "租中排列的一组 1 到 4 个控件。系统确定如何在可用空间内最佳地排列组中的控件；只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
+      "markdownDescription": "租中排列的一组 1 到 4 个控件。系统确定如何在可用空间内最佳地排列组中的控件；只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null`的特殊值可用于跳过排列中的控件。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "触摸布局控件组项",
+      "description": "控制组中的单个项。使用`null`跳过排列中的控件。",
+      "markdownDescription": "控制组中的单个项。使用`null`跳过排列中的控件。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "游戏手柄操作",
+      "description": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
+      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "可见",
+      "description": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+      "markdownDescription": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "一维死区",
+      "description": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
+      "markdownDescription": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "二维死区",
+      "description": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
+      "markdownDescription": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "方向板死区",
+      "description": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
+      "markdownDescription": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "阈值",
+      "description": "生成输出值所需的规范化输入值。",
+      "markdownDescription": "生成输出值所需的规范化输入值。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "径向",
+      "description": "是否沿径向输入组件或每个轴单独计算死区阈值。",
+      "markdownDescription": "是否沿径向输入组件或每个轴单独计算死区阈值。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "交互",
+      "description": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
+      "markdownDescription": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "DirectionalPadInteractionActivationType": {
+      "title": "激活类型",
+      "description": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
       "markdownDescription": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
       "anyOf": [
         {
           "type": "string",
@@ -5000,319 +2849,458 @@
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
-      "examples": [
-        "exclusive",
-        "allowNeighboring",
-        {
-          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
-        }
-      ],
-      "title": "激活类型"
-    },
-    "_HexColor": {
-      "type": "string",
-      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$"
-    },
-    "_ControllerAnalogMagnitudinalOutputType": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_ControllerTriggerOutputType"
-        },
-        {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
-        }
       ]
     },
-    "_FaceImageAsset": {
-      "required": [
-        "type",
-        "value"
-      ],
-      "type": "object",
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/FaceImageAssetValue"
-        },
-        "type": {
-          "const": "asset",
-          "markdownDescription": "用作控件组件的前景图形的自定义资产。",
-          "type": "string",
-          "description": "用作控件组件的前景图形的自定义资产。",
-          "title": "人脸图像资产样式设置组件"
-        },
-        "opacity": {
-          "$ref": "#/$defs/Opacity"
-        }
-      },
-      "additionalProperties": false
-    },
-    "_InputMapping1DToRelativeMouse1DOutput": {
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "input",
-            "output"
-          ],
-          "properties": {
-            "sensitivity": {
-              "$ref": "#/$defs/Sensitivity"
-            },
-            "output": {
-              "$ref": "#/$defs/_RelativeMouse1DOutputType"
-            },
-            "input": {
-              "$ref": "#/$defs/_InputAxis1D"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ]
-    },
-    "_ColorPaletteBase": {
-      "patternProperties": {
-        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/$defs/_CustomColorPaletteColor"
-        }
-      },
-      "type": "object",
+    "DirectionalPadStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
       "examples": [
         {},
         {
-          "myColor": "#ff00ffff",
-          "system_contentPrimary": "#ffffffff"
-        }
-      ],
-      "properties": {
-        "system_actionColorA": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_contrastSecondary": {
-          "$ref": "#/$defs/_SystemColorContrastSecondary"
-        },
-        "system_contrastPrimary": {
-          "$ref": "#/$defs/_SystemColorContrastPrimary"
-        },
-        "system_contentSecondary": {
-          "$ref": "#/$defs/_SystemColorContentSecondary"
-        },
-        "system_actionColorY": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_accentPrimary": {
-          "$ref": "#/$defs/_SystemColorAccentPrimary"
-        },
-        "system_contentPrimary": {
-          "$ref": "#/$defs/_SystemColorContentPrimary"
-        },
-        "system_actionColorDefault": {
-          "$ref": "#/$defs/_SystemColorActionColor"
-        },
-        "system_accentSecondary": {
-          "$ref": "#/$defs/_SystemColorAccentSecondary"
-        },
-        "system_actionColorX": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        },
-        "system_actionColorB": {
-          "$ref": "#/$defs/_SystemColorGamepadActionColor"
-        }
-      },
-      "additionalProperties": false
-    },
-    "TurboActionInterval": {
-      "examples": [
-        500,
-        1000
-      ],
-      "title": "间隔",
-      "description": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
-      "exclusiveMinimum": 0,
-      "markdownDescription": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
-      "type": "number"
-    },
-    "_ControlTypeJoystick": {
-      "const": "joystick",
-      "markdownDescription": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
-      "type": "string",
-      "description": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
-      "title": "游戏杆控件类型"
-    },
-    "JoystickDisabledStyle": {
-      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "background": {
-              "$ref": "#/$defs/Background"
-            },
-            "opacity": {
-              "$ref": "#/$defs/Opacity"
-            },
-            "outline": {
-              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
-            },
-            "knob": {
-              "$ref": "#/$defs/Knob"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
-      "examples": [
-        {},
-        {
-          "knob": {
-            "faceImage": {
-              "type": "asset",
-              "value": "CustomKnobFaceImage"
-            },
+          "default": {
             "stroke": {
               "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
               "color": "#0099ffaa"
-            },
-            "background": {
-              "type": "asset",
-              "value": "CustomKnobBackgroundImage"
-            }
-          },
-          "background": {
-            "type": "asset",
-            "value": "CustomJoystickBackgroundImage"
-          }
-        },
-        {
-          "$ref": "#/definitions/commonJoystickStyle"
-        }
-      ],
-      "title": "控件禁用样式"
-    },
-    "Opacity": {
-      "markdownDescription": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
-      "anyOf": [
-        {
-          "minimum": 0,
-          "maximum": 1,
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/Reference"
-        }
-      ],
-      "description": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
-      "examples": [
-        1,
-        0.5,
-        0,
-        {
-          "$ref": "#/definitions/buttonOpacity"
-        }
-      ],
-      "title": "不透明度"
-    },
-    "_ControlTypeArcadeButtons": {
-      "const": "arcadeButtons",
-      "markdownDescription": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
-      "type": "string",
-      "description": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
-      "title": "Arcade 按钮控件类型"
-    },
-    "_Touchpad": {
-      "type": "object",
-      "required": [
-        "type",
-        "axis"
-      ],
-      "examples": [
-        {
-          "axis": [
-            {
-              "output": "relativeMouse",
-              "input": "axisXY"
-            }
-          ],
-          "type": "touchpad",
-          "styles": {
-            "default": {
-              "faceImage": {
-                "type": "icon",
-                "value": "look"
-              }
             }
           }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
         }
       ],
-      "properties": {
-        "styles": {
-          "$ref": "#/$defs/TouchpadStyles"
-        },
-        "visible": {
-          "$ref": "#/$defs/ControlVisibility"
-        },
-        "renderAsButton": {
-          "$ref": "#/$defs/RenderAsButton"
-        },
-        "action": {
-          "$ref": "#/$defs/ActionType"
-        },
-        "axis": {
-          "$ref": "#/$defs/AxisMapping2D"
-        },
-        "enabled": {
-          "$ref": "#/$defs/ControlEnabled"
-        },
-        "type": {
-          "$ref": "#/$defs/_ControlTypeTouchpad"
-        }
-      },
-      "additionalProperties": false
-    },
-    "LayerUpperContent": {
-      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
       "anyOf": [
         {
-          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "right": {
-              "$ref": "#/$defs/LayerUpperRightContent"
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
             }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "description": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "展开",
+      "description": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
+      "markdownDescription": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
       "examples": [
+        true,
+        false,
         {
-          "right": [
-            {
-              "type": "blank"
-            },
-            {
-              "type": "button",
-              "action": "view"
-            }
-          ]
-        },
-        {
-          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
         }
       ],
-      "title": "上层内容"
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "人脸图像样式设置组件",
+      "description": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+      "markdownDescription": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "人脸图像图标标签样式组件",
+      "description": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
+      "markdownDescription": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "人脸图像图标",
+      "description": "此属性用于选择要用于此组件的内置图标。",
+      "markdownDescription": "此属性用于选择要用于此组件的内置图标。",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "填充",
+      "description": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "markdownDescription": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "渐变",
+      "description": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
+      "markdownDescription": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "指示器样式组件",
+      "description": "用于指示控件的当前值或位置的笔划的视觉样式。",
+      "markdownDescription": "用于指示控件的当前值或位置的笔划的视觉样式。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "内部",
+      "description": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
+      "markdownDescription": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "内部",
+      "description": "一组 1 到 4 层控件，包括`blank`控件，用于在下方层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
+      "markdownDescription": "一组 1 到 4 层控件，包括`blank`控件，用于在下方层隐藏控件，这些控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
     },
     "InputCurveRange": {
+      "deprecated": true,
+      "title": "[已弃用]输入曲线范围",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
       "examples": [
         [
           0,
@@ -5334,63 +3322,1480 @@
           }
         ]
       ],
-      "title": "[已弃用]输入曲线范围",
-      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
       "anyOf": [
         {
           "items": {
             "anyOf": [
               {
+                "type": "number",
                 "minimum": -1,
-                "maximum": 1,
-                "type": "number"
+                "maximum": 1
               },
               {
                 "$ref": "#/$defs/Reference"
               }
             ]
           },
-          "type": "array",
           "maxItems": 2,
-          "minItems": 2
+          "minItems": 2,
+          "type": "array"
         },
         {
           "$ref": "#/$defs/Reference"
         }
-      ],
-      "deprecated": true,
-      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。"
-    },
-    "_ActionTypeBase": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
-          },
-          "type": "array"
-        }
-      ],
-      "examples": [
-        "gamepadB",
-        {
-          "$ref": "../../context.json#/state/jumpControllerMapping"
-        },
-        [
-          "gamepadA",
-          "leftTrigger"
-        ]
       ]
     },
-    "_ControllerAction": {
-      "anyOf": [
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[已弃用]输入响应曲线",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
+      "examples": [
         {
-          "$ref": "#/$defs/_ControllerButtonOutputType"
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
         },
         {
-          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[已弃用]输入响应曲线类型",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。",
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "控件激活样式",
+      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "控件默认样式",
+      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "方向指示器样式设置组件",
+      "description": "指示交互方向的视觉样式",
+      "markdownDescription": "指示交互方向的视觉样式",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
+              "markdownDescription": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "控件禁用样式",
+      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "控制空闲样式",
+      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "控件移动样式",
+      "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+      "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "大纲样式组件",
+      "description": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+      "markdownDescription": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "大纲样式组件",
+      "description": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
+      "markdownDescription": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "Knob 样式设置组件",
+      "description": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
+      "markdownDescription": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "触摸布局层",
+      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "触摸布局层",
+      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "触摸布局层控件",
+      "description": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
+      "markdownDescription": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "触摸布局层控制组",
+      "description": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
+      "markdownDescription": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "触摸布局层控件组项",
+      "description": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
+      "markdownDescription": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "触摸布局层控制轮",
+      "description": "一组以圆圈或滚轮形状组织的层控件。",
+      "markdownDescription": "一组以圆圈或滚轮形状组织的层控件。",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "下层数组内容",
+      "description": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "markdownDescription": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "下层内容",
+      "description": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
+      "markdownDescription": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "传感器层内容",
+      "description": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "上层内容",
+      "description": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "上层右侧内容",
+      "description": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
+      "markdownDescription": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "布局操作目标",
+      "description": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
+      "markdownDescription": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "颜色",
+      "description": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
+      "markdownDescription": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "布局内容",
+      "description": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
+      "markdownDescription": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "触摸布局控制轮",
+      "description": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
+      "markdownDescription": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[已弃用]布局方向",
+      "description": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
+      "markdownDescription": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "下层布局数组内容",
+      "description": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "markdownDescription": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "下层布局内容",
+      "description": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
+      "markdownDescription": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "传感器布局内容",
+      "description": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
+      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "布局样式",
+      "description": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "markdownDescription": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "上层布局内容",
+      "description": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
+      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "右上角布局内容",
+      "description": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
+      "markdownDescription": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "不透明度",
+      "description": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
+      "markdownDescription": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "外部​​",
+      "description": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
+      "markdownDescription": "定义滚轮外环上存在的控件或控件组的外部环。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "外部​​",
+      "description": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
+      "markdownDescription": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
         }
       ]
     },
@@ -5406,31 +4811,626 @@
           "$ref": "#/$defs/_Null"
         }
       ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "控制拉取操作",
+      "description": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "markdownDescription": "此属性允许控件在处于`pulled`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "PullIndicator": {
+      "title": "拉动指示器样式组件",
+      "description": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
+      "markdownDescription": "当前正在拉取控件指示器的视觉样式。可以自定义此项的颜色，以指示拉取控件的语义。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "背景样式组件",
+      "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+      "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "亲属",
+      "description": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
+      "markdownDescription": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "呈现为按钮",
+      "description": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
+      "markdownDescription": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "扩展",
+      "description": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
+      "markdownDescription": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "灵敏度",
+      "description": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
+      "markdownDescription": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "传感器控件",
+      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "层传感器控件",
+      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "精华",
+      "description": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
+      "markdownDescription": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "笔划样式组件",
+      "description": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
+      "markdownDescription": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "限制轴",
+      "description": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+      "markdownDescription": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "限制轴样式组件",
+      "description": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+      "markdownDescription": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "控件已激活向上样式",
+              "description": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
+              "markdownDescription": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "控件已激活向下样式",
+              "description": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
+              "markdownDescription": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "控件禁用样式",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "控制空闲向上样式",
+              "description": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
+              "markdownDescription": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "切换",
+      "description": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
+      "markdownDescription": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "控件禁用样式",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "控件移动样式",
+              "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+              "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "间隔",
+      "description": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
+      "markdownDescription": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
     }
   },
-  "description": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
   "properties": {
-    "orientation": {
-      "$ref": "#/$defs/LayoutOrientation"
+    "$schema": {
+      "type": "string"
     },
     "content": {
       "$ref": "#/$defs/LayoutContent"
     },
-    "definitions": {
-      "$ref": "#/$defs/Definitions"
-    },
     "styles": {
       "$ref": "#/$defs/LayoutStyles"
     },
-    "$schema": {
-      "type": "string"
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
     }
   },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "required": [
     "content"
   ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.0/layout.json",
-  "title": "触摸适配捆绑包布局架构",
-  "markdownDescription": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。"
+  "type": "object"
 }

--- a/touch-adaptation-kit/schemas/zh-CN/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/zh-CN/takxconfig/v1/takxconfig.json
@@ -1,221 +1,221 @@
 {
-  "additionalProperties": false,
-  "type": "object",
-  "$defs": {
-    "LanguageItem": {
-      "markdownDescription": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。",
-      "description": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。",
-      "enum": [
-        "ar",
-        "ar-SA",
-        "cs",
-        "cs-CZ",
-        "da",
-        "da-DK",
-        "de",
-        "de-DE",
-        "el",
-        "el-GR",
-        "en",
-        "en-US",
-        "en-GB",
-        "es",
-        "es-ES",
-        "es-MX",
-        "fi",
-        "fi-FI",
-        "fil",
-        "fil-PH",
-        "fr",
-        "fr-FR",
-        "he",
-        "he-IL",
-        "hu",
-        "hu-HU",
-        "id",
-        "id-ID",
-        "it",
-        "it-IT",
-        "ja",
-        "ja-JP",
-        "ko",
-        "ko-KR",
-        "ms",
-        "ms-MY",
-        "nb",
-        "nb-NO",
-        "nl",
-        "nl-NL",
-        "pl",
-        "pl-PL",
-        "pt",
-        "pt-BR",
-        "pt-PT",
-        "ru",
-        "ru-RU",
-        "sk",
-        "sk-SK",
-        "sv",
-        "sv-SE",
-        "th",
-        "th-TH",
-        "tr",
-        "tr-TR",
-        "vi",
-        "vi-VN",
-        "zh",
-        "zh-CN",
-        "zh-TW"
-      ],
-      "title": "IETF 语言标记"
-    }
-  },
-  "description": "触摸适配捆绑包配置文件(即 `takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
-  "properties": {
-    "versionName": {
-      "markdownDescription": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 处描述的 API 查询此属性。",
-      "type": "string",
-      "description": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 处描述的 API 查询此属性。",
-      "examples": [
-        "DLC 2"
-      ],
-      "title": "触摸适配捆绑包版本名称"
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "触摸适配捆绑包配置文件架构",
+    "description": "触摸适配捆绑包配置文件(即 `takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+    "markdownDescription": "触摸适配捆绑包配置文件(即 `takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+    "$defs": {
+        "LanguageItem": {
+            "title": "IETF 语言标记",
+            "description": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。",
+            "markdownDescription": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。",
+            "enum": [
+                "ar",
+                "ar-SA",
+                "cs",
+                "cs-CZ",
+                "da",
+                "da-DK",
+                "de",
+                "de-DE",
+                "el",
+                "el-GR",
+                "en",
+                "en-US",
+                "en-GB",
+                "es",
+                "es-ES",
+                "es-MX",
+                "fi",
+                "fi-FI",
+                "fil",
+                "fil-PH",
+                "fr",
+                "fr-FR",
+                "he",
+                "he-IL",
+                "hu",
+                "hu-HU",
+                "id",
+                "id-ID",
+                "it",
+                "it-IT",
+                "ja",
+                "ja-JP",
+                "ko",
+                "ko-KR",
+                "ms",
+                "ms-MY",
+                "nb",
+                "nb-NO",
+                "nl",
+                "nl-NL",
+                "pl",
+                "pl-PL",
+                "pt",
+                "pt-BR",
+                "pt-PT",
+                "ru",
+                "ru-RU",
+                "sk",
+                "sk-SK",
+                "sv",
+                "sv-SE",
+                "th",
+                "th-TH",
+                "tr",
+                "tr-TR",
+                "vi",
+                "vi-VN",
+                "zh",
+                "zh-CN",
+                "zh-TW"
+            ]
+        }
     },
-    "layouts": {
-      "type": "object",
-      "markdownDescription": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
-      "properties": {
-        "default": {
-          "markdownDescription": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient 中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
-          "type": "string",
-          "description": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient 中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "title": "触摸适配捆绑包默认布局"
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
         },
-        "path": {
-          "examples": [
-            "./layouts"
-          ],
-          "title": "触摸适配捆绑包布局路径",
-          "format": "uri-reference",
-          "description": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
-          "markdownDescription": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
-          "type": "string"
-        }
-      },
-      "description": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
-      "examples": [
-        {
-          "path": "./layouts"
+        "layouts": {
+            "title": "触摸适配捆绑包布局配置",
+            "description": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
+            "markdownDescription": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
+            "examples": [
+                {
+                    "path": "./layouts"
+                },
+                {
+                    "path": "./layouts",
+                    "default": "cinematic"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "触摸适配捆绑包布局路径",
+                    "description": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
+                    "markdownDescription": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
+                    "examples": [
+                        "./layouts"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "default": {
+                    "title": "触摸适配捆绑包默认布局",
+                    "description": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient 中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
+                    "markdownDescription": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient 中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
+                    "examples": [
+                        "cinematic",
+                        "menu",
+                        "firstPerson"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ]
         },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
+        "assets": {
+            "title": "触摸适配捆绑包资产配置",
+            "description": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
+            "markdownDescription": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
+            "examples": [
+                {
+                    "path": "./assets"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "触摸适配捆绑包资产路径",
+                    "description": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
+                    "markdownDescription": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
+                    "examples": [
+                        "./assets"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "context": {
+            "title": "触摸适配捆绑包上下文文件配置",
+            "description": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
+            "markdownDescription": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
+            "examples": [
+                {
+                    "path": "./context.json"
+                }
+            ],
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "title": "触摸适配捆绑包上下文文件路径",
+                    "description": "此属性定义从此文件到上下文文件的相对路径。",
+                    "markdownDescription": "此属性定义从此文件到上下文文件的相对路径。",
+                    "examples": [
+                        "./context.json"
+                    ],
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "languages": {
+            "title": "触摸适配捆绑包语言配置",
+            "description": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
+            "markdownDescription": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
+            "examples": [
+                [],
+                [
+                    "en-US"
+                ],
+                [
+                    "en",
+                    "fr-FR"
+                ]
+            ],
+            "items": {
+                "$ref": "#/$defs/LanguageItem"
+            },
+            "type": "array"
+        },
+        "version": {
+            "title": "触摸适配捆绑包版本",
+            "description": "该属性定义了触摸捆绑包的版本号。虽然版本由主要、次要、构建和修订组件组成，但这些特定语义不会被触摸捆绑包运行时解释。相反，将使用运行时能够加载的最高版本化的捆绑包。确定可以加载捆绑包的能力取决于在捆绑包中使用的最大布局模式版本。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 中描述的 API 查询此属性。",
+            "markdownDescription": "该属性定义了触摸捆绑包的版本号。虽然版本由主要、次要、构建和修订组件组成，但这些特定语义不会被触摸捆绑包运行时解释。相反，将使用运行时能够加载的最高版本化的捆绑包。确定可以加载捆绑包的能力取决于在捆绑包中使用的最大布局模式版本。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 中描述的 API 查询此属性。",
+            "examples": [
+                "1.0.0.0"
+            ],
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+        },
+        "versionName": {
+            "title": "触摸适配捆绑包版本名称",
+            "description": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 处描述的 API 查询此属性。",
+            "markdownDescription": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 处描述的 API 查询此属性。",
+            "examples": [
+                "DLC 2"
+            ],
+            "type": "string"
         }
-      ],
-      "title": "触摸适配捆绑包布局配置",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
     },
-    "version": {
-      "examples": [
-        "1.0.0.0"
-      ],
-      "title": "触摸适配捆绑包版本",
-      "description": "该属性定义了触摸捆绑包的版本号。虽然版本由主要、次要、构建和修订组件组成，但这些特定语义不会被触摸捆绑包运行时解释。相反，将使用运行时能够加载的最高版本化的捆绑包。确定可以加载捆绑包的能力取决于在捆绑包中使用的最大布局模式版本。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 中描述的 API 查询此属性。",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "markdownDescription": "该属性定义了触摸捆绑包的版本号。虽然版本由主要、次要、构建和修订组件组成，但这些特定语义不会被触摸捆绑包运行时解释。相反，将使用运行时能够加载的最高版本化的捆绑包。确定可以加载捆绑包的能力取决于在捆绑包中使用的最大布局模式版本。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 中描述的 API 查询此属性。",
-      "type": "string"
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "type": "object",
-      "markdownDescription": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
-      "properties": {
-        "path": {
-          "examples": [
-            "./context.json"
-          ],
-          "title": "触摸适配捆绑包上下文文件路径",
-          "format": "uri-reference",
-          "description": "此属性定义从此文件到上下文文件的相对路径。",
-          "markdownDescription": "此属性定义从此文件到上下文文件的相对路径。",
-          "type": "string"
-        }
-      },
-      "description": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "title": "触摸适配捆绑包上下文文件配置",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    },
-    "languages": {
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "title": "触摸适配捆绑包语言配置",
-      "description": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "markdownDescription": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
-      "type": "array"
-    },
-    "assets": {
-      "type": "object",
-      "markdownDescription": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
-      "properties": {
-        "path": {
-          "examples": [
-            "./assets"
-          ],
-          "title": "触摸适配捆绑包资产路径",
-          "format": "uri-reference",
-          "description": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
-          "markdownDescription": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
-          "type": "string"
-        }
-      },
-      "description": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "title": "触摸适配捆绑包资产配置",
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
-  "title": "触摸适配捆绑包配置文件架构",
-  "markdownDescription": "触摸适配捆绑包配置文件(即 `takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。"
+    "additionalProperties": false,
+    "required": [
+      "layouts",
+      "version"
+    ]
 }

--- a/touch-adaptation-kit/schemas/zh-CN/takxconfig/v1/takxconfig.json
+++ b/touch-adaptation-kit/schemas/zh-CN/takxconfig/v1/takxconfig.json
@@ -1,155 +1,9 @@
 {
-  "required": [
-    "layouts",
-    "version"
-  ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "$schema": {
-      "type": "string"
-    },
-    "context": {
-      "examples": [
-        {
-          "path": "./context.json"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
-      "markdownDescription": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
-      "required": [
-        "path"
-      ],
-      "title": "触摸适配捆绑包上下文文件配置",
-      "properties": {
-        "path": {
-          "markdownDescription": "此属性定义从此文件到上下文文件的相对路径。",
-          "description": "此属性定义从此文件到上下文文件的相对路径。",
-          "title": "触摸适配捆绑包上下文文件路径",
-          "examples": [
-            "./context.json"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "versionName": {
-      "description": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion处描述的 API 查询此属性。",
-      "title": "触摸适配捆绑包版本名称",
-      "examples": [
-        "DLC 2"
-      ],
-      "type": "string",
-      "markdownDescription": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion处描述的 API 查询此属性。"
-    },
-    "assets": {
-      "examples": [
-        {
-          "path": "./assets"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
-      "markdownDescription": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
-      "required": [
-        "path"
-      ],
-      "title": "触摸适配捆绑包资产配置",
-      "properties": {
-        "path": {
-          "markdownDescription": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
-          "description": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
-          "title": "触摸适配捆绑包资产路径",
-          "examples": [
-            "./assets"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    },
-    "languages": {
-      "markdownDescription": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
-      "items": {
-        "$ref": "#/$defs/LanguageItem"
-      },
-      "description": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
-      "title": "触摸适配捆绑包语言配置",
-      "examples": [
-        [],
-        [
-          "en-US"
-        ],
-        [
-          "en",
-          "fr-FR"
-        ]
-      ],
-      "type": "array"
-    },
-    "version": {
-      "markdownDescription": "此属性定义触摸捆绑包的版本号。虽然版本由主要组件、次版本组件、内部版本组件和修订版组件组成，但 Touch 捆绑包运行时不会解释这些特定语义。改为使用运行时能够加载的最高版本的捆绑包。捆绑包的加载能力由捆绑包中使用的最大布局架构版本决定。可以通过https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion处描述的 API 查询此属性。",
-      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-      "description": "此属性定义触摸捆绑包的版本号。虽然版本由主要组件、次版本组件、内部版本组件和修订版组件组成，但 Touch 捆绑包运行时不会解释这些特定语义。改为使用运行时能够加载的最高版本的捆绑包。捆绑包的加载能力由捆绑包中使用的最大布局架构版本决定。可以通过https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion处描述的 API 查询此属性。",
-      "title": "触摸适配捆绑包版本",
-      "examples": [
-        "1.0.0.0"
-      ],
-      "type": "string"
-    },
-    "layouts": {
-      "examples": [
-        {
-          "path": "./layouts"
-        },
-        {
-          "default": "cinematic",
-          "path": "./layouts"
-        }
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
-      "markdownDescription": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
-      "required": [
-        "path"
-      ],
-      "title": "触摸适配捆绑包布局配置",
-      "properties": {
-        "default": {
-          "description": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
-          "title": "触摸适配捆绑包默认布局",
-          "examples": [
-            "cinematic",
-            "menu",
-            "firstPerson"
-          ],
-          "type": "string",
-          "markdownDescription": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。"
-        },
-        "path": {
-          "markdownDescription": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
-          "description": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
-          "title": "触摸适配捆绑包布局路径",
-          "examples": [
-            "./layouts"
-          ],
-          "type": "string",
-          "format": "uri-reference"
-        }
-      }
-    }
-  },
-  "title": "触摸适配捆绑包配置文件架构",
-  "description": "触控适应捆绑包配置文件(，即`takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
-  "markdownDescription": "触控适应捆绑包配置文件(，即`takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
   "additionalProperties": false,
-  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v4.0/takxconfig.json",
+  "type": "object",
   "$defs": {
     "LanguageItem": {
+      "markdownDescription": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。",
       "description": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。",
       "enum": [
         "ar",
@@ -213,9 +67,155 @@
         "zh-CN",
         "zh-TW"
       ],
-      "title": "IETF 语言标记",
-      "markdownDescription": "除了捆绑包支持的非特定语言之外，还定义一种语言的单语言标记。"
+      "title": "IETF 语言标记"
     }
   },
-  "type": "object"
+  "description": "触摸适配捆绑包配置文件(即 `takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+  "properties": {
+    "versionName": {
+      "markdownDescription": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 处描述的 API 查询此属性。",
+      "type": "string",
+      "description": "此属性定义表示此版本的触摸捆绑包的描述性名称。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 处描述的 API 查询此属性。",
+      "examples": [
+        "DLC 2"
+      ],
+      "title": "触摸适配捆绑包版本名称"
+    },
+    "layouts": {
+      "type": "object",
+      "markdownDescription": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
+      "properties": {
+        "default": {
+          "markdownDescription": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient 中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
+          "type": "string",
+          "description": "此属性定义触摸捆绑包的起始活动布局。若要指定默认布局，请使用不带文件扩展名的布局文件的名称。稍后可通过在 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreamingshowtouchcontrollayoutonclient 中描述的 API 调用更改活动布局。如果省略，将不使用任何起始布局。",
+          "examples": [
+            "cinematic",
+            "menu",
+            "firstPerson"
+          ],
+          "title": "触摸适配捆绑包默认布局"
+        },
+        "path": {
+          "examples": [
+            "./layouts"
+          ],
+          "title": "触摸适配捆绑包布局路径",
+          "format": "uri-reference",
+          "description": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
+          "markdownDescription": "此属性定义从此文件到包含此捆绑包的所有布局的目录的相对路径。",
+          "type": "string"
+        }
+      },
+      "description": "此属性定义与布局文件相关的捆绑包属性，例如磁盘布局文件的位置以及应用作默认布局的布局文件。",
+      "examples": [
+        {
+          "path": "./layouts"
+        },
+        {
+          "default": "cinematic",
+          "path": "./layouts"
+        }
+      ],
+      "title": "触摸适配捆绑包布局配置",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "version": {
+      "examples": [
+        "1.0.0.0"
+      ],
+      "title": "触摸适配捆绑包版本",
+      "description": "该属性定义了触摸捆绑包的版本号。虽然版本由主要、次要、构建和修订组件组成，但这些特定语义不会被触摸捆绑包运行时解释。相反，将使用运行时能够加载的最高版本化的捆绑包。确定可以加载捆绑包的能力取决于在捆绑包中使用的最大布局模式版本。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 中描述的 API 查询此属性。",
+      "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
+      "markdownDescription": "该属性定义了触摸捆绑包的版本号。虽然版本由主要、次要、构建和修订组件组成，但这些特定语义不会被触摸捆绑包运行时解释。相反，将使用运行时能够加载的最高版本化的捆绑包。确定可以加载捆绑包的能力取决于在捆绑包中使用的最大布局模式版本。可以通过 https://learn.microsoft.com/gaming/gdk/_content/gc/reference/system/xgamestreaming/functions/xgamestreaminggettouchbundleversion 中描述的 API 查询此属性。",
+      "type": "string"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "context": {
+      "type": "object",
+      "markdownDescription": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
+      "properties": {
+        "path": {
+          "examples": [
+            "./context.json"
+          ],
+          "title": "触摸适配捆绑包上下文文件路径",
+          "format": "uri-reference",
+          "description": "此属性定义从此文件到上下文文件的相对路径。",
+          "markdownDescription": "此属性定义从此文件到上下文文件的相对路径。",
+          "type": "string"
+        }
+      },
+      "description": "此属性定义与上下文文件相关的捆绑包属性，例如文件在磁盘上的位置。如果省略，捆绑包将不包含上下文文件。",
+      "examples": [
+        {
+          "path": "./context.json"
+        }
+      ],
+      "title": "触摸适配捆绑包上下文文件配置",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "languages": {
+      "examples": [
+        [],
+        [
+          "en-US"
+        ],
+        [
+          "en",
+          "fr-FR"
+        ]
+      ],
+      "title": "触摸适配捆绑包语言配置",
+      "description": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
+      "items": {
+        "$ref": "#/$defs/LanguageItem"
+      },
+      "markdownDescription": "此属性定义与捆绑包支持的语言相关的捆绑包属性。如果省略，捆绑包将支持布局和资产文件夹的目录结构中的所有推断语言。无论此属性的值如何，捆绑包中始终包含中性语言。",
+      "type": "array"
+    },
+    "assets": {
+      "type": "object",
+      "markdownDescription": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
+      "properties": {
+        "path": {
+          "examples": [
+            "./assets"
+          ],
+          "title": "触摸适配捆绑包资产路径",
+          "format": "uri-reference",
+          "description": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
+          "markdownDescription": "此属性定义此捆绑包的从此文件到包含所有资产的目录的相对路径，如图像文件。",
+          "type": "string"
+        }
+      },
+      "description": "此属性定义与资产文件相关的捆绑包属性，例如磁盘资产文件所在的位置。",
+      "examples": [
+        {
+          "path": "./assets"
+        }
+      ],
+      "title": "触摸适配捆绑包资产配置",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "required": [
+    "layouts",
+    "version"
+  ],
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/takxconfig/v1/takxconfig.json",
+  "title": "触摸适配捆绑包配置文件架构",
+  "markdownDescription": "触摸适配捆绑包配置文件(即 `takxconfig.json`)是充当捆绑包的项目文件并以可重用、一致的方式定义所有捆绑包元数据和属性的文件。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。"
 }


### PR DESCRIPTION
When linting the schema for runtime use, a few misspellings and mistakes were detected. In addition, the localization process mistakenly reordered property names making it challenging to understand changes. This changes brings back the intended ordering though doesn't make it any easier for this specific change.