### PR TITLE
Use absolute link for code_of_conduct.md...

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -79,7 +79,7 @@ body:
     id: terms
     attributes:
       label: "Code of Conduct"
-      description: "By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)."
+      description: "By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/microsoft/xbox-game-streaming-tools/blob/main/CODE_OF_CONDUCT.md)."
       options:
         - label: "I agree to follow this repository's Code of Conduct"
           required: true

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -46,7 +46,7 @@ body:
     id: terms
     attributes:
       label: "Code of Conduct"
-      description: "By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)."
+      description: "By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/microsoft/xbox-game-streaming-tools/blob/main/CODE_OF_CONDUCT.md)."
       options:
         - label: "I agree to follow this repository's Code of Conduct"
           required: true


### PR DESCRIPTION
I stand corrected in that using relative links does not really work too well in the issue form YAML template files..
Using an absolute link per @miniwangdali's suggestion.