### PR TITLE
One more attempt at fixing links to code of conduct + config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -79,7 +79,7 @@ body:
     id: terms
     attributes:
       label: "Code of Conduct"
-      description: "By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md)."
+      description: "By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)."
       options:
         - label: "I agree to follow this repository's Code of Conduct"
           required: true

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -46,7 +46,7 @@ body:
     id: terms
     attributes:
       label: "Code of Conduct"
-      description: "By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md)."
+      description: "By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)."
       options:
         - label: "I agree to follow this repository's Code of Conduct"
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Send feedback via email
+    url: https://aka.ms/gdk-feedback-email
+    about: This link will open your default email client to send us feedback through email. This is the best way to reach us for private or sensitive feedback.


### PR DESCRIPTION
I think I've figured it out.
When the link was `(CODE_OF_CONDUCT.md)` it navigated to `https://github.com/microsoft/xbox-game-streaming-tools/issues/CODE_OF_CONDUCT.md`
When the link was `(../../CODE_OF_CONDUCT.md)` it navigated to `https://github.com/microsoft/CODE_OF_CONDUCT.md`
So this means the links `../CODE_OF_CONDUCT.md` should fix it :)