### PR TITLE
[TAK Schema] Add schema version 4.1

### DIFF
--- a/touch-adaptation-kit/schemas/context/v4.1/context.json
+++ b/touch-adaptation-kit/schemas/context/v4.1/context.json
@@ -1,0 +1,163 @@
+{
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.1/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Touch Adaptation Bundle Context Schema",
+    "description": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+    "markdownDescription": "A touch adaptation bundle context is the file that contains global, reusable state and definitions which can be referenced by other layouts. This allows for common schema snippets to be reused and for the touch controls to respond dynamically to game state. For the latest information on the changes between versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "Touch Bundle Allowed State Values",
+            "description": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
+            "markdownDescription": "This property is used to provide additional metadata on the set of possible values, like different asset file names, when using dynamic state. This is used for validation purposes to help ensure that all values will result in a valid touch layout and that no additional bundle files, like assets, are missing or unused. Note that this property is not used at runtime and any state change operations that result in an invalid layout will be ignored. It is therefore critical to test with a wide range of values to ensure proper operation in all cases.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/latest/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "Definable Types",
+            "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+            "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/latest/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "Definitions",
+            "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+            "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "Touch Bundle State",
+            "description": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
+            "markdownDescription": "This property is used to contain all of the dynamic state of the touch bundle by specifying custom named properties with primitive values. The `XGameStreamingUpdateTouchControlsState` API can be used to update the values in the section at runtime. This can be useful to match the exact state of the player's game to the controls being displayed, for instance when a player acquires new skills or customizes their control preferences. Most places in the touch layout that use a primitive string, number, or boolean type allow for dynamic replacement by defining the value as a `$ref` back to this state block.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "Touch Bundle State Item",
+            "description": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
+            "markdownDescription": "This property is an individual item that appears in the `state` configuration. Its value must be a primitive string, number, or boolean. Use the name of the item and a value of matching type when calling `XGameStreamingUpdateTouchControlsState` to update the state dynamically.",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "Styles",
+            "description": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+            "markdownDescription": "This property defines reusable styles which can be referenced within the layouts in this touch adaption bundle for styling purposes. If an equivalent `styles` property is defined in a given layout file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+            "$ref": "../../layout/latest/layout.json#/$defs/_LayoutStyles"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
+        }
+    },
+    "additionalProperties": false
+}

--- a/touch-adaptation-kit/schemas/ja-JP/context/v4.1/context.json
+++ b/touch-adaptation-kit/schemas/ja-JP/context/v4.1/context.json
@@ -1,0 +1,163 @@
+{
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.1/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "タッチ アダプテーション バンドルのコンテキスト スキーマ",
+    "description": "タッチ アダプテーション バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+    "markdownDescription": "タッチ アダプテーション バンドル コンテキストは、グローバルで再利用可能な状態と、他のレイアウトで参照できる定義を含むファイルです。これにより、一般的なスキーマ スニペットを再利用し、タッチ コントロールがゲームの状態に動的に応答できるようになります。バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "タッチ バンドルの許可状態値",
+            "description": "このプロパティは、動的状態を使用する場合に、さまざまなアセット ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、アセットなどの追加のバンドル ファイルが欠落したり未使用のままにならないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
+            "markdownDescription": "このプロパティは、動的状態を使用する場合に、さまざまなアセット ファイル名など、使用可能な値のセットに関する追加のメタデータを提供するために使用されます。これは検証の目的で使用され、すべての値が有効なタッチ レイアウトになり、アセットなどの追加のバンドル ファイルが欠落したり未使用のままにならないようにするのに役立ちます。このプロパティは実行時には使用されず、無効なレイアウトになる状態変更操作は無視されることに注意してください。そのため、すべてのケースで適切な動作を確保するために、幅広い値を使用してテストすることが重要です。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/latest/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "定義可能な型",
+            "description": "このファイルの `definitions` セクションで使用できるすべての型を含むユニオン型です。詳細については、`definitions` セクションを参照してください",
+            "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含むユニオン型です。詳細については、`definitions` セクションを参照してください",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/latest/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "定義",
+            "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+            "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "タッチ バンドルの状態",
+            "description": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
+            "markdownDescription": "このプロパティは、プリミティブ値でカスタムの名前付きプロパティを指定することで、タッチ バンドルのすべての動的な状態を格納するために使用されます。`XGameStreamingUpdateTouchControlsState` API を使用して、実行時にセクションの値を更新できます。これは、プレイヤーが新しいスキルを取得したり、コントロールの設定をカスタマイズしたりした場合など、プレイヤーのゲームの正確な状態を表示されるコントロールと一致させるために役立ちます。プリミティブ文字列、数値、またはブール型を使用するタッチ レイアウトのほとんどの場所では、値をこの状態ブロックに戻す `$ref` として定義することで、動的置換が可能になります。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "タッチ バンドルの状態アイテム",
+            "description": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
+            "markdownDescription": "このプロパティは、`state`構成に表示される個々の項目です。値はプリミティブ文字列、数値、またはブール値である必要があります。`XGameStreamingUpdateTouchControlsState`を呼び出して状態を動的に更新するときに、項目の名前と一致する型の値を使用します。",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "スタイル",
+            "description": "このプロパティは、スタイル設定を目的として、このタッチ アダプテーション バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+            "markdownDescription": "このプロパティは、スタイル設定を目的として、このタッチ アダプテーション バンドルのレイアウト内で参照できる再利用可能なスタイルを定義します。同等の `styles` プロパティが指定されたレイアウト ファイルで定義されている場合、それぞれの内容がマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+            "$ref": "../../layout/latest/layout.json#/$defs/_LayoutStyles"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
+        }
+    },
+    "additionalProperties": false
+}

--- a/touch-adaptation-kit/schemas/ja-JP/layout/v4.1/layout.json
+++ b/touch-adaptation-kit/schemas/ja-JP/layout/v4.1/layout.json
@@ -1,0 +1,5525 @@
+{
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.1/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "additionalProperties": false,
+  "title": "タッチ アダプテーション バンドルのレイアウト スキーマ",
+  "description": "タッチ アダプテーション バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを実現するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+  "markdownDescription": "タッチ アダプテーション バンドル レイアウトは、ゲーム シナリオと、モバイルまたはタッチ ゲーム プレイを実現するために必要なすべてのコントロールを表します。レイアウト バージョン間の変更に関する最新情報については、https://github.com/microsoft/xbox-game-streaming-tools/releases を参照してください。",
+  "$defs": {
+    "LayoutDefinableType": {
+      "title": "定義可能な型",
+      "description": "このファイルの `definitions` セクションで使用できるすべての型を含むユニオン型です。詳細については、`definitions` セクションを参照してください",
+      "markdownDescription": "このファイルの `definitions` セクションで使用できるすべての型を含むユニオン型です。詳細については、`definitions` セクションを参照してください",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        {
+          "$ref": "#/$defs/ActionType"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/AssetReference"
+        },
+        {
+          "$ref": "#/$defs/AxisCap"
+        },
+        {
+          "$ref": "#/$defs/AxisCapColor"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        {
+          "$ref": "#/$defs/Background"
+        },
+        {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/ButtonActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonToggledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonPulledStyle"
+        },
+        {
+          "$ref": "#/$defs/Color"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteDefaultVariant"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+        },
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/ControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneRadial"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneThreshold"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        {
+          "$ref": "#/$defs/FaceImage"
+        },
+        {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        {
+          "$ref": "#/$defs/FillColor"
+        },
+        {
+          "$ref": "#/$defs/Gradient"
+        },
+        {
+          "$ref": "#/$defs/Indicator"
+        },
+        {
+          "$ref": "#/$defs/InnerLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InnerLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InputCurveRange"
+        },
+        {
+          "$ref": "#/$defs/InputCurve"
+        },
+        {
+          "$ref": "#/$defs/InputCurveType"
+        },
+        {
+          "$ref": "#/$defs/JoystickActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDirectionIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickMovingStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        {
+          "$ref": "#/$defs/Knob"
+        },
+        {
+          "$ref": "#/$defs/Layer"
+        },
+        {
+          "$ref": "#/$defs/Layers"
+        },
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/LayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayerSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayoutColors"
+        },
+        {
+          "$ref": "#/$defs/LayoutOrientation"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Opacity"
+        },
+        {
+          "$ref": "#/$defs/OuterLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelControlGroup"
+        },
+        {
+          "$ref": "#/$defs/OuterLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelLayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/PullActionType"
+        },
+        {
+          "$ref": "#/$defs/PullIndicator"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        },
+        {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        {
+          "$ref": "#/$defs/Scale"
+        },
+        {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        {
+          "$ref": "#/$defs/SensorControl"
+        },
+        {
+          "$ref": "#/$defs/Sticky"
+        },
+        {
+          "$ref": "#/$defs/Stroke"
+        },
+        {
+          "$ref": "#/$defs/LayoutStyles"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisStyle"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        {
+          "$ref": "#/$defs/Toggle"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyleBase"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyles"
+        }
+      ]
+    },
+    "Definitions": {
+      "title": "定義",
+      "description": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "markdownDescription": "タッチ レイアウトの再利用可能なコンポーネントと値を格納するために使用できるセクションです。これらの定義は、後で '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }' のような JSON 参照で参照できます。JSON 参照は、レイアウト スキーマのほぼすべての部分でサポートされており、複数のコントロールで使用される共通のボタンの背景など、共通の要素を分解して再利用できます。コンテキスト ファイルでは、レイアウト間でコンポーネントを再利用するために、`definitions` プロパティと `state` もサポートされることに注意してください。",
+      "examples": [
+        {},
+        {
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
+    },
+    "Reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
+          "markdownDescription": "コンテキスト ファイルのようにローカルまたは近くのファイルで定義された値への参照です。詳細については、`definitions`レイアウト プロパティを参照してください。",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "Null",
+      "description": "これは、場所をスキップするためにコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
+      "markdownDescription": "これは、場所をスキップするためにコントロールの代わりに使用できる特別な値です。これは、特にコントロールの配列や、コンテンツの配置を埋め込むレイヤーで役立ちます。",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "加速度計コントロール型",
+          "description": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
+          "markdownDescription": "加速度計コントロールです。このコントロールにより、デバイスの動き、特に加速度をゲーム入力に変換することができます。",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
+      "examples": [
+        {
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "強キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "強キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "弱キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "弱パンチ ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "中キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "中パンチ ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "スペシャル キック ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "スペシャル パンチ ボタン",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "2 次元軸マッピング アイテム",
+      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力への単一のマッピングを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "3 次元軸マッピング アイテム",
+      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレイヤーに向かってビデオから外れているということです。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力への単一のマッピングを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレイヤーに向かってビデオから外れているということです。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "背景のスタイルを設定するために使用するカスタム アセットです。",
+          "markdownDescription": "背景のスタイルを設定するために使用するカスタム アセットです。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+          "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "空白のコントロール型",
+          "description": "レイヤーを使用するレイアウトを作成する場合、空白のコントロール型を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは操作可能ではなく、スタイル可能なコンポーネントがありません。",
+          "markdownDescription": "レイヤーを使用するレイアウトを作成する場合、空白のコントロール型を使用して、その下にあるレイヤー上の既存のコントロールまたはコントロールのグループをオーバーライドまたは非表示にします。空白のコントロールは操作可能ではなく、スタイル可能なコンポーネントがありません。",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "ゲームパッドのアナログ ジョイスティック出力",
+      "description": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
+      "markdownDescription": "指定したゲームパッドのジョイスティック軸に沿って、0 から最大値に値を出力します。`output`ではなく`action`として使用する場合、最大値のみが使用されます。",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "ゲームパッドのアナログ ジョイスティック出力",
+      "description": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
+      "markdownDescription": "指定したゲームパッドジョイスティック軸全体に沿って値を出力します。",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "ゲームパッドのアナログ ジョイスティック出力",
+      "description": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
+      "markdownDescription": "両方のゲームパッド ジョイスティック軸全体に沿って値を出力します。",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "ゲームパッド ボタンの出力",
+      "description": "ゲームパッド ボタンの押下を出力します。",
+      "markdownDescription": "ゲームパッド ボタンの押下を出力します。",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "ゲームパッドのアナログ トリガー出力",
+      "description": "指定されたゲームパッド トリガーにマップされる値を出力します。",
+      "markdownDescription": "指定されたゲームパッド トリガーにマップされる値を出力します。",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "アーケード ボタン コントロール型",
+      "description": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
+      "markdownDescription": "アーケード ボタン コントロール。このコントロールは、一般的な 6 つまたは 8 つのボタンアーケード キャビネットの配置に基づいて配置されたボタンのグループです。これは、一般的に戦闘スタイルのゲームで使用されます。ボタン間をタッチすると、プレイヤーは複数のボタンを同時に押すことができます。ボタンの行の上または下にタッチすると、その行のすべてのボタンが同時にアクティブになり、コンボを実行しやすくなります。",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "ボタン コントロール型",
+      "description": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロール型です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、照準を合わせながら撃つなどの 2 つ目の同時アクションがコントロールのメインのアクションと連携して必要な場合に役立ちます。",
+      "markdownDescription": "ボタン コントロールは、コントロールが押されている間にアクションを実行できる単純なコントロール型です。一部の高度な機能を可能にするために、操作がコントロールの範囲を超えたときに、pull アクションと呼ばれる追加のアクションを割り当てることができます。これは、照準を合わせながら撃つなどの 2 つ目の同時アクションがコントロールのメインのアクションと連携して必要な場合に役立ちます。",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "方向パッド コントロール型",
+      "description": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
+      "markdownDescription": "方向パッド コントロールは、物理ゲームパッドにある標準的な 4 方向または 8 方向のコントロールを模倣します。このコントロールは特に、特定のアクションを実行するために正確な方向が必要な 2D プラットフォームゲームや戦闘ゲームで役立ちます。4 方向または 8 方向のスタイル コントロールを選択するには、`interaction` プロパティを参照してください。",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "ジョイスティック コントロール型",
+      "description": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
+      "markdownDescription": "物理コントローラーのアナログ ジョイスティックを模倣するジョイスティック コントロール。これにより、プレイヤーは `axis` プロパティに基づいて、2 次元または 1 次元の空間でコントロールを移動できます。さらに、`action` プロパティと `actionThreshold` プロパティを使用して、移動と同時にアクションを実行できます。このコントロールは、プレイヤーの移動やカメラ コントロールによく使用され、タッチ レイアウトには、移動中や周囲を見回しながら実行できる任意のアクションに対して複数のジョイスティックを含めるのが一般的です。",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "スロットル コントロール型",
+      "description": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
+      "markdownDescription": "ボート、車、または飛行機の物理的なスロットルを模倣するスロットル コントロールです。このコントロールは、プレイヤーがノブを操作して、スロットルを上下に動かすことができます。ドライビングゲームやフライトゲームなど、常にアクセルを踏んでいる必要がある場合に有効なコントロールです。コントロールのスタイルを設定するときは、`activatedUp`、`activatedDown`、`idleUp` の状態を分けると、プレイヤーがアクセルやブレーキなどを使用しているときに正確にカスタマイズできます。",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "タッチパッド コントロール型",
+      "description": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` でボタンとしてレンダリングして、動きやカメラと、照準やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
+      "markdownDescription": "ノート PC で見つかった物理タッチパッドを模倣するタッチパッド コントロールです。このコントロールは、マウスやジョイスティック スタイルの動き (カメラ コントロールなど) に最適で、スワイプやドラッグでプレイヤーを正確に制御できます。さらに、`action` をコントロールに割り当てることができ、`renderAsButton` でボタンとしてレンダリングして、動きやカメラと、照準やジャンプなどの一般的な動作を組み合わせたコントロールを作成できます。",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "カスタム レイアウトの色",
+      "description": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
+      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色を定義します。この色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を続けて使用して参照できます。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "フェイス イメージ アセット スタイル設定コンポーネント",
+          "description": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム アセットです。",
+          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用されるカスタム アセットです。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "フェイス イメージ アイコンのスタイル設定コンポーネント",
+          "description": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
+          "markdownDescription": "コントロール コンポーネントの前景グラフィックとして使用される組み込みアイコンです。",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "ジャイロスコープ コントロール型",
+          "description": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
+          "markdownDescription": "ジャイロスコープ コントロール。このコントロールを使用すると、デバイスのモーション (特にその軸に関する回転) からゲーム入力に変換できます。このコントロールは、現実世界の回転がゲームの視点を自然に回転させる可能性があるため、プレイヤーのカメラを制御する場合に特に便利です。",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "軸のマグニチューディナル入力マッピング",
+      "description": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
+      "markdownDescription": "指定した軸の方向 (上、下、左、または右) に沿った入力の大きさのみを使用して、指定した出力に変換します。たとえば、`axisLeft` の値は、入力が現在のコントロールの原点からどれだけ離れているかに応じて 0 から 1 にマップされます。これは大きさに基づく値であるため、負の出力にはできません。",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X 軸入力マッピング",
+          "description": "指定された出力に変換するために、コントロールの X 軸に沿った操作 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "markdownDescription": "指定された出力に変換するために、コントロールの X 軸に沿った操作 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y 軸の入力マッピング",
+          "description": "指定された出力に変換するために、コントロールの Y 軸に沿った操作 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "markdownDescription": "指定された出力に変換するために、コントロールの Y 軸に沿った操作 (正と負の方向) を使用します。このマッピングの詳細については、`output`プロパティを参照してください。",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X 軸と Y 軸の入力マッピング",
+      "description": "コントロールの X 軸と Y 軸の操作を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "markdownDescription": "コントロールの X 軸と Y 軸の操作を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z 軸と Y 軸の入力マッピング",
+      "description": "コントロールの Z 軸と Y 軸の操作を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "markdownDescription": "コントロールの Z 軸と Y 軸の操作を使用して、指定された出力に変換します。このマッピングの詳細については、`output`プロパティを参照してください。",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
+          "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "レイアウト アクション",
+      "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクション型。",
+      "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクション型。",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "レイアウト アクション",
+          "description": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクション型。",
+          "markdownDescription": "アクションの実行中にレイヤーを適用するなど、レイアウトの変更をトリガーするアクション型。",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
+            },
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_RelativeMouse1DOutputType": {
+      "title": "相対マウスの 1 次元出力",
+      "description": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
+      "markdownDescription": "この出力型は、1 次元のコントロール入力を受け取り、1 つの軸に沿った相対的なマウスの動きに変換します。",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
+      ],
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "相対マウスの 2 次元出力",
+      "description": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
+      "markdownDescription": "この出力型は、2 次元のコントロール入力を受け取り、それらを相対マウスの動きに変換します。",
+      "const": "relativeMouse",
+      "type": "string"
+    },
+    "_RelativeMouseMagnitudinalOutputType": {
+      "title": "相対マウス方向の出力",
+      "description": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
+      "markdownDescription": "この出力型は、指定された入力軸に沿ったコントロール入力の大きさを受け取り、それを単一方向の相対マウス移動にマップします。たとえば、ジョイスティックの X 軸の動きが相対マウス X 軸出力にマップされている場合、ジョイスティックが右に保持されている限り、一連の正の X 方向のマウス移動が送信されます。",
+      "enum": [
+        "relativeMouseUp",
+        "relativeMouseDown",
+        "relativeMouseLeft",
+        "relativeMouseRight"
+      ],
+      "type": "string"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_StrokeBase": {
+      "examples": [
+        {
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
+              "markdownDescription": "このスタイル設定コンポーネントは、カスタマイズ可能な色と不透明度を持つ単色ストロークを指定するために使用されます。",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "title": "コンテンツのプライマリ システムの色のオーバーライド",
+      "description": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、中間ストローク、アイコンの濃淡、方向パッドのグラデーションなどのスタイル設定コンポーネントに使用されるプライマリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "コンテンツ セカンダリ システムの色のオーバーライド",
+      "description": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、背景や塗りつぶしなどのコンポーネントのスタイル設定に使用されるセカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "コントラストのプライマリ システムの色のオーバーライド",
+      "description": "このプロパティは、内側/外側のストロークやフェイス イメージのバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
+      "markdownDescription": "このプロパティは、内側/外側のストロークやフェイス イメージのバックプレートなどのコントラスト コンポーネントのスタイル設定に使用されるコントラストのプライマリ システム カラーをオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "コントラスト セカンダリ システムの色のオーバーライド",
+      "description": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、タッチパッド ストロークなどのコントラスト コンポーネントのスタイル設定に使用されるコントラスト セカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "アクション システムの色のオーバーライド",
+      "description": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、`action` フィールドがゲームパッド以外に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "ゲームパッド アクション システムの色のオーバーライド",
+      "description": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、`action` フィールドが`gamepadA`、`gamepadB`、`gamepadX`、または`gamepadY`に設定されているコントロールのスタイル設定コンポーネントに使用される、対応するゲームパッド アクション システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "アクセントのプライマリ システム カラーのオーバーライド",
+      "description": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
+      "markdownDescription": "このプロパティは、内部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント のプライマリ システム カラーをオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "アクセントのセカンダリ システムの色のオーバーライド",
+      "description": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
+      "markdownDescription": "このプロパティは、外部ホイールの編集などのコンポーネントのスタイル設定に使用されるアクセント セカンダリ システムの色をオーバーライドします。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
+      "examples": [
+        {
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "ターボ アクション",
+      "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+      "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "ターボ アクション",
+          "description": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+          "markdownDescription": "継続的ではなく、間隔に基づいてオンとオフをトリガーするアクション。",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "アクションのしきい値",
+      "description": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの操作が割り当てられたアクションをすぐに実行することを意味します。",
+      "markdownDescription": "このプロパティは、コントロールのアクションをトリガーするために必要な放射状で正規化された入力値を定義します。この値に達すると、コントロールはそのアクションを実行し、`moving`状態から`activated`状態に遷移します。省略した場合、既定値 0 は、すべてのコントロールの操作が割り当てられたアクションをすぐに実行することを意味します。",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionType": {
+      "title": "コントロール アクション",
+      "description": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "markdownDescription": "このプロパティを使用すると、コントロールが `activated` 状態のときに、1 つのアクションまたはアクションの配列を実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "ArcadeButton": {
+      "description": "`arcadeButtons` コントロール型の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロール型の簡略化されたバージョンです。",
+      "markdownDescription": "`arcadeButtons` コントロール型の単一ボタンです。このボタンは、アーケード ボタンの配置で適切に動作する `button` コントロール型の簡略化されたバージョンです。",
+      "examples": [
+        {
+          "action": "gamepadX",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "lightPunch"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonFightingButtons"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "$ref": "#/$defs/ActionType"
+            },
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
+            },
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
+            }
+          },
+          "required": [
+            "action"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyleBase": {
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "コントロールの無効なスタイル",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "アセット参照スタイル設定コンポーネント",
+      "description": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シート アセットの場合、拡張子なしのテクスチャ ファイル名を使用し、続けて `/` とスプライト アトラス内のスプライト名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
+      "markdownDescription": "アセット参照は、タッチ レイアウトにバンドルされたカスタム アセットの識別子です。ファイル全体を参照するには、ファイル拡張子のないイメージのファイル名を使用します。スプライト シート アセットの場合、拡張子なしのテクスチャ ファイル名を使用し、続けて `/` とスプライト アトラス内のスプライト名を使用します。画面の解像度が異なるデバイスを処理するには、各 DPI (1.0x、1.5x、2.0x、3.0x、4.0x) のファイルが提供されている必要があります。アセットが使用されているコントロールとコンポーネントに応じて、最大 1.0x の解像度が異なる場合がありますが、最も一般的に許可されている最大値は 60x60 と 120x120 です。他のすべての DPI 解像度は、1.0x アセットの解像度の倍数である必要があります。",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "軸キャップ スタイル設定コンポーネント",
+      "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+      "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "軸キャップ スタイル設定コンポーネント",
+              "description": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+              "markdownDescription": "軸コントロール コンポーネントの制限を表すために使用される視覚的なスタイルです。これは、軸の最大値または最小値を意味的に示す色でスタイル設定できます。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "2 次元軸マッピング",
+      "description": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 2 次元アナログ操作から 1 次元または 2 次元出力へのマッピングまたはマッピングのセットを定義します。軸の割り当てに基づいて、コントロールの外観が変更される場合があることに注意してください。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "3 次元軸マッピング",
+      "description": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレイヤーに向かってビデオから外れているということです。",
+      "markdownDescription": "このプロパティは、プレイヤーのコントロールとの 3 次元アナログ操作から 1 次元または 2 次元の出力へのマッピングまたはマッピングのセットを定義します。デバイス センサーと同様に、3 次元の操作の場合、座標空間は常にゲームのビデオに対して相対的です。つまり、正の X 方向がビデオの右側にあり、正の Y 方向がビデオの上部にあり、正の Z 方向がプレイヤーに向かってビデオから外れているということです。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "背景スタイル設定コンポーネント",
+      "description": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+      "markdownDescription": "コントロール コンポーネントの背景の視覚的なスタイルです。背景には、`color`または`asset`を指定できます。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "コントロールがアクティブ化されたスタイル",
+      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "コントロールの既定のスタイル",
+      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "コントロールの無効なスタイル",
+      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "コントロールのアイドルのスタイル",
+      "description": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは操作されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、操作されていないことを示します。",
+      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイルのオーバーライドです。この状態では、コントロールは操作されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明な背景と pull インジケーターと共に使用され、コントロールがアイドル状態であり、操作されていないことを示します。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "コントロールの切り替えスタイル",
+      "description": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
+      "markdownDescription": "コントロールが `toggled` 状態のときに使用されるスタイル設定オーバーライドです。`toggled` 状態は、コントロールは操作されていないが、現在切り替え中であるため、そのアクションは実行中である場合です。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "コントロールの pull されたスタイル",
+      "description": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+      "markdownDescription": "コントロールが `pulled` 状態のときに使用されるスタイル設定オーバーライドです。`pulled` 状態は、コントロールが操作され、コントロールの範囲を超えて使用され、追加のアクションが実行されたときです。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "色",
+      "description": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "markdownDescription": "このプロパティは、文字列表現を使用して色を定義します。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステム カラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "既定の色",
+      "description": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
+      "markdownDescription": "このプロパティは、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム色の先頭には、予約済みの `system_` キーワードが付きます。特定のバリアントで定義されていない、または特定のバリアントがアクティブでない色の場合、対応する色参照はここで定義されている色にフォールバックします。指定されたシステムカラーオーバーライドが指定されていない場合、色参照はシステムの既定の色にフォールバックします。スタイル設定のために色を使用できる領域では、`colors/` プレフィックスの後に色名を付けて、色を参照できます。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "ハイ コントラストの色のみ",
+      "description": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "markdownDescription": "このプロパティは、ハイ コントラスト モードが有効な場合に、他の場所で参照できる再利用可能な色のコレクションを定義します。色の定義は、レイアウトのコンテンツに固有、もしくはシステムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。ここで定義されていない色、またはハイ コントラスト モードが無効になっている場合、対応する色参照は `default` で定義されている色にフォールバックします。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "タッチ レイアウト コントロール",
+      "description": "プレイヤーが操作して変換されたアクションを実行できる個々のコントロールです。特定のコントロール型とその目的については、`type` プロパティを参照してください。",
+      "markdownDescription": "プレイヤーが操作して変換されたアクションを実行できる個々のコントロールです。特定のコントロール型とその目的については、`type` プロパティを参照してください。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "有効",
+      "description": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
+      "markdownDescription": "コントロールが `disabled` 状態かどうかを判断するプロパティ。このプロパティは、コンテキスト ファイル `state` と共に使用して、ゲームの状態に基づいてコントロールを動的に有効または無効にできる場合に最も便利です。省略すると、既定値の `true` が使用されます。無効にすると、コントロールは表示され、出力に沿って転送されますが、アクティブな外観はありません。この動作は、外観があり、画面にレンダリングされるコントロールに対してのみ当てはまります。センサー コントロールは、外観がないため、無効な状態では出力を転送しません。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "タッチ レイアウト コントロール グループ",
+      "description": "グループに並べられた 1 から 4 つのコントロールのセットです。このグループ内のアイテムはシステムによって配置され、通常は使用可能な領域の上から時計回りに進みます。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの相互作用領域の合計が大きくなる可能性があります。特別な値 `null` を使用して、配置内のコントロールをスキップできることに注意してください。",
+      "markdownDescription": "グループに並べられた 1 から 4 つのコントロールのセットです。このグループ内のアイテムはシステムによって配置され、通常は使用可能な領域の上から時計回りに進みます。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの相互作用領域の合計が大きくなる可能性があります。特別な値 `null` を使用して、配置内のコントロールをスキップできることに注意してください。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "タッチ レイアウト コントロール グループ アイテム",
+      "description": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+      "markdownDescription": "コントロール グループ内の 1 つの項目。`null`を使用して、配置内のコントロールをスキップします。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "ゲームパッド アクション",
+      "description": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
+      "markdownDescription": "このプロパティを使用すると、1 つのゲームパッド アクションまたはゲームパッド アクションの配列を、`activated` 状態のときにコントロールによって実行できます。",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "表示",
+      "description": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレイヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+      "markdownDescription": "コントロールを表示するかどうかを決定します。このプロパティは、ゲームの状態に基づいてコントロールを動的に表示および非表示にするためにコンテキスト ファイル `state` で使用する場合に最も便利です。省略すると、既定値の `true` が使用されます。表示されない場合、コントロールをアクティブにすることはできず、プレイヤーがコントロールが表示される場所にタッチしている場合でも、アクションは実行されません。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "1 次元のデッドゾーン",
+      "description": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
+      "markdownDescription": "コントロールによって生成される正規化された最小出力値です。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。省略した場合、デッドゾーンは使用されません。",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "2 次元のデッドゾーン",
+      "description": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
+      "markdownDescription": "コントロールによって生成される正規化された最小出力値。これは、ゲームにプログラムされたデッドゾーンをカウンターアクションする場合に便利です。`radial` が true に設定されている場合、デッドゾーンは放射状コンポーネントに沿って 1 次元に計算されます。それ以外の場合、各軸はしきい値を使用して個別に計算されます。省略した場合、デッドゾーンは使用されません。",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "方向パッドのデッドゾーン",
+      "description": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、プレイヤーにこのサイズが表示されます。",
+      "markdownDescription": "入力を無視する方向パッド領域の正規化された半径です。これは、小さな入力変更によってアクティブ化される方向が大幅に変更される可能性がある方向パッドの中心付近の方向の不要な変更を回避するために役立ちます。省略すると、0.25 の値が使用されます。この値に変更を加えると、方向パッドのレンダリング方法が変わり、プレイヤーにこのサイズが表示されます。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "しきい値",
+      "description": "出力値を生成するために必要な正規化された入力値です。",
+      "markdownDescription": "出力値を生成するために必要な正規化された入力値です。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "放射状",
+      "description": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
+      "markdownDescription": "デッドゾーンのしきい値が放射状入力コンポーネントに沿って計算されるか、各軸に対して個別に計算されるか。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "操作",
+      "description": "このプロパティは、プレイヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
+      "markdownDescription": "このプロパティは、プレイヤーがコントロールを操作する方法を決定します。詳細については、`activationType` プロパティを参照してください。",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteractionActivationType": {
+      "title": "アクティブ化型",
+      "description": "このプロパティは、プレイヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化型には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレイヤーがコントロールを操作している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
+      "markdownDescription": "このプロパティは、プレイヤーの操作に応じてコントロールとそのサブコンポーネントをアクティブにする方法を決定します。アクティブ化型には、`exclusive` または `allowNeighboring` のいずれかを指定できます。`exclusive` に設定すると、コントロールのサブコンポーネントが一度に 1 つだけアクティブになります。`allowNeighboring` が設定されている場合、プレイヤーがコントロールを操作している場所に基づいて、コントロールの複数のサブコンポーネントを同時にアクティブにすることができます。省略すると、既定値の `allowNeighboring` が使用されます。",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、操作中でないことを示します。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作されておらず、コントロールのニュートラル状態または休止状態です。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、完全に透明なグラデーションで使用され、コントロールがアイドル状態であり、操作中でないことを示します。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "展開",
+      "description": "このプロパティは、使用可能な領域を埋めるために、コントロールの操作可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
+      "markdownDescription": "このプロパティは、使用可能な領域を埋めるために、コントロールの操作可能領域を拡張するかどうかを決定します。これは、プレイヤーが領域のサイズをカスタマイズできる `inner` ホイール コンテナーに特に役立ちます。`false` に設定すると、コントロールは既定または最小の操作サイズにロックされます。省略すると、既定値の `true` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "フェイス イメージのスタイル設定コンポーネント",
+      "description": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、操作の意味を示すために使用されます。フェイス イメージには、`icon` または `asset` 型を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+      "markdownDescription": "コントロール コンポーネントの前景を表すビジュアル スタイル設定です。これは通常、操作の意味を示すために使用されます。フェイス イメージには、`icon` または `asset` 型を指定できます。アイコンは、さまざまなコントロール アクションを表現できる組み込みのグラフィックスです。アセットを使用すると、コントロールはレイアウトにバンドルされたカスタム イメージを使用できます。",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "フェイス イメージ アイコン ラベルのスタイル設定コンポーネント",
+      "description": "このプロパティは、フェイス イメージ アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
+      "markdownDescription": "このプロパティは、フェイス イメージ アイコンにラベルを表示する方法を決定します。`action` 型は、意味的画像を使用して、ゲームのプロンプトと画像が意味的アイコンと完全に一致しない場合に対応するアクションをプレイヤーに通知する場合に便利です。これらの追加ラベルを非表示にするには、`none` 型を使用できます。省略すると、既定値の `action` が使用されます。",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "フェイス イメージ アイコン",
+      "description": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
+      "markdownDescription": "このプロパティは、このコンポーネントに使用する組み込みアイコンを選択するために使用されます。",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "塗りつぶし",
+      "description": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "markdownDescription": "このプロパティは、コントロール コンポーネントの塗りつぶしに使用する色を変更します。省略すると、ほとんど透明な白い塗りつぶしが使用されます。色は、`hex-color` CSS 仕様に従って 16 進数の値として指定するか、`colors/` で始まる文字列の後に色の名前を続けて、既知のシステムカラーまたはレイアウトの色を参照することによって指定する必要があります。詳細については、https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color を参照してください。",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "グラデーション",
+      "description": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
+      "markdownDescription": "グラデーションは、ある色から別の色へのブレンドです。現在、許可されているグラデーションは、完全に透明から指定された色の値までです。",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "インジケーターのスタイル設定コンポーネント",
+      "description": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
+      "markdownDescription": "コントロールの現在の値または配置を示すために使用されるストロークの視覚的なスタイルです。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "内側​​",
+      "description": "コントロール ホイールの内側のセグメントにグループに並べられた 1 ~ 4 個のコントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法が決定されます。通常は、空間の上部から開始し、時計回りに進みます。内部セグメント全体の相互作用領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
+      "markdownDescription": "コントロール ホイールの内側のセグメントにグループに並べられた 1 ~ 4 個のコントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法が決定されます。通常は、空間の上部から開始し、時計回りに進みます。内部セグメント全体の相互作用領域は、割り当てられたコントロール間で均等に分割されることに注意してください。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "内側​​",
+      "description": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法が決定されます。通常は、空間の上部から開始し、時計回りに進みます。内部セグメント全体の相互作用領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "markdownDescription": "コントロール ホイールの内側のセグメント上のグループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法が決定されます。通常は、空間の上部から開始し、時計回りに進みます。内部セグメント全体の相互作用領域は、割り当てられたコントロール間で均等に分割されることに注意してください。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveRange": {
+      "deprecated": true,
+      "title": "[非推奨] 入力曲線の範囲",
+      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、最小値と最大値を定義します。すべての値が正規化されているため、-1 から 1 の範囲で指定する必要があります。",
+      "examples": [
+        [
+          0,
+          0.33
+        ],
+        [
+          0,
+          1
+        ],
+        {
+          "$ref": "#/definitions/commonJoystickInputRange"
+        },
+        [
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMin"
+          },
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMax"
+          }
+        ]
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": -1,
+                "maximum": 1
+              },
+              {
+                "$ref": "#/$defs/Reference"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[非推奨] 入力応答曲線",
+      "description": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作が変更されるか、将来のバージョンで削除される可能性があります。このプロパティは、入力を出力値にマップする方法の曲線または関数を定義します。`circular` または `circular-inverse` の種類を使用すると、右下のクアドラントまたは左上のクアドラントの図形にそれぞれ一致する円曲線に入力をマッピングできます。このプロパティを省略すると、既定の線形マッピングが使用されます。",
+      "examples": [
+        {
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
+        },
+        {
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[非推奨] 入力応答曲線型",
+      "description": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線型を定義します。`circular` 型を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティは動作を変更するか、将来のバージョンで削除される可能性があります。このプロパティは、使用する曲線型を定義します。`circular` 型を使用すると、円の右下 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。値 `circular-inverse` を使用すると、円の左上 4 分の 1 の図形と一致する円曲線を使用して入力をマップできます。",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "コントロールがアクティブ化されたスタイル",
+      "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+      "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "コントロールの既定のスタイル",
+      "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "方向インジケーターのスタイル設定コンポーネント",
+      "description": "操作の方向を示す視覚的なスタイル設定",
+      "markdownDescription": "操作の方向を示す視覚的なスタイル設定",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
+              "markdownDescription": "方向インジケーターの色の種類を指定するために使用されるプロパティで、値をカスタマイズできます。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "コントロールの無効なスタイル",
+      "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "コントロールのアイドルのスタイル",
+      "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+      "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "コントロールの移動スタイル",
+      "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+      "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "アウトライン スタイル設定コンポーネント",
+      "description": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+      "markdownDescription": "操作の方向を示すインジケーターを含むコントロールのアウトラインの視覚的なスタイル設定です。他の状態でのこのプロパティは、それらの状態でコントロールが操作されないので、インジケーターにスタイルを設定する機能を含まないかもしれません。",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "アウトライン スタイル設定コンポーネント",
+      "description": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが操作されている他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
+      "markdownDescription": "コントロールのアウトラインの視覚的なスタイル。このプロパティは、コントロールが操作されている他の状態では、操作の方向を示すインジケーターをスタイル設定する機能も含めることができます。",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "ノブ スタイル設定コンポーネント",
+      "description": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
+      "markdownDescription": "コントロールのノブの視覚的なスタイル設定です。ノブは、たとえばジョイスティックの上部を模倣するコントロールの操作点です。",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "タッチ レイアウト レイヤー",
+      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレイヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレイヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "タッチ レイアウト レイヤー",
+      "description": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレイヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "markdownDescription": "このプロパティを使用すると、コントロール `action` で使用できるカスタム コントロール レイヤーの定義を使用して、追加のコントロールをオーバーレイしたり、別のコントロールのプレイヤー操作に応じてレイアウト コンテンツを変更したりできます。",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "タッチ レイアウト レイヤー コントロール",
+      "description": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロール型とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロール型を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
+      "markdownDescription": "プレイヤーが操作して変換されたアクションを実行できる現在のレイヤー内の個々のコントロールです。特定のコントロール型とその目的については、`type` プロパティを参照してください。レイヤーは特別な `blank` コントロール型を追加して、このコントロールの下のレイヤーからコントロールを非表示にします。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "タッチ レイアウト レイヤー コントロール グループ",
+      "description": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "markdownDescription": "グループに配置された、下のレイヤーからコントロールを非表示にする `blank` コントロールを含む、1 から 4 個のレイヤー コントロールのセットです。使用可能な領域内でグループのコントロールを最適に配置する方法はシステムが決定します。1 つのコントロールのみを持つグループは、グループ化されていないコントロールとは異なります。グループの操作領域の合計が大きくなる可能性があります。インデックスをスキップするには、特別な値 `null` を使用できます。また、下のレイヤーのコントロール グループの項目数がこのコントロール グループと異なる場合は、そのレイヤーのすべての項目が非表示になります。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "タッチ レイアウト レイヤー コントロール グループ アイテム",
+      "description": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
+      "markdownDescription": "レイヤー コントロール グループ内の 1 つの項目です。`null` を使用して配置内のコントロールをスキップするか、下のレイヤーからコントロールを非表示にする `blank` を使用します。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "タッチ レイアウト レイヤー コントロール ホイール",
+      "description": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
+      "markdownDescription": "円またはホイールの形で整理されたレイヤー コントロールのセットです。",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "下位レイヤー配列のコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "下位レイヤーのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されているレイヤーのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "センサー レイヤーのコンテンツ",
+      "description": "このプロパティは、デバイスのセンサー入力を操作として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "markdownDescription": "このプロパティは、デバイスのセンサー入力を操作として使用するレイヤー コンテンツのコンテナーを定義します。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "上位レイヤーのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロール型を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの上部領域を反映します。ただし、`blank` コントロール型を使用して、この下のレイヤーからコントロールを非表示にすることができます。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "上位レイヤーの右側のコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロール型を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイヤー コンテンツを定義します。このプロパティは、メイン レイアウトの右上の領域を反映します。ただし、`blank` コントロール型を使用して、このコントロールの下にあるレイヤーからコントロールを非表示にすることができます。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "レイアウト アクション ターゲット",
+      "description": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
+      "markdownDescription": "このプロパティは、アクションの実行時に適用するレイヤーを指定します。この名前は、レイアウト コンテンツの`layers` プロパティに含まれている必要があります。",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "色",
+      "description": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "markdownDescription": "このプロパティは、他の場所で参照できるカラー定義で構成されるカラー パレットのコレクションを定義します。スタイル バリアントごとに、カラー パレットを定義できます。特定のバリエーションで定義されていない色の場合は、`default` カラー パレットまたはシステムの既定値が使用されます。色の定義は、レイアウトのコンテンツに固有であるか、システムの既定の色をオーバーライドすることができます。システム カラーには、予約済みの `system_` キーワードがプレフィックスとして付けられます。色は、スタイル設定のために色を使用できる領域で、`colors/` プレフィックスの後に色名を付けて参照できます。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "レイアウト コンテンツ",
+      "description": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
+      "markdownDescription": "このプロパティは、レイアウトの実際のコンテンツを定義します。レイアウト上のコンテンツは、ディスプレイ上の場所 (`lower` など) に基づいてコンテナーに編成されます。`left` 領域と `right` 領域は、プレイヤーの親指の下に中央揃えになるように意図されており、デバイスとプレイ方法に最適になるようにプレイヤーが移動およびカスタマイズできるため、特別な場所です。ボタンなどの各コンテナー コントロール内で、名前付きプロパティまたはサブ配列に基づいて、直接指定するか、サブコンテナーに配置できます。",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "タッチ レイアウト コントロール ホイール",
+      "description": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
+      "markdownDescription": "円またはホイールの形で編成されたコントロールのセットです。これらのホイール コントロールは、既定では、レイアウト コンテンツで `right` または `left` プロパティが使用されているかどうかに基づいて、画面の右側または左側のプレイヤーの親指の下に配置されます。ホイールは、コントロールの内部グループと、コントロールの外側のリングで構成されます。",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[非推奨] レイアウトの向き",
+      "description": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
+      "markdownDescription": "⚠️ 非推奨: このプロパティはサポートされなくなりました。値は無視され、すべてのレイアウトで同等の `landscape` が使用されます。",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "下位レイアウト配列のコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下中央から外側に拡大する配列であるレイアウトのコンテンツを定義します。このプロパティは、レイアウト コンテンツの同じ名前付きプロパティと同じように動作します。ただし、このプロパティを使用すると、このプロパティの下のレイヤーからコントロールを非表示にするために `blank` コントロールを使用することもできます。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "下位レイアウトのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の下端に固定されるレイアウトの内容を定義します。下端に沿ったコンテンツは中央に配置され、左端と右端に向かって外側に広がります。このコンテンツはディスプレイの中央にあるため、大規模なデバイスではアクセスが困難な場合があります。そのため、カメラ モードの切り替えやその他のモード スワップなど、使用頻度の低いコントロールをこの領域に配置することをお勧めします。",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "センサー レイアウト コンテンツ",
+      "description": "このプロパティは、デバイスのセンサー入力を操作として使用するレイアウト コンテンツのコンテナーを定義します。",
+      "markdownDescription": "このプロパティは、デバイスのセンサー入力を操作として使用するレイアウト コンテンツのコンテナーを定義します。",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "レイアウト スタイル",
+      "description": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "markdownDescription": "このプロパティは、スタイル設定のためにレイアウト全体で参照できる再利用可能なスタイルを定義します。コンテキスト ファイルで同等の `styles` プロパティが定義されている場合、それぞれのコンテンツがマージされます。重複する定義が見つかった場合は、レイアウト内の定義が優先され、コンテキスト ファイル内の定義が上書きされます。",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "上部レイアウトのコンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大型のデバイスでは簡単にアクセスできないため、この領域は、ポーズ メニューを呼び出しやや映画の場面のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の上端に固定されるレイアウト コンテンツを定義します。現時点では、左上がシステム クイック アクセス メニュー用に予約されているため、コントロールを追加できるのは右上の領域のみです。右上のコンテンツは大型のデバイスでは簡単にアクセスできないため、この領域は、ポーズ メニューを呼び出しやや映画の場面のスキップなど、ゲームプレイの途中ではなく断続的にアクセスするだけで済むコントロールに最適です。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "右上のレイアウト コンテンツ",
+      "description": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
+      "markdownDescription": "このプロパティは、使用可能な表示領域の右上隅に固定されるレイアウト コンテンツを定義します。このコンテナーに追加されたコントロールは、隅から始まり、画面の上中央に向かって内側に拡大します。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "不透明度",
+      "description": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
+      "markdownDescription": "このプロパティは、コントロール コンポーネントの透明度を変更します。省略した場合、既定値 1 はコントロールが完全に不透明であることを意味します。",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "外側​​",
+      "description": "ホイールの外部リングに存在するコントロールまたはコントロール グループの外部リングを定義します。このリング内のアイテムは、ホイールの上から時計回りに配置されます。各インデックスには、単一のコントロールまたはコントロールの配列を指定できます。配列が指定されている場合、このコントロール グループは相互作用領域を 2 倍にします。追加されたコントロールは、ホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには 8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以上のコントロールが削除されたか、検証規則エラーが発生する可能性があります。'null' コントロールは、コントロール グループをオフセットするために外側のホイール配列の先頭で使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
+      "markdownDescription": "ホイールの外部リングに存在するコントロールまたはコントロール グループの外部リングを定義します。このリング内のアイテムは、ホイールの上から時計回りに配置されます。各インデックスには、単一のコントロールまたはコントロールの配列を指定できます。配列が指定されている場合、このコントロール グループは相互作用領域を 2 倍にします。追加されたコントロールは、ホイールの中央からさらに広がる可能性があります。合計で、外側のホイールには 8 つの個々のコントロールまたは 4 つのコントロール グループのためのスペースがあります。これ以上のコントロールが削除されたか、検証規則エラーが発生する可能性があります。'null' コントロールは、コントロール グループをオフセットするために外側のホイール配列の先頭で使用できることに注意してください。これが完了すると、最終的な個々のコントロールを追加できます。",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "外側​​",
+      "description": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
+      "markdownDescription": "ホイール上のレイヤー コントロールとレイヤー コントロール グループの外側のリングを定義します。このプロパティは、同じ名前付きレイアウト プロパティと同じように動作しますが、その下のレイヤーからコントロールを非表示にするためにさらに `blank` コントロールを許可する点が異なります。下のレイヤーのコントロールまたはコントロール グループの項目数がこのレイヤーの対応するインデックスと異なる場合、そのレイヤーのすべての項目は非表示になります。基本レイアウト ホイールと同様に、`null` を使用してコントロールまたはコントロール グループをスキップできます。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterWheelControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "コントロールの pull アクション",
+      "description": "このプロパティを使用すると、1 つのアクション、すべてのアクションの配列、またはコントロールが `pulled` 状態のときに、いくつかの定義されたアクションの 1 つを実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。このプロパティが型 `segmented` のオブジェクトとして定義されている場合、プル アクション リングは、コントロールの上部から始まり、時計回りに進行する等しいセグメントに分割されます。コントロールがプルされる正確な場所に基づいて、1 つのセグメントが `pulled` 状態になります。",
+      "markdownDescription": "このプロパティを使用すると、1 つのアクション、すべてのアクションの配列、またはコントロールが `pulled` 状態のときに、いくつかの定義されたアクションの 1 つを実行できます。これらのアクションは、ゲームパッドの入力や、レイアウトに新しいレイヤーを表示するなど、より複雑なアクションにマップできます。このプロパティが型 `segmented` のオブジェクトとして定義されている場合、プル アクション リングは、コントロールの上部から始まり、時計回りに進行する等しいセグメントに分割されます。コントロールがプルされる正確な場所に基づいて、1 つのセグメントが `pulled` 状態になります。",
+      "anyOf": [
+        {
+          "properties": {
+             "type":  { 
+              "const": "segmented",
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/_ActionTypeBase"
+              },
+              "maxItems": 4,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/_ActionTypeBase"
+        }
+      ]
+    },
+    "PullIndicator": {
+      "title": "pull インジケーターのスタイル設定コンポーネント",
+      "description": "コントロールが現在プルされているインジケーターの視覚的なスタイル。配列を使用する場合、プル インジケーターの型は 'セグメント化' プル インジケーターである必要があります。この場合、各配列要素はそのセグメントのスタイルに対応します。",
+      "markdownDescription": "コントロールが現在プルされているインジケーターの視覚的なスタイル。配列を使用する場合、プル インジケーターの型は 'セグメント化' プル インジケーターである必要があります。この場合、各配列要素はそのセグメントのスタイルに対応します。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        [
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          null,
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          }
+        ],
+        [
+          {
+            "opacity": 0
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PullIndicatorSegment"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        }
+      ]
+    },
+    "PullIndicatorSegment": {
+      "title": "プル インジケーター セグメントのスタイル設定コンポーネント",
+      "description": "コントロールがこのセグメントの方向に引っ張られているインジケーターの視覚的なスタイルです。この色は、コントロールをプルするセマンティクスと、アクションのセマンティクスを示すカスタム 顔イメージを示すためにカスタマイズできます。既定では、プル アクションにマップされている 1 つのゲームパッド アクションには、そのゲームパッド関数が顔イメージとして示されます。",
+      "markdownDescription": "コントロールがこのセグメントの方向に引っ張られているインジケーターの視覚的なスタイルです。この色は、コントロールをプルするセマンティクスと、アクションのセマンティクスを示すカスタム 顔イメージを示すためにカスタマイズできます。既定では、プル アクションにマップされている 1 つのゲームパッド アクションには、そのゲームパッド関数が顔イメージとして示されます。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "背景スタイル設定コンポーネント",
+      "description": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+      "markdownDescription": "背景のスタイルを設定するために使用される色です。この色を使用する正確な図形はコンポーネントによって異なるため、カスタマイズできません。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "相対",
+      "description": "このプロパティは、コントロールの操作の計算方法を決定します。操作は、操作が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、操作の開始点を基準にして計算します。",
+      "markdownDescription": "このプロパティは、コントロールの操作の計算方法を決定します。操作は、操作が開始された場所に対して相対的に計算されるか、コントロールの中心を使用して絶対的な方法で計算されます。省略した場合、既定値 `true` を使用して、操作の開始点を基準にして計算します。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "ボタンとしてレンダリング",
+      "description": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
+      "markdownDescription": "このプロパティにより、コントロールはボタンとして表示されます。省略すると、既定値の `false` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "スケール",
+      "description": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
+      "markdownDescription": "コントロールのサイズを変更するために使用される乗数。この値は 0.5 から 2 の範囲で指定する必要があります。省略すると、既定値の 1 が使用されます。",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "感度",
+      "description": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
+      "markdownDescription": "コントロールの感度を変更するために使用される乗数。この値は 0 より大きくする必要があります。省略すると、既定値の 1 が使用されます。",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "センサー コントロール",
+      "description": "デバイスの使用可能なセンサーから操作を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロール型とその目的については、`type` プロパティを参照してください。",
+      "markdownDescription": "デバイスの使用可能なセンサーから操作を受け取り、出力に変換する個々の非表示コントロールです。特定のコントロール型とその目的については、`type` プロパティを参照してください。",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "レイヤー センサー コントロール",
+      "description": "デバイスの使用可能なセンサーから操作を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "markdownDescription": "デバイスの使用可能なセンサーから操作を受け取り、出力に変換する個々の非表示コントロール。`blank` コントロールを使用すると、このコントロールの下にあるレイヤーのセンサー コントロールを非表示にしたり、オフにしたりできます。",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "固定",
+      "description": "このプロパティは、プレイヤーがコントロールの操作を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、クルーズ コントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
+      "markdownDescription": "このプロパティは、プレイヤーがコントロールの操作を停止したときにコントロールがニュートラルな位置に戻る場合に変更されます。設定しても、固定スロットルは `axisDown` 領域に残りません。たとえば、これを使用して、クルーズ コントロール スタイル機能を実装できます。省略すると、既定値の `false` が使用されます。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "ストローク スタイル設定コンポーネント",
+      "description": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
+      "markdownDescription": "コントロール コンポーネントのストロークの視覚的なスタイル設定です。ストロークは通常、コントロール コンポーネントの範囲を表示するために使用される境界線またはアウトラインです。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "スロットル軸",
+      "description": "このプロパティは、プレイヤーによるコントロールの操作から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+      "markdownDescription": "このプロパティは、プレイヤーによるコントロールの操作から、中間点から指定された出力への上または下への単一のマッピングを定義します。",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "スロットル軸のスタイル設定コンポーネント",
+      "description": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+      "markdownDescription": "スロットル軸コンポーネントの視覚的なスタイルです。このコンポーネントは、入力可能な範囲と、コントロールが現在どの領域に含まれているかを示します (上または下)。",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "コントロールがアクティブ化されたアップ スタイル",
+              "description": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが操作されているとき (特にコントロールの中央の上の領域) です。",
+              "markdownDescription": "コントロールが `activatedUp` 状態のときに使用されるスタイル設定オーバーライドです。`activatedUp` 状態は、コントロールが操作されているとき (特にコントロールの中央の上の領域) です。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "コントロールがアクティブ化されたダウン スタイル",
+              "description": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが操作されているとき (特にコントロールの中央の下の領域) です。",
+              "markdownDescription": "コントロールが `activatedDown` 状態のときに使用されるスタイル設定オーバーライドです。`activatedDown` 状態は、コントロールが操作されているとき (特にコントロールの中央の下の領域) です。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "コントロールの無効なスタイル",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "コントロールのアイドル アップのスタイル",
+              "description": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` になっている場合のみです。",
+              "markdownDescription": "コントロールが `idleUp` 状態のときに使用されるスタイル設定オーバーライドです。`idleUp` 状態は、コントロールが操作されていないが、コントロールの値がコントロールの中央の上の領域に残っている場合です。この状態に到達できるのは、コントロールが `sticky` になっている場合のみです。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "トグル",
+      "description": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
+      "markdownDescription": "このプロパティは、コントロールをトグル コントロールに変更します。コントロールは、操作されなくなったときに `idle` 状態に戻る代わりに、アクションがまだ実行されている `toggled` 状態に遷移します。プレイヤーがコントロールを再び操作すると、切り替えが解除され、`idle` 状態に戻ります。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "コントロールのスタイル",
+      "description": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "markdownDescription": "コントロールの視覚的なスタイル設定の定義です。コントロールの各状態について、スタイル設定をオーバーライドできます。特定の状態でカスタマイズされていない要素では、`default` スタイル設定プロパティまたはシステムの既定値が、コントロールのスタイル設定の基準として使用されます。システムは、`disabled` 状態の不透明度を減らすなど、特定の状態で適切な `default` スタイルからコントロールの視覚エフェクトを変更できます。",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "コントロールがアクティブ化されたスタイル",
+              "description": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "markdownDescription": "コントロールが `activated` 状態のときに使用されるスタイル設定オーバーライドです。`activated` 状態は、コントロールが操作中で、そのアクションが実行されているときです。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "コントロールの既定のスタイル",
+              "description": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "markdownDescription": "コントロールに適用される既定のスタイル設定パラメーターです。これらのパラメーターは、コントロールに対して提供されるシステムの既定のスタイル設定をオーバーライドするために使用されます。特定の状態のスタイルを指定することで、ビジュアルをさらにオーバーライドできます。`disabled` のような、特定のスタイルが指定されていない状態では、既定のスタイルがフォールバックとして使用されますが、コントロールが無効であることを示すために全体的な不透明度を下げたりするなど、その状態に対していくつかの変更が行われる場合があることに注意してください。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "コントロールの無効なスタイル",
+              "description": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "markdownDescription": "コントロールが `disabled` 状態のときに使用されるスタイル オーバーライドです。この状態では、プレイヤーがコントロールを操作するときに出力が実行されていても、コントロールは視覚的に無効になります。ここで明示的にオーバーライドされない限り、`default` スタイル設定構成で指定された値は、コントロール全体の不透明度を下げるとともに使用され、すべての操作インジケーターは非表示になり、コントロールが無効になっていることを示します。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "コントロールのアイドルのスタイル",
+              "description": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+              "markdownDescription": "コントロールが `idle` 状態のときに使用されるスタイル設定オーバーライドです。この状態では、コントロールは操作中ではなく、ニュートラルまたは休止していると見なされます。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "コントロールの移動スタイル",
+              "description": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+              "markdownDescription": "コントロールが `moving` 状態のときに使用されるスタイル設定オーバーライド。`moving` 状態は、コントロールが操作されているが、そのアクションがまだ実行されていない場合です。操作の方向を示すために、この状態で追加のスタイル要素を使用できる場合があります。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "間隔",
+      "description": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
+      "markdownDescription": "このプロパティは、割り当てられたサブアクションが全体的なアクションの実行中にオンまたはオフになる一定の間隔または期間をミリ秒単位で定義します。",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "type": "object"
+}

--- a/touch-adaptation-kit/schemas/ko-KR/context/v4.1/context.json
+++ b/touch-adaptation-kit/schemas/ko-KR/context/v4.1/context.json
@@ -1,0 +1,163 @@
+{
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.1/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "터치 적응 번들 컨텍스트 스키마",
+    "description": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+    "markdownDescription": "터치 적응 번들 컨텍스트는 다른 레이아웃에서 참조할 수 있는 재사용 가능한 전역 상태 및 정의를 포함하는 파일입니다. 이를 통해 일반적인 스키마 코드 조각을 재사용하고 터치 컨트롤이 게임 상태에 동적으로 응답할 수 있습니다. 버전 간 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "터치 번들 허용 상태 값",
+            "description": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
+            "markdownDescription": "이 속성은 동적 상태를 사용할 때 다른 자산 파일 이름과 같이 가능한 값 집합에 대한 추가 메타데이터를 제공하는 데 사용됩니다. 이는 모든 값이 유효한 터치 레이아웃이 되고 자산과 같은 추가 번들 파일이 누락되거나 사용되지 않도록 하는 유효성 검사 목적으로 사용됩니다. 이 속성은 런타임에 사용되지 않으며 유효하지 않은 레이아웃을 초래하는 모든 상태 변경 작업은 무시됩니다. 따라서 모든 경우에 적절한 작동을 보장하기 위해 광범위한 값으로 테스트하는 것이 중요합니다.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/latest/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "정의 가능한 유형",
+            "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+            "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/latest/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "정의",
+            "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+            "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "번들 상태 터치",
+            "description": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
+            "markdownDescription": "이 속성은 기본 값으로 사용자 지정 명명된 속성을 지정하여 터치 번들의 모든 동적 상태를 포함하는 데 사용됩니다. `XGameStreamingUpdateTouchControlsState` API를 사용하여 런타임 시 섹션의 값을 업데이트할 수 있습니다. 예를 들어 플레이어가 새로운 기술을 습득하거나 컨트롤 기본 설정을 사용자 지정할 때 플레이어 게임의 정확한 상태를 표시되는 컨트롤과 일치시키는 데 유용할 수 있습니다. 기본 문자열, 숫자 또는 부울 유형을 사용하는 터치 레이아웃의 대부분의 위치는 값을 이 상태 블록으로 다시 `$ref`로 정의하여 동적 교체를 허용합니다.",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "번들 상태 항목 터치",
+            "description": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
+            "markdownDescription": "이 속성은 `state` 구성에 나타나는 개별 항목입니다. 해당 값은 기본 문자열, 숫자 또는 부울이어야 합니다. 상태를 동적으로 업데이트하기 위해 `XGameStreamingUpdateTouchControlsState` 호출할 때 항목의 이름과 일치하는 형식의 값을 사용합니다.",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "스타일",
+            "description": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
+            "markdownDescription": "이 속성은 스타일 지정을 위해 이 터치 적응 번들의 레이아웃 내에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 주어진 레이아웃 파일에 동등한 `styles` 속성이 정의되어 있으면 각각의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 선호되며 컨텍스트 파일의 정의를 덮어씁니다.",
+            "$ref": "../../layout/latest/layout.json#/$defs/_LayoutStyles"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
+        }
+    },
+    "additionalProperties": false
+}

--- a/touch-adaptation-kit/schemas/ko-KR/layout/v4.1/layout.json
+++ b/touch-adaptation-kit/schemas/ko-KR/layout/v4.1/layout.json
@@ -1,0 +1,5525 @@
+{
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.1/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "additionalProperties": false,
+  "title": "터치 적응 번들 레이아웃 스키마",
+  "description": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+  "markdownDescription": "터치 적응 번들 레이아웃은 게임 시나리오와 모바일 또는 터치 게임 플레이를 허용하는 데 필요한 모든 컨트롤을 나타냅니다. 레이아웃 버전 간의 변경 내용에 대한 최신 정보는 https://github.com/microsoft/xbox-game-streaming-tools/releases를 참조하세요.",
+  "$defs": {
+    "LayoutDefinableType": {
+      "title": "정의 가능한 유형",
+      "description": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "markdownDescription": "이 파일의 `definitions` 섹션에서 사용할 수 있는 모든 형식을 포함하는 공용 구조체 형식입니다. 자세한 내용은 `definitions` 섹션을 참조하세요.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        {
+          "$ref": "#/$defs/ActionType"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/AssetReference"
+        },
+        {
+          "$ref": "#/$defs/AxisCap"
+        },
+        {
+          "$ref": "#/$defs/AxisCapColor"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        {
+          "$ref": "#/$defs/Background"
+        },
+        {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/ButtonActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonToggledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonPulledStyle"
+        },
+        {
+          "$ref": "#/$defs/Color"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteDefaultVariant"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+        },
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/ControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneRadial"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneThreshold"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        {
+          "$ref": "#/$defs/FaceImage"
+        },
+        {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        {
+          "$ref": "#/$defs/FillColor"
+        },
+        {
+          "$ref": "#/$defs/Gradient"
+        },
+        {
+          "$ref": "#/$defs/Indicator"
+        },
+        {
+          "$ref": "#/$defs/InnerLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InnerLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InputCurveRange"
+        },
+        {
+          "$ref": "#/$defs/InputCurve"
+        },
+        {
+          "$ref": "#/$defs/InputCurveType"
+        },
+        {
+          "$ref": "#/$defs/JoystickActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDirectionIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickMovingStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        {
+          "$ref": "#/$defs/Knob"
+        },
+        {
+          "$ref": "#/$defs/Layer"
+        },
+        {
+          "$ref": "#/$defs/Layers"
+        },
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/LayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayerSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayoutColors"
+        },
+        {
+          "$ref": "#/$defs/LayoutOrientation"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Opacity"
+        },
+        {
+          "$ref": "#/$defs/OuterLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelControlGroup"
+        },
+        {
+          "$ref": "#/$defs/OuterLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelLayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/PullActionType"
+        },
+        {
+          "$ref": "#/$defs/PullIndicator"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        },
+        {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        {
+          "$ref": "#/$defs/Scale"
+        },
+        {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        {
+          "$ref": "#/$defs/SensorControl"
+        },
+        {
+          "$ref": "#/$defs/Sticky"
+        },
+        {
+          "$ref": "#/$defs/Stroke"
+        },
+        {
+          "$ref": "#/$defs/LayoutStyles"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisStyle"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        {
+          "$ref": "#/$defs/Toggle"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyleBase"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyles"
+        }
+      ]
+    },
+    "Definitions": {
+      "title": "정의",
+      "description": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "markdownDescription": "다시 사용할 수 있는 구성 요소와 터치 레이아웃 값을 포함하는 데 사용할 수 있는 섹션입니다. 이러한 정의는 나중에 '{ \"$ref\": \"#/definitions/joystickKnobStyle\" }'와 같은 JSON 참조를 사용하여 참조할 수 있습니다. JSON 참조는 레이아웃 스키마의 거의 모든 부분에서 지원되며, 여러 컨트롤에서 사용되는 공통 단추 배경과 같은 공통 요소를 축소하여 재사용할 수 있습니다. 컨텍스트 파일은 `definitions` 속성과 `state` 지원하여 레이아웃에서 구성 요소를 다시 사용할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
+    },
+    "Reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
+          "markdownDescription": "컨텍스트 파일과 같이 로컬 또는 인근 파일에 정의된 값에 대한 참조입니다. 자세한 내용은 `definitions` 레이아웃 속성을 참조하십시오.",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "null",
+      "description": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
+      "markdownDescription": "위치를 건너뛰기 위해 컨트롤 대신 사용할 수 있는 특수 값입니다. 콘트롤 배열과 콘텐츠 배치를 패딩하기 위한 레이어에서 특히 유용합니다.",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "가속도계 제어 유형",
+          "description": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
+          "markdownDescription": "가속도계 컨트롤입니다 컨트롤을 사용하면 장치의 동작, 특히 가속도를 게임 입력으로 변환할 수 있습니다.",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
+      "examples": [
+        {
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "헤비 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "헤비 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "라이트 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "라이트 펀치 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "미디엄 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "중간 펀치 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "스페셜 킥 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "특수 펀치 버튼",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "2차원 축 매핑 항목",
+      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "3차원 축 매핑 항목",
+      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 단일 매핑을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
+          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 사용자 지정 자산입니다.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+          "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "공백 제어 유형",
+          "description": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
+          "markdownDescription": "레이어를 사용하는 레이아웃을 만들 때 빈 컨트롤 유형을 사용하여 그 아래 레이어에 있는 기존 컨트롤 또는 컨트롤 그룹을 재정의하거나 숨깁니다. 빈 컨트롤은 상호 작용할 수 없으며 스타일을 지정할 수 있는 구성 요소가 없습니다.",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "게임패드 아날로그 조이스틱 출력",
+      "description": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
+      "markdownDescription": "지정된 게임패드 조이스틱 축을 따라 0에서 최대값까지 값을 출력합니다. `output`이 아닌 `action`으로 사용되는 경우 최대값만 사용됩니다.",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "게임패드 아날로그 조이스틱 출력",
+      "description": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "markdownDescription": "지정된 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "게임패드 아날로그 조이스틱 출력",
+      "description": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "markdownDescription": "두 게임패드 조이스틱 축 전체를 따라 값을 출력합니다.",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "게임패드 버튼 출력",
+      "description": "게임패드 버튼 누름을 출력합니다.",
+      "markdownDescription": "게임패드 버튼 누름을 출력합니다.",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "게임패드 아날로그 트리거 출력",
+      "description": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
+      "markdownDescription": "지정된 게임패드 트리거에 매핑되는 값을 출력합니다.",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "아케이드 버튼 제어 유형",
+      "description": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
+      "markdownDescription": "아케이드 버튼 컨트롤. 이 컨트롤은 일반적인 6개 또는 8개 버튼 아케이드 캐비닛 배열을 기반으로 배열된 버튼 그룹입니다. 일반적으로 격투 스타일 게임에서 사용됩니다. 버튼 사이를 터치하면 플레이어가 한 번에 여러 버튼을 누를 수 있습니다. 버튼 열의 위나 아래를 터치하면 해당 행의 모든 버튼이 동시에 활성화되어 콤보를 더 쉽게 수행할 수 있습니다.",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "버튼 제어 유형",
+      "description": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
+      "markdownDescription": "버튼 컨트롤은 컨트롤을 누르고 있는 동안 작업을 수행할 수 있는 간단한 컨트롤 유형입니다. 일부 고급 기능을 허용하기 위해 상호 작용이 제어 범위를 넘어 이동할 때 끌어오기 작업이라고 하는 추가 동작을 할당할 수 있습니다. 이는 사격 중 조준과 같이 컨트롤의 주요 동작과 함께 두 번째 동시 동작이 필요한 상황에서 유용합니다.",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "방향 패드 제어 유형",
+      "description": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
+      "markdownDescription": "방향 패드 컨트롤은 실제 게임패드에 있는 표준 4방향 또는 8방향 컨트롤을 모방합니다. 이 컨트롤은 특정 작업을 수행하기 위해 정확한 지시가 필요한 2D 플랫포머 및 격투 게임에서 특히 유용합니다. 4방향 또는 8방향 스타일 컨트롤 중에서 선택하려면 `interaction` 속성을 참조하세요.",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "조이스틱 제어 유형",
+      "description": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
+      "markdownDescription": "물리적 컨트롤러의 아날로그 조이스틱을 모방한 조이스틱 컨트롤입니다. 이를 통해 플레이어는 `axis` 속성을 기반으로 2차원 또는 1차원 공간에서 컨트롤을 이동할 수 있습니다. 또한 `action` 및 `actionThreshold` 속성을 사용하여 동작과 함께 동시 동작을 수행할 수 있습니다. 이 컨트롤은 플레이어 이동 또는 카메라 컨트롤에 자주 사용되며 조준이나 사격과 같이 이동하거나 둘러보는 동안 수행할 수 있는 모든 작업에 대해 여러 조이스틱을 포함하는 터치 레이아웃이 일반적입니다.",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "스로틀 제어 유형",
+      "description": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
+      "markdownDescription": "보트, 자동차 또는 비행기의 물리적 스로틀을 모방한 스로틀 컨트롤입니다. 이 컨트롤에는 플레이어가 스로틀을 위 또는 아래로 이동하기 위해 상호 작용할 수 있는 노브가 있습니다. 이 컨트롤은 가스를 항상 억제해야 하는 경우가 많은 운전 또는 비행 게임에 가장 유용합니다. 컨트롤의 스타일을 지정할 때 별도의 `activatedUp`, `activatedDown` 및 `idleUp` 상태를 사용하면 플레이어가 가스, 브레이크 등을 사용할 때 정확한 사용자 지정을 표시할 수 있습니다.",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "터치패드 제어 방식",
+      "description": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
+      "markdownDescription": "랩톱 컴퓨터에 있는 물리적 터치패드를 모방한 터치패드 컨트롤입니다. 이 컨트롤은 카메라 컨트롤과 같은 마우스 또는 조이스틱 스타일의 움직임에 가장 적합하며 플레이어가 스와이프 및 드래그를 통해 정밀한 컨트롤을 허용합니다. 또한 `action`을 컨트롤에 할당할 수 있으며 `renderAsButton`을 사용하여 버튼으로 렌더링하여 움직임이나 카메라를 조준이나 점프와 같은 일반적인 동작과 결합하는 컨트롤을 만들 수 있습니다.",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "사용자 지정 레이아웃 색상",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색을 정의합니다. 이 색은 'colors/' 접두사 다음에 색 이름을 사용하여 색을 스타일 지정에 사용할 수 있는 영역에서 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "얼굴 이미지 자산 스타일링 구성 요소",
+          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
+          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 사용자 지정 자산입니다.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "얼굴 이미지 아이콘 스타일링 구성 요소",
+          "description": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
+          "markdownDescription": "컨트롤 구성 요소의 전경 그래픽으로 사용되는 기본 제공 아이콘입니다.",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "자이로스코프 제어 유형",
+          "description": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
+          "markdownDescription": "자이로 스코프 컨트롤. 이 컨트롤을 사용하면 장치의 동작, 특히 해당 축에 대한 회전을 게임 입력으로 변환할 수 있습니다. 이 컨트롤은 실제 세계 회전이 자연스럽게 게임의 관점을 회전할 수 있기 때문에 플레이어의 카메라를 제어하는 데 특히 유용할 수 있습니다.",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "축 크기 입력 매핑",
+      "description": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
+      "markdownDescription": "지정된 축 방향(위, 아래, 왼쪽 또는 오른쪽)을 따라 입력의 크기만 사용하여 지정된 출력으로 변환합니다. 예를 들어 `axisLeft` 값은 입력이 현재 제어 원점에서 얼마나 왼쪽에 있는지에 따라 0에서 1로 매핑됩니다. 크기 기반 값이므로 음수 출력이 가능하지 않습니다.",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X축 입력 매핑",
+          "description": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "markdownDescription": "컨트롤의 X축을 따라 상호 작용(양수 및 음수 방향)을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y축 입력 매핑",
+          "description": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "markdownDescription": "컨트롤의 Y축을 따라 상호 작용을 사용하며, 양수 방향에서는 양수이고 음수이면 지정된 출력으로 변환됩니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X축 및 Y축 입력 매핑",
+      "description": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "markdownDescription": "컨트롤의 X 및 Y 축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z 및 Y축 입력 매핑",
+      "description": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "markdownDescription": "컨트롤의 Z 및 Y축에서 상호 작용을 사용하여 지정된 출력으로 변환합니다. 이 매핑에 대한 자세한 내용은 `output` 속성을 참조하십시오.",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
+          "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "레이아웃 작업",
+      "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+      "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "레이아웃 작업",
+          "description": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+          "markdownDescription": "작업이 실행되는 동안 레이어 적용과 같은 레이아웃 변경을 트리거하는 작업 유형입니다.",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
+            },
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_RelativeMouse1DOutputType": {
+      "title": "상대 마우스 1차원 출력",
+      "description": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
+      "markdownDescription": "이 출력 유형은 1차원 제어 입력을 받아 단일 축을 따라 상대적인 마우스 움직임으로 변환합니다.",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
+      ],
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "상대 마우스 2차원 출력",
+      "description": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
+      "markdownDescription": "이 출력 유형은 2차원 제어 입력을 받아 상대적인 마우스 움직임으로 변환합니다.",
+      "const": "relativeMouse",
+      "type": "string"
+    },
+    "_RelativeMouseMagnitudinalOutputType": {
+      "title": "상대 마우스 방향 출력",
+      "description": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
+      "markdownDescription": "이 출력 유형은 지정된 입력 축을 따라 제어 입력의 크기를 취하여 한 방향으로 상대적인 마우스 움직임에 매핑합니다. 예를 들어 조이스틱의 X축 이동이 상대적인 마우스 X축 출력에 매핑된 경우 조이스틱이 오른쪽으로 유지되는 동안 일련의 긍정적인 X 방향 마우스 이동이 전송됩니다.",
+      "enum": [
+        "relativeMouseUp",
+        "relativeMouseDown",
+        "relativeMouseLeft",
+        "relativeMouseRight"
+      ],
+      "type": "string"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_StrokeBase": {
+      "examples": [
+        {
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
+              "markdownDescription": "이 스타일 구성 요소는 사용자 지정 가능한 색상 및 불투명도로 단색 획을 지정하는 데 사용됩니다.",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "title": "콘텐츠 기본 시스템 색상 재정의",
+      "description": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 가운데 획, 아이콘 색조 및 dpad 그라데이션과 같은 구성 요소 스타일 지정에 사용되는 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "콘텐츠 보조 시스템 색상 재정의",
+      "description": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
+      "markdownDescription": "이 속성은 배경 및 채우기와 같은 구성 요소 스타일 지정에 사용되는 보조 시스템 색을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "대비 기본 시스템 색상 재정의",
+      "description": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 내부/외부 획 및 얼굴 이미지 백플레이트와 같은 대비 구성 요소의 스타일 지정에 사용되는 대비 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "대비 보조 시스템 색상 재정의",
+      "description": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
+      "markdownDescription": "이 속성은 터치 패드 스트로크와 같은 대비 구성 요소에 사용되는 대비 보조 시스템 색을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "액션 시스템 색상 재정의",
+      "description": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 `action` 필드가 비 게임패드 작업으로 설정된 컨트롤의 구성 요소 스타일 지정에 사용되는 해당 작업 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "게임패드 액션 시스템 색상 재정의",
+      "description": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 `action` 필드가 `gamepadA`, `gamepadB`, `gamepadX` 또는 `gamepadY`로 설정된 컨트롤의 구성요소 스타일 지정에 사용되는 해당 게임패드 작업 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "악센트 기본 시스템 색상 재정의",
+      "description": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 ergo-edit 내부 휠과 같은 스타일링 구성 요소에 사용되는 액센트 기본 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "악센트 보조 시스템 색상 재정의",
+      "description": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
+      "markdownDescription": "이 속성은 ergo-edit 외부 휠과 같은 스타일링 구성 요소에 사용되는 악센트 보조 시스템 색상을 재정의합니다.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
+      "examples": [
+        {
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "터보 액션",
+      "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+      "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "터보 액션",
+          "description": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+          "markdownDescription": "연속이 아닌 간격을 기준으로 켜고 끄는 동작입니다.",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "작업 임계값",
+      "description": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+      "markdownDescription": "이 속성은 컨트롤 동작을 트리거하는 데 필요한 정규화된 방사형 입력 값을 정의합니다. 이 값에 도달하면 컨트롤이 해당 작업을 실행하고 `moving` 상태에서 `activated` 상태로 전환합니다. 생략하면 기본값 0이 사용됩니다. 즉, 모든 컨트롤 상호 작용이 할당된 작업을 즉시 실행합니다.",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionType": {
+      "title": "제어 동작",
+      "description": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 `activated` 상태일 때 단일 작업 또는 일련의 작업을 컨트롤에서 수행할 수 있습니다. 이러한 작업은 게임패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다.",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "ArcadeButton": {
+      "description": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
+      "markdownDescription": "`arcadeButtons` 컨트롤 유형의 단일 버튼입니다. 이 버튼은 아케이드 버튼 배열에서 잘 작동하도록 `button` 컨트롤 유형의 단순화된 버전입니다.",
+      "examples": [
+        {
+          "action": "gamepadX",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "lightPunch"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonFightingButtons"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "$ref": "#/$defs/ActionType"
+            },
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
+            },
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
+            }
+          },
+          "required": [
+            "action"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyleBase": {
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "컨트롤 비활성화 스타일",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "자산 참조 스타일링 구성 요소",
+      "description": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
+      "markdownDescription": "자산 참조는 터치 레이아웃과 함께 번들로 제공되는 사용자 지정 자산의 식별자입니다. 전체 파일을 참조하려면 파일 확장자 없이 이미지의 파일 이름을 사용하세요. 스프라이트시트 자산의 경우 확장자가 없는 텍스처 파일 이름을 사용하고 스프라이트 아틀래스 내의 스프라이트 이름과 `/`를 사용합니다. 화면 해상도가 다른 장치를 처리하기 위해 DPI(1.0x, 1.5x, 2.0x, 3.0x, 4.0x)별 파일을 제공해야 합니다. 자산이 사용되는 컨트롤 및 구성 요소에 따라 최대 1.0x 해상도가 다를 수 있지만 60x60 및 120x120이 가장 일반적으로 허용되는 최대값입니다. 다른 모든 DPI 해상도는 1.0x 자산 해상도의 배수여야 합니다.",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "축 캡 스타일링 구성 요소",
+      "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+      "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "축 캡 스타일링 구성 요소",
+              "description": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+              "markdownDescription": "축 제어 구성 요소의 한계를 나타내는 데 사용되는 시각적 스타일입니다. 축의 최대값 또는 최소값을 의미 체계적으로 나타내기 위해 색상으로 스타일을 지정할 수 있습니다.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "2차원 축 매핑",
+      "description": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 2차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 축 할당에 따라 컨트롤의 모양과 느낌이 변경될 수 있습니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "3차원 축 매핑",
+      "description": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 3차원 아날로그 상호 작용에서 1차원 또는 2차원 출력으로의 매핑 또는 매핑 집합을 정의합니다. 장치 센서와 같은 3차원 상호 작용의 경우 좌표 공간은 항상 게임의 비디오를 기준으로 합니다. 즉, 양의 X 방향은 영상의 오른쪽, 양의 Y 방향은 영상의 상단, 양의 Z 방향은 영상에서 플레이어를 향하도록 하는 것입니다.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "배경 스타일 구성 요소",
+      "description": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+      "markdownDescription": "컨트롤 구성 요소 배경의 시각적 스타일입니다. 배경은 `color` 또는 `asset` 수 있습니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "컨트롤 활성화 스타일",
+      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "제어 기본 스타일",
+      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "컨트롤 비활성화 스타일",
+      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "유휴 스타일 제어",
+      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
+      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 완전히 투명한 배경 및 끌어오기 표시기와 함께 사용되어 컨트롤이 유휴 상태이고 상호 작용하지 않음을 나타냅니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "전환된 스타일 제어",
+      "description": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
+      "markdownDescription": "컨트롤이 `toggled` 상태일 때 사용되는 스타일 재정의입니다. `toggled` 상태는 컨트롤이 상호 작용하지 않지만 현재 토글 상태이므로 해당 작업이 실행되는 경우입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "끌어온 컨트롤 스타일",
+      "description": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+      "markdownDescription": "컨트롤이 `pulled` 상태일 때 사용되는 스타일 재정의입니다. `pulled` 상태는 컨트롤이 상호 작용되고 컨트롤의 범위를 벗어나서 사용되어 추가 작업이 실행될 때입니다.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "색상",
+      "description": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "markdownDescription": "이 속성은 문자열 표현을 사용하여 색상을 정의합니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "기본 색상",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 특정 변형에 정의되지 않은 색상 또는 특정 변형이 활성화되지 않은 경우 해당 색상 참조는 여기에 정의된 색상으로 대체됩니다. 지정된 시스템 색상 재지정이 지정되지 않은 경우 색상 참조는 시스템의 기본 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "고대비 색상",
+      "description": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 고대비 모드가 활성화된 경우 다른 곳에서 참조할 수 있는 재사용 가능한 색상 모음을 정의합니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 여기에 정의되지 않은 색상이나 고대비 모드가 비활성화된 경우 해당 색상 참조는 `default`에 정의된 색상으로 대체됩니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "터치 레이아웃 제어",
+      "description": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "markdownDescription": "플레이어가 번역된 작업을 수행하기 위해 상호 작용할 수 있는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "사용",
+      "description": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
+      "markdownDescription": "컨트롤이 `disabled` 상태인지 여부를 결정하는 속성입니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 활성화 및 비활성화할 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 비활성화되면 컨트롤이 표시되고 여전히 출력을 따라 전달되지만 활성화된 모양은 없습니다. 이 동작은 모양이 있고 화면에 렌더링되는 컨트롤에만 적용됩니다. 센서 컨트롤은 모양이 없기 때문에 비활성화된 상태일 때 출력을 전달하지 않습니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "터치 레이아웃 컨트롤 그룹",
+      "description": "그룹에서 정렬된 1~007E;4개 컨트롤 집합입니다. 이 그룹 내의 항목은 시스템에서 정렬되며, 일반적으로 사용 가능한 영역의 위쪽에서 시계 방향으로 진행됩니다. 하나의 컨트롤만 있는 그룹은 그룹화되지 않은 컨트롤과 다릅니다. 그룹에 더 큰 총 상호 작용 영역이 포함될 수 있습니다. 정렬에서 컨트롤을 건너뛰는 데 `null` 특수 값을 사용할 수 있습니다.",
+      "markdownDescription": "그룹에서 정렬된 1~007E;4개 컨트롤 집합입니다. 이 그룹 내의 항목은 시스템에서 정렬되며, 일반적으로 사용 가능한 영역의 위쪽에서 시계 방향으로 진행됩니다. 하나의 컨트롤만 있는 그룹은 그룹화되지 않은 컨트롤과 다릅니다. 그룹에 더 큰 총 상호 작용 영역이 포함될 수 있습니다. 정렬에서 컨트롤을 건너뛰는 데 `null` 특수 값을 사용할 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "터치 레이아웃 제어 그룹 항목",
+      "description": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+      "markdownDescription": "컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰려면 `null` 사용합니다.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "게임패드 액션",
+      "description": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 `activated` 상태일 때 컨트롤이 단일 게임패드 동작 또는 일련의 게임패드 동작을 수행할 수 있습니다.",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "표시",
+      "description": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+      "markdownDescription": "컨트롤이 표시되는지 여부를 결정합니다. 이 속성은 게임 상태에 따라 컨트롤을 동적으로 표시하고 숨길 수 있도록 컨텍스트 파일 `state`와 함께 사용할 때 가장 유용합니다. 생략하면 기본값 `true`가 사용됩니다. 보이지 않으면 컨트롤을 활성화할 수 없으며 플레이어가 컨트롤이 표시되는 위치를 터치하더라도 어떤 작업도 실행하지 않습니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "1차원 데드존",
+      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
+      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. 생략하면 데드존이 사용되지 않습니다.",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "2차원 데드존",
+      "description": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
+      "markdownDescription": "컨트롤에서 생성된 정규화된 최소 출력 값입니다. 이는 게임에 프로그래밍된 데드존에 대응하는 데 유용합니다. `radial`이 true로 설정되면 데드존이 방사형 구성요소를 따라 1차원적으로 계산됩니다. 그렇지 않으면 각 축은 임계값을 사용하여 개별적으로 계산됩니다. 생략하면 데드존이 사용되지 않습니다.",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "방향 패드 데드존",
+      "description": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
+      "markdownDescription": "입력을 무시하는 방향성 패드 영역의 정규화된 반경입니다. 작은 입력 변화가 활성화되는 방향을 크게 바꿀 수 있는 방향성 패드의 중심 근처에서 원하지 않는 방향의 변화를 피하는 데 유용합니다. 생략하면 0.25 값이 사용됩니다. 이 값을 변경하면 플레이어에게 이 크기를 표시하기 위해 방향 패드가 렌더링되는 방식이 변경됩니다.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "임계값",
+      "description": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
+      "markdownDescription": "출력 값을 생성하는 데 필요한 정규화된 입력 값입니다.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "방사형",
+      "description": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
+      "markdownDescription": "데드존 임계값이 방사형 입력 구성 요소를 따라 계산되는지 아니면 각 축에 대해 개별적으로 계산되는지 여부입니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "상호 작용",
+      "description": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
+      "markdownDescription": "이 속성은 플레이어가 컨트롤을 상호 작용하는 방법을 결정합니다. 자세한 내용은 `activationType` 속성을 참조하십시오.",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteractionActivationType": {
+      "title": "활성화 유형",
+      "description": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
+      "markdownDescription": "이 속성은 플레이어 상호 작용에 대한 응답으로 컨트롤과 해당 하위 구성 요소가 활성화되는 방식을 결정합니다. 활성화 유형은 `exclusive` 또는 `allowNeighboring`일 수 있습니다. `exclusive`으로 설정하면 컨트롤의 하위 구성요소 하나만 한 번에 활성화됩니다. `allowNeighboring`이 설정되면 플레이어가 컨트롤과 상호 작용하는 위치에 따라 컨트롤의 여러 하위 구성 요소가 동시에 활성화될 수 있습니다. 생략하면 `allowNeighboring`의 기본값이 사용됩니다.",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
+              "markdownDescription": "컨트롤이 `idle`상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 컨트롤의 중립 또는 휴지 상태입니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 컨트롤이 유휴 상태이고 상호 작용하지 않음을 표시하기 위해 완전히 투명한 그라데이션과 함께 사용됩니다.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "확장",
+      "description": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
+      "markdownDescription": "이 속성은 컨트롤이 사용 가능한 공간을 채우기 위해 상호 작용 가능한 영역을 확장해야 하는지 여부를 결정합니다. 플레이어가 영역의 크기를 사용자 지정할 수 있는 `inner` 휠 컨테이너에 특히 유용합니다. `false`로 설정하면 컨트롤이 기본 또는 최소 상호 작용 크기로 잠깁니다. 생략하면 기본값 `true`가 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "얼굴 이미지 스타일링 구성 요소",
+      "description": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+      "markdownDescription": "컨트롤 구성 요소의 전경을 나타내는 시각적 스타일입니다. 일반적으로 상호 작용의 의미 체계적 의미를 표시하는 데 사용됩니다. 얼굴 이미지는 `icon` 또는 `asset` 유형일 수 있습니다. 아이콘은 다양한 컨트롤 동작을 표현할 수 있는 기본 제공 그래픽이며, 자산은 컨트롤이 레이아웃과 함께 번들로 제공되는 사용자 지정 이미지를 사용할 수 있도록 합니다.",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "얼굴 이미지 아이콘 레이블 스타일링 구성 요소",
+      "description": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
+      "markdownDescription": "이 속성은 얼굴 이미지 아이콘에 레이블이 표시되는 방식을 결정합니다. `action` 유형은 의미 체계 이미지를 사용하여 게임 프롬프트 및 이미지가 시맨틱 아이콘과 완벽하게 일치하지 않는 경우 플레이어에게 해당 작업이 무엇인지 상기시키는 데 유용합니다. 이러한 추가 레이블을 숨기려면 `none` 유형을 사용할 수 있습니다. 생략하면 `action`의 기본값이 사용됩니다.",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "얼굴 이미지 아이콘",
+      "description": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
+      "markdownDescription": "이 속성은 이 구성 요소에 사용할 기본 제공 아이콘을 선택하는 데 사용됩니다.",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "채우다",
+      "description": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "markdownDescription": "이 속성은 컨트롤 구성 요소를 채울 색상을 변경합니다. 생략하면 대부분 투명한 흰색 채우기가 사용됩니다. 색상은 `hex-color` CSS 사양을 따르는 16진수 값으로 지정하거나 색상 이름이 뒤에 오는 `colors/`로 시작하는 문자열을 사용하여 알려진 시스템 색상 또는 레이아웃 색상을 참조하여 지정해야 합니다. 자세한 내용은 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color를 참조하세요.",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "그라데이션",
+      "description": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
+      "markdownDescription": "그라데이션은 한 색상에서 다른 색상으로의 혼합입니다. 현재 허용되는 유일한 그라데이션은 완전히 투명한 상태에서 제공된 색상 값까지입니다.",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "지표 스타일링 구성 요소",
+      "description": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
+      "markdownDescription": "컨트롤의 현재 값 또는 배치를 나타내는 데 사용되는 획의 시각적 스타일입니다.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "내부",
+      "description": "컨트롤 휠의 내부 세그먼트에 있는 그룹에 정렬된 1~007E;4개 컨트롤 집합입니다. 시스템에서는 일반적으로 공간의 맨 위에서 시작하여 시계 방향으로 진행하여 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 동일하게 나뉩니다.",
+      "markdownDescription": "컨트롤 휠의 내부 세그먼트에 있는 그룹에 정렬된 1~007E;4개 컨트롤 집합입니다. 시스템에서는 일반적으로 공간의 맨 위에서 시작하여 시계 방향으로 진행하여 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 동일하게 나뉩니다.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "내부",
+      "description": "컨트롤 휠의 내부 세그먼트에 있는 그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~007E;4개의 레이어 컨트롤 집합입니다. 시스템에서는 일반적으로 공간의 맨 위에서 시작하여 시계 방향으로 진행하여 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 동일하게 나뉩니다. 아래 레이어의 컨트롤 그룹에 이 컨트롤 그룹과 다른 수의 항목이 있는 경우 해당 계층의 모든 항목이 숨겨집니다.",
+      "markdownDescription": "컨트롤 휠의 내부 세그먼트에 있는 그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~007E;4개의 레이어 컨트롤 집합입니다. 시스템에서는 일반적으로 공간의 맨 위에서 시작하여 시계 방향으로 진행하여 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 전체 내부 세그먼트의 상호 작용 영역은 할당된 컨트롤 간에 동일하게 나뉩니다. 아래 레이어의 컨트롤 그룹에 이 컨트롤 그룹과 다른 수의 항목이 있는 경우 해당 계층의 모든 항목이 숨겨집니다.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveRange": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 입력 곡선 범위",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 이후 버전에서 제거될 수 있습니다. 이 속성은 최소값과 최대값을 정의합니다. 모든 값이 정규화되었으므로 -1에서 1 사이여야 합니다.",
+      "examples": [
+        [
+          0,
+          0.33
+        ],
+        [
+          0,
+          1
+        ],
+        {
+          "$ref": "#/definitions/commonJoystickInputRange"
+        },
+        [
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMin"
+          },
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMax"
+          }
+        ]
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": -1,
+                "maximum": 1
+              },
+              {
+                "$ref": "#/$defs/Reference"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 입력 응답 곡선",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작이 변경되거나 이후 버전에서 제거될 수 있습니다. 이 속성은 입력이 출력 값에 매핑되는 방식의 곡선 또는 함수를 정의합니다. `circular` 또는 `circular-inverse` 유형을 사용하면 각각 오른쪽 아래 사분면 또는 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑할 수 있습니다. 이 속성을 생략하면 기본 선형 매핑이 사용됩니다.",
+      "examples": [
+        {
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
+        },
+        {
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 입력 응답 곡선 유형",
+      "description": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 동작을 변경하거나 향후 버전에서 제거될 수 있습니다. 이 속성은 사용할 곡선 유형을 정의합니다. `circular` 유형은 원의 오른쪽 아래 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다. `circular-inverse` 값은 원의 왼쪽 위 사분면의 모양과 일치하는 원형 곡선으로 입력을 매핑하는 데 사용할 수 있습니다.",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "컨트롤 활성화 스타일",
+      "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "제어 기본 스타일",
+      "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "방향 표시기 스타일링 구성 요소",
+      "description": "상호 작용 방향을 나타내는 시각적 스타일 지정",
+      "markdownDescription": "상호 작용 방향을 나타내는 시각적 스타일 지정",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
+              "markdownDescription": "방향 표시기가 값을 사용자 지정할 수 있는 색 형식으로 지정하도록 지정하는 데 사용되는 속성입니다.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "컨트롤 비활성화 스타일",
+      "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "유휴 스타일 제어",
+      "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+      "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "제어 이동 스타일",
+      "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+      "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "아웃라인 스타일링 구성 요소",
+      "description": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+      "markdownDescription": "상호 작용 방향에 대한 표시기가 있는 컨트롤 개요의 시각적 스타일입니다. 다른 상태의 이 속성에는 컨트롤이 해당 상태에서 상호 작용하지 않기 때문에 표시기의 스타일을 지정하는 기능이 포함되지 않을 수 있습니다.",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "아웃라인 스타일링 구성 요소",
+      "description": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
+      "markdownDescription": "컨트롤 개요의 시각적 스타일입니다. 이 속성은 컨트롤이 상호 작용하는 다른 상태에서 상호 작용 방향에 대한 표시기의 스타일을 지정하는 기능도 포함할 수 있습니다.",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "노브 스타일링 구성 요소",
+      "description": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
+      "markdownDescription": "컨트롤 노브의 시각적 스타일입니다. 노브는 예를 들어 조이스틱 상단을 모방하는 컨트롤의 상호 작용 지점입니다.",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "터치 레이아웃 레이어",
+      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "터치 레이아웃 레이어",
+      "description": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "markdownDescription": "이 속성을 사용하면 다른 컨트롤의 플레이어 작업에 대한 응답으로 추가 컨트롤을 오버레이하거나 레이아웃 콘텐츠를 변경하기 위해 컨트롤 `action`에서 사용할 수 있는 사용자 지정 컨트롤 레이어를 정의할 수 있습니다.",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "터치 레이아웃 레이어 컨트롤",
+      "description": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
+      "markdownDescription": "플레이어가 변환된 작업을 수행하기 위해 상호 작용할 수 있는 현재 레이어의 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요. 레이어는 이 레이어 아래의 레이어에서 모든 컨트롤을 숨기기 위해 특수한 `blank` 컨트롤 유형을 추가합니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "터치 레이아웃 레이어 컨트롤 그룹",
+      "description": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "markdownDescription": "그룹으로 정렬된 아래 레이어에서 컨트롤을 숨기는 `blank` 컨트롤을 포함하여 1~4개의 레이어 컨트롤 세트. 시스템은 사용 가능한 공간 내에서 그룹의 컨트롤을 가장 잘 정렬하는 방법을 결정합니다. 컨트롤이 하나만 있는 그룹은 그룹이 더 큰 전체 상호 작용 영역을 포함할 수 있으므로 그룹화되지 않은 컨트롤과 다릅니다. `null`이라는 특수 값을 사용하여 색인을 건너뛸 수 있습니다. 또한 아래 레이어의 컨트롤 그룹이 이 컨트롤 그룹과 항목 수가 다른 경우 해당 레이어의 모든 항목이 숨겨집니다.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "터치 레이아웃 레이어 제어 그룹 항목",
+      "description": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
+      "markdownDescription": "레이어 컨트롤 그룹의 단일 항목입니다. 정렬에서 컨트롤을 건너뛰거나 `blank` `null` 사용하여 아래 레이어에서 컨트롤을 숨깁니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "레이아웃 레이어 컨트롤 휠 터치",
+      "description": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
+      "markdownDescription": "원 또는 바퀴 모양으로 구성된 레이어 컨트롤 세트입니다.",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "하위 계층 배열 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "하위 계층 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이어의 콘텐츠를 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "센서 레이어 콘텐츠",
+      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이어 콘텐츠의 컨테이너를 정의합니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "상위 계층 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 이 레이어 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤 유형을 사용할 수 있다는 점을 제외하면 기본 레이아웃의 위쪽 영역을 미러링합니다.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "상위 계층 오른쪽 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이어 콘텐츠를 정의합니다. 이 속성은 기본 레이아웃의 오른쪽 위 영역을 미러링합니다. 단, `blank` 컨트롤 유형을 사용하여 이 레이어 아래의 레이어에서 컨트롤을 숨길 수 있습니다.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "레이아웃 작업 대상",
+      "description": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
+      "markdownDescription": "이 속성은 작업이 실행될 때 적용할 계층을 지정합니다. 이 이름은 레이아웃 콘텐츠의 `layers` 속성에 나타나야 합니다.",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "색",
+      "description": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "markdownDescription": "이 속성은 다른 곳에서 참조할 수 있는 색상 정의로 구성된 색상 팔레트 모음을 정의합니다. 각 스타일 변형에 대해 색상 팔레트를 정의할 수 있습니다. 특정 변형에 정의되지 않은 색상의 경우 `default` 색상 팔레트 또는 시스템 기본값이 사용됩니다. 색상 정의는 레이아웃의 내용에 따라 다르거나 시스템의 기본 색상을 재정의할 수 있습니다. 시스템 색상에는 예약된 `system_` 키워드가 접두사로 붙습니다. 색상은 스타일 지정 목적으로 색상을 사용할 수 있는 영역에서 색상 이름 앞에 `colors/` 접두사를 사용하여 참조할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "레이아웃 콘텐츠",
+      "description": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
+      "markdownDescription": "이 속성은 레이아웃의 실제 콘텐츠를 정의합니다. 레이아웃의 콘텐츠는 `lower`와 같이 표시되어야 하는 디스플레이 위치에 따라 컨테이너로 구성됩니다. `left` 및 `right` 영역은 플레이어의 엄지손가락 아래 중앙에 위치하도록 되어 있고 플레이어가 자신의 장치와 선호하는 플레이 방식에 가장 잘 맞도록 이동하고 사용자 정의할 수 있기 때문에 특별한 위치입니다. 버튼과 같은 각 컨테이너 컨트롤 내에서 명명된 속성 또는 하위 배열을 기반으로 하위 컨테이너에 직접 지정하거나 배치할 수 있습니다.",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "터치 레이아웃 컨트롤 휠",
+      "description": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
+      "markdownDescription": "원 또는 바퀴 모양으로 구성된 컨트롤 세트입니다. 이러한 휠 컨트롤은 기본적으로 레이아웃 콘텐츠에서 `right` 또는 `left` 속성이 사용되었는지 여부에 따라 화면의 오른쪽 또는 왼쪽에 있는 플레이어의 엄지손가락 아래에 배치됩니다. 휠은 내부 제어 그룹과 외부 제어 링으로 구성됩니다.",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[사용되지 않음] 레이아웃 방향",
+      "description": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
+      "markdownDescription": "⚠️ 사용되지 않음: 이 속성은 더 이상 지원되지 않습니다. 해당 값이 무시되고 모든 레이아웃에서 `landscape` 해당 값을 사용합니다.",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "하위 레이아웃 배열 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 영역의 하단 중앙에서 바깥쪽으로 확장되는 배열인 레이아웃의 내용을 정의합니다. 이 속성은 이 속성 아래에 있는 레이어에서 컨트롤을 숨기는 데 `blank` 컨트롤을 사용할 수 있다는 점을 제외하면 레이아웃 콘텐츠의 동일한 명명된 속성과 동일하게 작동합니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "하위 레이아웃 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 아래쪽 가장자리에 고정되는 레이아웃의 콘텐츠를 정의합니다. 아래쪽 가장자리를 따라 있는 콘텐츠는 중앙에 배치되고 왼쪽 및 오른쪽 가장자리를 향해 바깥쪽으로 커집니다. 이 콘텐츠는 디스플레이 중앙에 있기 때문에 더 큰 장치에서는 도달하기 어려울 수 있습니다. 따라서 카메라 모드 전환이나 다른 모드 전환과 같이 자주 사용하지 않는 컨트롤을 이 공간에 배치하는 것이 좋습니다.",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "센서 레이아웃 콘텐츠",
+      "description": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
+      "markdownDescription": "이 속성은 장치의 센서 입력을 상호 작용으로 사용하는 레이아웃 콘텐츠의 컨테이너를 정의합니다.",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "레이아웃 스타일",
+      "description": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
+      "markdownDescription": "이 속성은 스타일 지정을 위해 레이아웃 전체에서 참조할 수 있는 재사용 가능한 스타일을 정의합니다. 컨텍스트 파일에 동일한 `styles` 속성이 정의되어 있으면 각 속성의 내용이 병합됩니다. 중복 정의가 발견되면 레이아웃의 정의가 우선하며 컨텍스트 파일에서 정의를 덮어씁니다.",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "상위 레이아웃 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 위쪽 가장자리에 고정되는 레이아웃 콘텐츠를 정의합니다. 현재 왼쪽 상단은 시스템 빠른 액세스 메뉴용으로 예약되어 있으므로 오른쪽 상단 공간만 컨트롤을 추가할 수 있습니다. 오른쪽 상단의 콘텐츠는 더 큰 장치에서 쉽게 액세스할 수 없기 때문에 이 공간은 일시 중지 메뉴를 끌어오거나 영화 장면을 건너뛰는 것과 같이 게임 플레이 도중이 아닌 간헐적으로만 액세스해야 하는 컨트롤에 가장 적합합니다.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "오른쪽 상단 레이아웃 콘텐츠",
+      "description": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
+      "markdownDescription": "이 속성은 사용 가능한 표시 공간의 오른쪽 상단 모서리에 고정되는 레이아웃 콘텐츠를 정의합니다. 이 컨테이너에 추가된 컨트롤은 모서리에서 시작하여 화면 상단 중앙을 향해 안쪽으로 커집니다.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "불투명",
+      "description": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
+      "markdownDescription": "이 속성은 컨트롤 구성 요소의 투명도를 변경합니다. 생략하면 컨트롤이 완전히 불투명하다는 의미인 기본값 1이 사용됩니다.",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "밖의",
+      "description": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 이 링 내의 항목은 휠의 위쪽에서 시계 방향으로 정렬됩니다. 각 인덱스는 단일 컨트롤 또는 컨트롤 배열일 수 있습니다. 배열을 지정하면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중심에서 더 멀리 확장될 수 있습니다. 총 외부 휠에는 개별 컨트롤 8개 또는 컨트롤 그룹 4개에 대한 공간이 있습니다. 이 범위를 벗어나는 모든 컨트롤이 제거되거나 유효성 검사 규칙 오류가 발생할 수 있습니다. 'null' 컨트롤은 외부 휠 배열의 시작 부분에 사용하여 컨트롤 그룹을 오프셋할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
+      "markdownDescription": "휠의 외부 링에 있는 컨트롤 또는 컨트롤 그룹의 외부 링을 정의합니다. 이 링 내의 항목은 휠의 위쪽에서 시계 방향으로 정렬됩니다. 각 인덱스는 단일 컨트롤 또는 컨트롤 배열일 수 있습니다. 배열을 지정하면 이 컨트롤 그룹은 상호 작용 공간을 두 배로 늘리고 추가된 컨트롤은 휠 중심에서 더 멀리 확장될 수 있습니다. 총 외부 휠에는 개별 컨트롤 8개 또는 컨트롤 그룹 4개에 대한 공간이 있습니다. 이 범위를 벗어나는 모든 컨트롤이 제거되거나 유효성 검사 규칙 오류가 발생할 수 있습니다. 'null' 컨트롤은 외부 휠 배열의 시작 부분에 사용하여 컨트롤 그룹을 오프셋할 수 있습니다. 이 작업이 완료되면 최종 개별 컨트롤을 추가할 수 있습니다.",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "밖의",
+      "description": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
+      "markdownDescription": "휠에서 레이어 컨트롤 및 레이어 컨트롤 그룹의 외부 링을 정의합니다. 이 속성은 그 아래에 있는 레이어에서 컨트롤을 숨기기 위해 `blank` 컨트롤을 추가로 허용한다는 점을 제외하고 동일한 명명된 레이아웃 속성과 동일하게 작동합니다. 아래 레이어의 컨트롤 또는 컨트롤 그룹에 이 레이어의 해당 인덱스와 다른 항목 수가 있는 경우 해당 레이어의 모든 항목이 숨겨집니다. 기본 레이아웃 휠과 마찬가지로 `null`을 사용하여 컨트롤 또는 컨트롤 그룹을 건너뛸 수 있습니다.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterWheelControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "컨트롤 끌어오기 동작",
+      "description": "이 속성을 사용하면 단일 작업, 한 번에 작업 배열 또는 컨트롤이 `pulled` 상태일 때 정의된 여러 동작 중 하나를 수행할 수 있습니다. 이러한 작업은 게임 패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다. 이 속성이 `segmented` 형식이 있는 개체로 정의되면 끌어오기 작업 링이 컨트롤의 위쪽에서 시작하여 시계 방향으로 진행되는 등분으로 나뉩니다. 컨트롤을 끌어오는 위치의 정확한 위치에 따라 단일 세그먼트가 `pulled` 상태가 됩니다.",
+      "markdownDescription": "이 속성을 사용하면 단일 작업, 한 번에 작업 배열 또는 컨트롤이 `pulled` 상태일 때 정의된 여러 동작 중 하나를 수행할 수 있습니다. 이러한 작업은 게임 패드 입력 또는 레이아웃에 새 레이어 표시와 같은 더 복잡한 작업에 매핑할 수 있습니다. 이 속성이 `segmented` 형식이 있는 개체로 정의되면 끌어오기 작업 링이 컨트롤의 위쪽에서 시작하여 시계 방향으로 진행되는 등분으로 나뉩니다. 컨트롤을 끌어오는 위치의 정확한 위치에 따라 단일 세그먼트가 `pulled` 상태가 됩니다.",
+      "anyOf": [
+        {
+          "properties": {
+             "type":  { 
+              "const": "segmented",
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/_ActionTypeBase"
+              },
+              "maxItems": 4,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/_ActionTypeBase"
+        }
+      ]
+    },
+    "PullIndicator": {
+      "title": "끌어오기 표시기 스타일 구성 요소",
+      "description": "컨트롤을 현재 끌어오는 표시기의 시각적 스타일입니다. 배열을 사용하는 경우 끌어오기 표시기의 형식은 '분할된' 끌어오기 표시기여야 합니다. 이 경우 각 배열 요소는 해당 세그먼트의 스타일에 해당합니다.",
+      "markdownDescription": "컨트롤을 현재 끌어오는 표시기의 시각적 스타일입니다. 배열을 사용하는 경우 끌어오기 표시기의 형식은 '분할된' 끌어오기 표시기여야 합니다. 이 경우 각 배열 요소는 해당 세그먼트의 스타일에 해당합니다.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        [
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          null,
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          }
+        ],
+        [
+          {
+            "opacity": 0
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PullIndicatorSegment"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        }
+      ]
+    },
+    "PullIndicatorSegment": {
+      "title": "끌어오기 표시기 세그먼트 스타일 구성 요소",
+      "description": "컨트롤이 현재 이 세그먼트 방향으로 끌어오는 표시기의 시각적 스타일입니다. 컨트롤을 풀하는 의미 체계와 해당 작업 의미 체계를 나타내는 사용자 지정 얼굴 이미지를 나타내도록 이 색을 사용자 지정할 수 있습니다. 기본적으로 끌어오기 작업에 매핑된 단일 게임 패드 동작에는 해당 게임 패드 함수가 얼굴 이미지로 표시됩니다.",
+      "markdownDescription": "컨트롤이 현재 이 세그먼트 방향으로 끌어오는 표시기의 시각적 스타일입니다. 컨트롤을 풀하는 의미 체계와 해당 작업 의미 체계를 나타내는 사용자 지정 얼굴 이미지를 나타내도록 이 색을 사용자 지정할 수 있습니다. 기본적으로 끌어오기 작업에 매핑된 단일 게임 패드 동작에는 해당 게임 패드 함수가 얼굴 이미지로 표시됩니다.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "배경 스타일 구성 요소",
+      "description": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+      "markdownDescription": "배경의 스타일을 지정하는 데 사용되는 색입니다. 색이 사용되는 정확한 셰이프는 구성 요소에 따라 달라지며 사용자 지정할 수 없습니다.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "상대적인",
+      "description": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
+      "markdownDescription": "이 속성은 컨트롤과의 상호 작용을 계산하는 방법을 결정합니다. 상호 작용은 상호 작용이 시작된 위치를 기준으로 계산되거나 컨트롤의 중심을 사용하여 절대 방식으로 계산됩니다. 생략하면 `true` 기본값이 상호 작용의 시작점을 기준으로 계산하는 데 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "버튼으로 렌더링",
+      "description": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
+      "markdownDescription": "이 속성을 사용하면 컨트롤이 단추로 시각적으로 표시됩니다. 생략하면 `false` 기본값이 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "규모",
+      "description": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "markdownDescription": "컨트롤 크기를 변경하는 데 사용되는 승수 값입니다. 이 값은 0.5에서 2 사이여야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "민감도",
+      "description": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "markdownDescription": "컨트롤의 민감도를 변경하는 데 사용되는 승수 값입니다. 이 값은 0보다 커야 합니다. 생략하면 기본값 1이 사용됩니다.",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "센서 제어",
+      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. 특정 컨트롤 유형 및 목적에 대한 정보는 `type` 속성을 참조하세요.",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "레이어 센서 제어",
+      "description": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "markdownDescription": "장치의 사용 가능한 센서에서 상호 작용을 가져와 출력으로 변환하는 보이지 않는 개별 컨트롤입니다. `blank` 컨트롤은 이 레이어 아래의 레이어에서 센서 컨트롤을 숨기거나 끄는 데 사용할 수 있습니다.",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "접착식",
+      "description": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
+      "markdownDescription": "플레이어가 컨트롤과의 상호 작용을 중지하면 컨트롤이 다시 중립 위치로 돌아가면 이 속성이 변경됩니다. 설정된 경우에도 `axisDown` 영역에 고정 스로틀이 남아 있지 않습니다. 예를 들어 크루즈 컨트롤 스타일 기능을 구현하는 데 사용할 수 있습니다. 생략하면 기본값 `false`가 사용됩니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "획 스타일 지정 구성 요소",
+      "description": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
+      "markdownDescription": "컨트롤 구성 요소의 스트로크에 대한 시각적 스타일입니다. 스트로크는 일반적으로 제어 구성 요소의 범위를 표시하는 데 사용되는 테두리 또는 윤곽선입니다.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "스로틀 축",
+      "description": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+      "markdownDescription": "이 속성은 컨트롤과 플레이어의 상호 작용에서 중간 지점에서 지정된 출력까지 위 또는 아래로 단일 매핑을 정의합니다.",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "스로틀 축 스타일링 구성 요소",
+      "description": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+      "markdownDescription": "스로틀 축 구성 요소의 시각적 스타일입니다. 이 구성 요소는 플레이어에게 가능한 입력 범위와 컨트롤이 현재 있는 영역(위 또는 아래)을 표시합니다.",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "컨트롤 활성화 업 스타일",
+              "description": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "markdownDescription": "컨트롤이 `activatedUp` 상태일 때 사용되는 스타일 재정의입니다. `activatedUp` 상태는 특히 컨트롤 중앙 위의 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "컨트롤 활성화 다운 스타일",
+              "description": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "markdownDescription": "컨트롤이 `activatedDown` 상태일 때 사용되는 스타일 재정의입니다. `activatedDown` 상태는 특히 컨트롤 중앙 아래 영역에서 컨트롤이 상호 작용할 때입니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "컨트롤 비활성화 스타일",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
+              "markdownDescription": "컨트롤이 `idleUp` 상태일 때 사용되는 스타일 재정의입니다. `idleUp` 상태는 컨트롤이 상호 작용되고 있지 않지만 컨트롤의 값이 컨트롤 중심 위의 영역에 유지되는 경우입니다. 컨트롤이 `sticky` 경우에만 이 상태에 도달할 수 있습니다.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "토글",
+      "description": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
+      "markdownDescription": "이 속성은 컨트롤을 토글 컨트롤로 변경합니다. 더 이상 상호 작용하지 않을 때 `idle` 상태로 돌아가는 대신 컨트롤이 해당 작업이 계속 실행되는 `toggled` 상태로 전환됩니다. 플레이어가 컨트롤과 다시 상호 작용하면 전환이 해제되고 `idle` 상태로 돌아갑니다.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "컨트롤 스타일",
+      "description": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "markdownDescription": "컨트롤의 시각적 스타일 정의입니다. 컨트롤의 각 상태에 대해 스타일을 재정의할 수 있습니다. 특정 상태에서 사용자 지정되지 않은 요소의 경우 `default` 스타일 지정 속성 또는 시스템 기본값이 컨트롤 스타일을 지정하는 기준으로 사용됩니다. 시스템은 예를 들어 `disabled` 상태에서 불투명도를 줄임으로써 특정 상태에서 적절하게 `default` 스타일에서 컨트롤의 시각적 개체를 여전히 수정할 수 있습니다.",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "컨트롤 활성화 스타일",
+              "description": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "markdownDescription": "컨트롤이 `activated` 상태일 때 사용되는 스타일 재정의입니다. `activated` 상태는 컨트롤이 상호 작용되고 해당 작업이 실행되고 있는 때입니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "제어 기본 스타일",
+              "description": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "markdownDescription": "컨트롤에 적용할 기본 스타일 지정 매개 변수입니다. 이러한 매개 변수는 시스템에서 컨트롤에 대해 제공한 기본 스타일을 재정의하는 데 사용됩니다. 특정 상태에 대한 스타일을 지정하여 시각적 개체를 더 재정의할 수 있습니다. 특정 상태(예: `disabled`)에서는 특정 스타일이 제공되지 않은 경우 기본 스타일이 대체로 사용되지만 컨트롤을 사용할 수 없음을 나타내기 위해 전체 불투명도가 감소하는 등 해당 상태에 대해 일부 변경이 발생할 수 있습니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "컨트롤 비활성화 스타일",
+              "description": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "markdownDescription": "컨트롤이 `disabled` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서는 플레이어가 컨트롤과 상호 작용할 때 출력이 계속 실행되더라도 컨트롤이 시각적으로 비활성화됩니다. 여기서 명시적으로 재정의하지 않는 한 `default` 스타일 구성에 제공된 값은 감소된 전체 컨트롤 불투명도와 함께 사용되며 컨트롤이 비활성화되었음을 표시하기 위해 모든 상호 작용 표시기가 숨겨집니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "유휴 스타일 제어",
+              "description": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "markdownDescription": "컨트롤이 `idle` 상태일 때 사용되는 스타일 재정의입니다. 이 상태에서 컨트롤은 상호 작용하지 않으며 중립 또는 휴지 상태로 간주됩니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "제어 이동 스타일",
+              "description": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+              "markdownDescription": "컨트롤이 `moving` 상태일 때 사용되는 스타일 재정의입니다. `moving` 상태는 컨트롤이 상호작용 중이지만 해당 동작이 아직 실행되지 않은 상태입니다. 상호 작용의 방향을 나타내기 위해 이 상태에서 추가 스타일 요소를 사용할 수 있습니다.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "간격",
+      "description": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
+      "markdownDescription": "이 속성은 전체 작업이 실행되는 동안 할당된 하위 작업이 켜지고 꺼지는 정기적인 간격 또는 기간(밀리초)을 정의합니다.",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "type": "object"
+}

--- a/touch-adaptation-kit/schemas/layout/v4.1/layout.json
+++ b/touch-adaptation-kit/schemas/layout/v4.1/layout.json
@@ -1,0 +1,5525 @@
+{
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.1/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "additionalProperties": false,
+  "title": "Touch Adaptation Bundle Layout Schema",
+  "description": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+  "markdownDescription": "A touch adaptation bundle layout represents a game scenario and all of the controls needed to allow mobile or touch game-play. For the latest information on the changes between layout versions, see https://github.com/microsoft/xbox-game-streaming-tools/releases.",
+  "$defs": {
+    "LayoutDefinableType": {
+      "title": "Definable Types",
+      "description": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "markdownDescription": "Union type that includes all types which can be used in the `definitions` section of this file. See the `definitions` section for more information",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        {
+          "$ref": "#/$defs/ActionType"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/AssetReference"
+        },
+        {
+          "$ref": "#/$defs/AxisCap"
+        },
+        {
+          "$ref": "#/$defs/AxisCapColor"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        {
+          "$ref": "#/$defs/Background"
+        },
+        {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/ButtonActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonToggledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonPulledStyle"
+        },
+        {
+          "$ref": "#/$defs/Color"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteDefaultVariant"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+        },
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/ControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneRadial"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneThreshold"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        {
+          "$ref": "#/$defs/FaceImage"
+        },
+        {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        {
+          "$ref": "#/$defs/FillColor"
+        },
+        {
+          "$ref": "#/$defs/Gradient"
+        },
+        {
+          "$ref": "#/$defs/Indicator"
+        },
+        {
+          "$ref": "#/$defs/InnerLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InnerLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InputCurveRange"
+        },
+        {
+          "$ref": "#/$defs/InputCurve"
+        },
+        {
+          "$ref": "#/$defs/InputCurveType"
+        },
+        {
+          "$ref": "#/$defs/JoystickActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDirectionIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickMovingStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        {
+          "$ref": "#/$defs/Knob"
+        },
+        {
+          "$ref": "#/$defs/Layer"
+        },
+        {
+          "$ref": "#/$defs/Layers"
+        },
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/LayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayerSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayoutColors"
+        },
+        {
+          "$ref": "#/$defs/LayoutOrientation"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Opacity"
+        },
+        {
+          "$ref": "#/$defs/OuterLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelControlGroup"
+        },
+        {
+          "$ref": "#/$defs/OuterLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelLayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/PullActionType"
+        },
+        {
+          "$ref": "#/$defs/PullIndicator"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        },
+        {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        {
+          "$ref": "#/$defs/Scale"
+        },
+        {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        {
+          "$ref": "#/$defs/SensorControl"
+        },
+        {
+          "$ref": "#/$defs/Sticky"
+        },
+        {
+          "$ref": "#/$defs/Stroke"
+        },
+        {
+          "$ref": "#/$defs/LayoutStyles"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisStyle"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        {
+          "$ref": "#/$defs/Toggle"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyleBase"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyles"
+        }
+      ]
+    },
+    "Definitions": {
+      "title": "Definitions",
+      "description": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "markdownDescription": "A section that can be used to contain reusable components and values for touch layouts. These definitions can be later referenced with a JSON reference like `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }`. JSON references are supported for nearly every part of the layout schema enabling common elements, like a common button background used across several controls, to be factored out and reused. Note that the context file also supports the `definitions` property, as well as `state`, to reuse components across layouts.",
+      "examples": [
+        {},
+        {
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
+    },
+    "Reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
+          "markdownDescription": "Reference to a value defined locally or in a nearby file like the context file. See the `definitions` layout property for more information.",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "Null",
+      "description": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
+      "markdownDescription": "This is a special value that can be used in place of a control to skip a location. This is useful especially in arrays of controls and on layers to pad out the placement of content.",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "Accelerometer Control Type",
+          "description": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
+          "markdownDescription": "An accelerometer control. This control allows translations from a device's motion, specifically its acceleration, into game input.",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
+      "examples": [
+        {
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "Heavy Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "Heavy Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "Light Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "Light Punch Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "Medium Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "Medium Punch Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "Special Kick Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "Special Punch Button",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "Two Dimensional Axis Mapping Item",
+      "description": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "markdownDescription": "This property defines a single mapping from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "Three Dimensional Axis Mapping Item",
+      "description": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "markdownDescription": "This property defines a single mapping from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "A custom asset used to style the background.",
+          "markdownDescription": "A custom asset used to style the background.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+          "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Blank Control Type",
+          "description": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
+          "markdownDescription": "When creating a layout that uses layers, a blank control type is used to override or hide an existing control or group of controls on the layers underneath it. The blank control is not interactable and does not have any stylable components.",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "Gamepad Analog Joystick Output",
+      "description": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
+      "markdownDescription": "Outputs values from 0 to the maximum value along the specified gamepad joystick axis. When used as an `action` as opposed to an `output`, only the maximum value is used.",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "Gamepad Analog Joystick Output",
+      "description": "Outputs values along the entirety of the specified gamepad joystick axis.",
+      "markdownDescription": "Outputs values along the entirety of the specified gamepad joystick axis.",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "Gamepad Analog Joystick Output",
+      "description": "Outputs values along the entirety of both gamepad joystick axes.",
+      "markdownDescription": "Outputs values along the entirety of both gamepad joystick axes.",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "Gamepad Button Output",
+      "description": "Outputs a gamepad button press.",
+      "markdownDescription": "Outputs a gamepad button press.",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "Gamepad Analog Trigger Output",
+      "description": "Outputs values that map to the specified gamepad trigger.",
+      "markdownDescription": "Outputs values that map to the specified gamepad trigger.",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "Arcade Buttons Control Type",
+      "description": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
+      "markdownDescription": "An arcade buttons control. This control is a group of buttons arranged based on common 6 or 8 button arcade cabinet arrangements. This is commonly used with fighting style games. Touching between buttons allows the player to press multiple buttons at once. Touching above or below a row of buttons will activate all buttons in that row simultaneously, making it easier to perform combos.",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "Button Control Type",
+      "description": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
+      "markdownDescription": "A button control is a simple control type that allows an action to be performed while the control is being pressed. To allow for some advanced functionality, an additional action, known as the pull action, can be assigned when the interaction moves beyond the extent of the control. This is useful in situations where a second, simultaneous action is needed in coordination with the main action of the control like aiming while shooting.",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "Directional Pad Control Type",
+      "description": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
+      "markdownDescription": "A directional pad control mimics the standard 4-way or 8-way control found on physical gamepads. This control is especially useful in 2D platformer and fighting games where precise directions are needed to perform certain actions. To choose between the 4-way or 8-way style control, refer to the `interaction` property.",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "Joystick Control Type",
+      "description": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
+      "markdownDescription": "A joystick control that mimics an analog joystick from a physical controller. It allows the player to move the control in either two dimensional or one dimensional space based on the `axis` property. In addition, it allows simultaneous actions to be performed along with the movement by using the `action` and `actionThreshold` properties. This control is often used for player locomotion or camera control, and it is common for touch layouts to include several joysticks for any actions that can be performed while moving or looking around like aiming or shooting.",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "Throttle Control Type",
+      "description": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
+      "markdownDescription": "A throttle control that mimics a physical throttle in a boat, car, or airplane. This control has a knob that a player can interact with to move the throttle either up or down. This control is most useful for driving or flying games where the gas often needs to be held down at all times. When styling the control, separate `activatedUp`, `activatedDown`, and `idleUp` states allow precise customization to show when a player is using gas, brakes, etc.",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "Touchpad Control Type",
+      "description": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
+      "markdownDescription": "A touchpad control that mimics a physical touchpad found on a laptop computer. This control is best used for mouse or joystick style movements, like camera control, and allows a player precise control through swipes and drags. In addition, an `action` can be assigned to the control and it can be rendered as a button with `renderAsButton` in order to create a control that combines movement or camera with a common action like aiming or jumping.",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "Custom Layout Color",
+      "description": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a reusable color that can be referenced elsewhere. This color can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Face Image Asset Styling Component",
+          "description": "A custom asset used as the foreground graphic for the control component.",
+          "markdownDescription": "A custom asset used as the foreground graphic for the control component.",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Face Image Icon Styling Component",
+          "description": "A built-in icon used as the foreground graphic for the control component.",
+          "markdownDescription": "A built-in icon used as the foreground graphic for the control component.",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "Gyroscope Control Type",
+          "description": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
+          "markdownDescription": "A gyroscope control. This control allows a translation from a device's motion, in particular rotations about its axes, into game input. This control can be especially useful for controlling the player's camera since real world rotations naturally can rotate the perspective of the game.",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "Axis Magnitudinal Input Mapping",
+      "description": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
+      "markdownDescription": "Uses only the magnitude of the input along the specified axis direction (up, down, left or right) to translate to the specified output. For instance, a value of `axisLeft` will be mapped from 0 to 1 according to how far left from the control origin the input currently is. Since this a magnitude based value, no negative outputs are possible.",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X Axis Input Mapping",
+          "description": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "markdownDescription": "Uses interactions along the X axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y Axis Input Mapping",
+          "description": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "markdownDescription": "Uses interactions along the Y axis of the control, positive in the positive and negative direction, to translate to the specified output. See the `output` property for more information on this mapping.",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X and Y Axis Input Mapping",
+      "description": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "markdownDescription": "Uses interactions in the X and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z and Y Axis Input Mapping",
+      "description": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "markdownDescription": "Uses interactions in the Z and Y axis of the control to translate to the specified output. See the `output` property for more information on this mapping.",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
+          "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "Layout Action",
+      "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+      "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "Layout Action",
+          "description": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+          "markdownDescription": "Action type that triggers a layout change like applying a layer while the action is being executed.",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
+            },
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_RelativeMouse1DOutputType": {
+      "title": "Relative Mouse One Dimensional Output",
+      "description": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
+      "markdownDescription": "This output type takes one dimensional control inputs and translates them to relative mouse movements along a single axis.",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
+      ],
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "Relative Mouse Two Dimensional Output",
+      "description": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
+      "markdownDescription": "This output type takes two dimensional control inputs and translates them to relative mouse movements.",
+      "const": "relativeMouse",
+      "type": "string"
+    },
+    "_RelativeMouseMagnitudinalOutputType": {
+      "title": "Relative Mouse Directional Output",
+      "description": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
+      "markdownDescription": "This output type takes the magnitude of a control input along a specified input axis and maps it to relative mouse movements in a single direction. For instance, if a joystick's X axis movement was mapped to relative mouse X axis output, a series of positive X direction mouse movements will be sent as long as the joystick is held to the right.",
+      "enum": [
+        "relativeMouseUp",
+        "relativeMouseDown",
+        "relativeMouseLeft",
+        "relativeMouseRight"
+      ],
+      "type": "string"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_StrokeBase": {
+      "examples": [
+        {
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "This styling component is used to specify a solid stroke with customizable color and opacity.",
+              "markdownDescription": "This styling component is used to specify a solid stroke with customizable color and opacity.",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "title": "Content Primary System Color Override",
+      "description": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
+      "markdownDescription": "This property overrides the primary system color used for styling components such as middle strokes, icon tints, and dpad gradients.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "Content Secondary System Color Override",
+      "description": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
+      "markdownDescription": "This property overrides the secondary system color used for styling components such as backgrounds and fills.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "Contrast Primary System Color Override",
+      "description": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
+      "markdownDescription": "This property overrides the contrast primary system color used for styling contrast components such as inner/outer strokes and face image backplates.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "Contrast Secondary System Color Override",
+      "description": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
+      "markdownDescription": "This property overrides the contrast secondary system color used for styling contrast components such as touchpad strokes.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "Action System Color Override",
+      "description": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
+      "markdownDescription": "This property overrides the corresponding action system color used for styling components on controls where the `action` field is set to a non-gamepad action.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "Gamepad Action System Color Override",
+      "description": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
+      "markdownDescription": "This property overrides the corresponding gamepad action system color used for styling components on controls where the `action` field is set to `gamepadA`, `gamepadB`, `gamepadX`, or `gamepadY`.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "Accent Primary System Color Override",
+      "description": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
+      "markdownDescription": "This property overrides the accent primary system color used for styling components such as the ergo-edit inner wheel.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "Accent Secondary System Color Override",
+      "description": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
+      "markdownDescription": "This property overrides the accent secondary system color used for styling components such as the ergo-edit outer wheel.",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
+      "examples": [
+        {
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "Turbo Action",
+      "description": "Action that triggers on and off based on an interval instead of continuously.",
+      "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "Turbo Action",
+          "description": "Action that triggers on and off based on an interval instead of continuously.",
+          "markdownDescription": "Action that triggers on and off based on an interval instead of continuously.",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "Action Threshold",
+      "description": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+      "markdownDescription": "This property defines the radial, normalized input value required to trigger the control's action. When this value is reached, the control will execute its action and transition from the `moving` state to the `activated` state. If omitted, a default value of 0 is used meaning that any control interaction will immediately execute the assigned action.",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionType": {
+      "title": "Control Action",
+      "description": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "markdownDescription": "This property allows either a single action or an array of actions to be performed by the control when it is in the `activated` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout.",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "ArcadeButton": {
+      "description": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
+      "markdownDescription": "A single button on the `arcadeButtons` control type. This button is a simplified version of the `button` control type to work well in the arcade button arrangement.",
+      "examples": [
+        {
+          "action": "gamepadX",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "lightPunch"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonFightingButtons"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "$ref": "#/$defs/ActionType"
+            },
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
+            },
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
+            }
+          },
+          "required": [
+            "action"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyleBase": {
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "Control Disabled Style",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "Asset Reference Styling Component",
+      "description": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
+      "markdownDescription": "An asset reference is an identifier for a custom asset bundled with the touch layouts. To refer to an entire file, use the file name of the image without the file extension. For a sprite sheet asset, use the texture file name without the extension followed by a `/` and the sprite name within the sprite atlas. Note that in order to handle devices with different screen resolutions, it is expected that files for each DPI (1.0x, 1.5x, 2.0x, 3.0x, 4.0x) are provided. Depending on which control and component the asset is being used for, the maximum 1.0x resolution may be different though 60x60 and 120x120 are the most common allowed maximums. All other DPI resolutions should be a multiple of the 1.0x asset's resolution.",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "Axis Cap Styling Component",
+      "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+      "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "Axis Cap Styling Component",
+              "description": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+              "markdownDescription": "The visual styling used to depict the limit of an axis control component. This can be styled with a color to semantically indicate the maximum or minimum value of the axis.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "Two Dimensional Axis Mapping",
+      "description": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "markdownDescription": "This property defines the mapping or set of mappings from a player's two dimensional analog interactions with the control into either one or two dimensions outputs. Note that based on the axis assignments, the look and feel of the control may change.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "Three Dimensional Axis Mapping",
+      "description": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "markdownDescription": "This property defines the mapping or set of mappings from a player's three dimensional analog interactions with the control into either a one or two dimensional outputs. For three dimensional interactions, like with device sensors, the coordinate space is always relative to the game's video. In other words, it is such that the positive X direction is to the right of the video, the positive Y direction is to the top of the video and the positive Z direction is out of the video towards the player.",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "Background Styling Component",
+      "description": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+      "markdownDescription": "The visual styling of the background of the control component. The background can be a `color` or `asset`.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "Control Activated Style",
+      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "Control Default Style",
+      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "Control Disabled Style",
+      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "Control Idle Style",
+      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
+      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent background and pull indicator to show the control is idle and not being interacted with.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "Control Toggled Style",
+      "description": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
+      "markdownDescription": "Styling overrides used when the control is in the `toggled` state. The `toggled` state is when the control is not being interacted with but its action is being executed since it is currently toggled.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "Control Pulled Style",
+      "description": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+      "markdownDescription": "Styling overrides used when the control is in the `pulled` state. The `pulled` state is when the control is being interacted with and used beyond the extents of the control causing additional actions to be executed.",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "Color",
+      "description": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "markdownDescription": "This property defines a color using a string representation. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "Default Colors",
+      "description": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined in a specific variant or no specific variant is active, the corresponding color references will fallback to the colors defined here. If a given system color override is not specified, the color reference will fallback to the system's default colors. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "High Contrast Colors",
+      "description": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a collection of reusable colors that can be referenced elsewhere when High Contrast mode is enabled. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. For any colors that are not defined here or when High Contrast mode is disabled, the corresponding color references will fallback to the colors defined in `default`. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "Touch Layout Control",
+      "description": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
+      "markdownDescription": "An individual control that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "Enabled",
+      "description": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
+      "markdownDescription": "Property that determines if a control is in the `disabled` state or not. This property is most useful when used with context file `state` to allow controls to be dynamically enabled and disabled based on game state. If omitted, a default value of `true` is used. When disabled, the control is visible and still forwards along output but has no appearance of being active. Note that this behavior is only true for controls that have an appearance and are rendered on screen. Sensor controls do not forward output when in the disabled state, as they have no appearance.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "Touch Layout Control Group",
+      "description": "A set of 1 to 4 controls arranged in a group. Items within this group are arranged by the system, typically proceeding clockwise from the top of the available area. A group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
+      "markdownDescription": "A set of 1 to 4 controls arranged in a group. Items within this group are arranged by the system, typically proceeding clockwise from the top of the available area. A group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip a control in the arrangement.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "Touch Layout Control Group Item",
+      "description": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+      "markdownDescription": "A single item in the control group. Use `null` to skip a control in the arrangement.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "Gamepad Action",
+      "description": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
+      "markdownDescription": "This property allows either a single gamepad action or an array of gamepad actions to be performed by the control when it is in the `activated` state.",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "Visible",
+      "description": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+      "markdownDescription": "Determines if the control is shown or not. This property is most useful when used with context file `state` to allow controls to be dynamically shown and hidden based on game state. If omitted, a default value of `true` is used. When not visible, a control cannot be activated and does not execute any actions even if a player is touching where the control would otherwise be shown.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "One Dimensional Deadzone",
+      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
+      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If omitted, no deadzone is used.",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "Two Dimensional Deadzone",
+      "description": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
+      "markdownDescription": "The normalized, minimum output value produced by the control. This is useful to counteract a deadzone programmed into the game. If `radial` is set to true, the deadzone is calculated one dimensionally along the radial component. Otherwise, each axis is computed individually using the threshold value. If omitted, no deadzone is used.",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "Directional Pad Deadzone",
+      "description": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
+      "markdownDescription": "Normalized radius of the directional pad region that will ignore inputs. This is useful to avoid unwanted changes in direction near the center of the directional pad where small input changes could drastically change the direction being activated. If omitted, a value of 0.25 is used. Note that changes to this value will change the way the directional pad is rendered to give an indication to the player of this size.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "Threshold",
+      "description": "The normalized, input value needed in order to produce output values.",
+      "markdownDescription": "The normalized, input value needed in order to produce output values.",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "Radial",
+      "description": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
+      "markdownDescription": "Whether or not the deadzone threshold is calculated along the radial input component or against each axis individually.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "Interaction",
+      "description": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
+      "markdownDescription": "This property determines how the control can be interacted with by the player. See the `activationType` property for more information.",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteractionActivationType": {
+      "title": "Activation Type",
+      "description": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
+      "markdownDescription": "This property determines how the control and its subcomponents are activated in response to player interaction. The activation type can either be `exclusive` or `allowNeighboring`. When set to `exclusive`, only a single subcomponent of the control will be activated at a time. If `allowNeighboring` is set, multiple subcomponents of the control can be simultaneously activated based on where the player is interacting with the control. If omitted, a default value of `allowNeighboring` is used.",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is the neutral or resting state of the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a fully transparent gradient to show the control is idle and not being interacted with.",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "Expand",
+      "description": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
+      "markdownDescription": "This property determines if the control should expand its interactable area to fill the available space. This is especially useful for the `inner` wheel container where a player can customize the size of the area. When set to `false` the control is locked to its default or minimum interaction size. If omitted, a default value of `true` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "Face Image Styling Component",
+      "description": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+      "markdownDescription": "The visual styling that represents the foreground of the control component. This is typically used to show the semantic meaning of interacting with it. The face image can be an `icon` or `asset` type. Icons are built-in graphics that can express a wide variety of control actions while assets allow a control to use a custom image bundled with the layout.",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "Face Image Icon Label Styling Component",
+      "description": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
+      "markdownDescription": "This property determines how labels are shown on the face image icon. The `action` type is useful when using semantic imagery to remind players what the corresponding actions are in the case game prompts and imagery does not match the semantic icon perfectly. To hide these additional labels, the `none` type can be used. If omitted, a default value of `action` is used.",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "Face Image Icon",
+      "description": "This property is used to select which built-in icon to use for this component.",
+      "markdownDescription": "This property is used to select which built-in icon to use for this component.",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "Fill",
+      "description": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "markdownDescription": "This property changes the color with which to fill in the control component. If omitted, a mostly transparent white fill is used. Colors must be specified as a hexadecimal value following the `hex-color` CSS specification or by referencing a known system color or layout color by using a string starting with `colors/` followed by the name of the color. See https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color for more information.",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "Gradient",
+      "description": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
+      "markdownDescription": "A gradient is a blend from one color to another. Currently, the only gradients allowed are from fully transparent to the supplied color value.",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "Indicator Styling Component",
+      "description": "The visual styling for the stroke used to indicate the current value or placement of the control.",
+      "markdownDescription": "The visual styling for the stroke used to indicate the current value or placement of the control.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "Inner",
+      "description": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space, typically by starting at the top of space and proceeding clockwise. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
+      "markdownDescription": "A set of 1 to 4 controls arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space, typically by starting at the top of space and proceeding clockwise. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "Inner",
+      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space, typically by starting at the top of space and proceeding clockwise. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group on the inner segment of the control wheel. The system determines how to best arrange controls from the group within the available space, typically by starting at the top of space and proceeding clockwise. Note that the interaction area of the entire inner segment will be equally divided among the assigned controls. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveRange": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Input Curve Range",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the minimum and maximum values. All values are normalized so must be between -1 and 1.",
+      "examples": [
+        [
+          0,
+          0.33
+        ],
+        [
+          0,
+          1
+        ],
+        {
+          "$ref": "#/definitions/commonJoystickInputRange"
+        },
+        [
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMin"
+          },
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMax"
+          }
+        ]
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": -1,
+                "maximum": 1
+              },
+              {
+                "$ref": "#/$defs/Reference"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Input Response Curve",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines the curve or function of how inputs are mapped to output values. A type of `circular` or `circular-inverse` can be used to map inputs with a circular curve matching the shape of the lower right quadrant or upper left quadrant respectively. If this property is omitted, a default linear mapping is used.",
+      "examples": [
+        {
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
+        },
+        {
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Input Response Curve Type",
+      "description": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
+      "markdownDescription": "⚠️ Deprecated: This property may change behavior or be removed in future versions. This property defines which curve type to use. A type of `circular` can be used to map inputs with a circular curve matching the shape of the lower right quadrant of a circle. A value of `circular-inverse` can be used to map inputs with a circular curve matching the shape of the upper left quadrant of a circle.",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "Control Activated Style",
+      "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "Control Default Style",
+      "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "Direction Indicator Styling Component",
+      "description": "The visual styling for an indicator of the direction of the interaction",
+      "markdownDescription": "The visual styling for an indicator of the direction of the interaction",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "Property used to specify that the direction indicator is of color type whose value can be customized.",
+              "markdownDescription": "Property used to specify that the direction indicator is of color type whose value can be customized.",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "Control Disabled Style",
+      "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "Control Idle Style",
+      "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+      "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "Control Moving Style",
+      "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+      "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "Outline Styling Component",
+      "description": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+      "markdownDescription": "The visual styling for the outline of the control with an indicator for the direction of the interaction. This property in other states may not include the ability to style the indicator as the control is not being interacted with in those states.",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "Outline Styling Component",
+      "description": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
+      "markdownDescription": "The visual styling for the outline of the control. This property, in other states where the control is being interacted with, can additionally include the ability to style an indicator for the direction of the interaction.",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "Knob Styling Component",
+      "description": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
+      "markdownDescription": "The visual styling for the knob of the control. The knob is the interaction point of the control that mimics the top of a joystick for instance.",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "Touch Layout Layers",
+      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "Touch Layout Layers",
+      "description": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "markdownDescription": "This property allows the definition of custom control layers that can be used in a control `action` to overlay additional control or change the layout content in response to a player action on another control.",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "Touch Layout Layer Control",
+      "description": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
+      "markdownDescription": "An individual control in the current layer that a player can interact with to perform some translated action. Refer to the `type` property for information on the specific control types and their purpose. Layers add the special `blank` control type to hide any control from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "Touch Layout Layer Control Group",
+      "description": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "markdownDescription": "A set of 1 to 4 layer controls, including the `blank` control to hide controls from the layer(s) below, arranged in a group. The system determines how to best arrange controls from the group within the available space; a group with only one control is different than an ungrouped control as the group may include a larger total interaction area. Note that a special value of `null` can be used to skip an index. Also note that if a control group from a layer below has a different number of items than this control group, all items from that layer will be hidden.",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "Touch Layout Layer Control Group Item",
+      "description": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
+      "markdownDescription": "A single item in the layer control group. Use `null` to skip a control in the arrangement or `blank` to hide up the control from the layer(s) underneath.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "Touch Layout Layer Control Wheel",
+      "description": "A set of layer controls organized in a circle or wheel shape.",
+      "markdownDescription": "A set of layer controls organized in a circle or wheel shape.",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "Lower Layer Array Content",
+      "description": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines the content of the layer that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "Lower Layer Content",
+      "description": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines the content of the layer that is fixed to the bottom edge of the available display space. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "Sensors Layer Content",
+      "description": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines a container of layer content that uses the device's sensor inputs as interactions. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "Upper Layer Content",
+      "description": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines layer content that is fixed to the top edge of the available display space. This property mirrors the main layout's upper area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "Upper Layer Right Content",
+      "description": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines layer content that is fixed to the upper right corner of the available display space. This property mirrors the main layout's upper right area except that it allows the `blank` control type to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "Layout Action Target",
+      "description": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
+      "markdownDescription": "This property specifies what layer to apply when the action is executed. This name must appear in the `layers` property of the layout content.",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "Colors",
+      "description": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "markdownDescription": "This property defines a collection of color palettes composed of color definitions that can be referenced elsewhere. For each style variant, a color palette may be defined. For any colors that are not defined in a specific variant, the `default` color palette or system's defaults will be used. A color definition can be specific to the layout's content or override the system's default colors. System colors are prefixed with the reserved `system_` keyword. Colors can be referenced using the `colors/` prefix followed by the color name in areas where a color can be used for styling purposes.",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "Layout Content",
+      "description": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
+      "markdownDescription": "This property defines the actual content of the layout. Content on the layout is organized into containers based on where on the display, like `lower`, it should appear. The `left` and `right` areas are special locations because they are intended to be centered underneath the player's thumbs and can be moved and customized by the player to best fit their device and preferred way to play. Within each container controls, like a button, can either be directly specified or placed into sub-containers based on named properties or sub-arrays.",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "Touch Layout Control Wheel",
+      "description": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
+      "markdownDescription": "A set of controls organized in a circle or wheel shape. These wheel controls are by default placed under the player's thumbs on either the right or left of the screen based on if the `right` or `left` property is used in the layout content. The wheel is made up of an inner group of controls as well as an outer ring of controls.",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[DEPRECATED] Layout Orientation",
+      "description": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
+      "markdownDescription": "⚠️ Deprecated: This property is no longer supported. Its value is ignored and all layouts use the equivalent of `landscape`.",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "Lower Layout Array Content",
+      "description": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "markdownDescription": "This property defines the content of the layout that is an array growing outward from the bottom center of the available display area. This property operates identically to the same named property of the layout content except that this property additionally allows the `blank` control to be used to hide controls from the layer(s) underneath this one.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "Lower Layout Content",
+      "description": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
+      "markdownDescription": "This property defines the content of the layout that is fixed to the bottom edge of the available display space. Content along the lower edge is centered and grows outward towards the left and right edges. Because this content is in the center of the display, it can be difficult to reach for larger devices. As such, it is recommended to place less frequently used controls in this space like switching camera modes or other mode swaps.",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "Sensors Layout Content",
+      "description": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
+      "markdownDescription": "This property defines a container of layout content that uses the device's sensor inputs as interactions.",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "Layout Styles",
+      "description": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "markdownDescription": "This property defines reusable styles which can be referenced throughout the layout for styling purposes. If an equivalent `styles` property is defined in the context file, the contents of each will be merged. If a duplicate definition is found, the definition in the layout is preferred, overwriting the definition in the context file.",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "Upper Layout Content",
+      "description": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
+      "markdownDescription": "This property defines layout content that is fixed to the top edge of the available display space. Currently, only the top right space is available for controls to be added as the top left is reserved for the system quick access menu. Because the content in the upper right is not as easily accessible on larger devices, this space is best used for controls that only need accessed intermittently and not in the middle of game-play, like pulling up a pause menu or skipping cinematic moments.",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "Upper Right Layout Content",
+      "description": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
+      "markdownDescription": "This property defines layout content that is fixed to the upper right corner of the available display space. Controls added to this container start in the corner and grow inward towards the top center of the screen.",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "Opacity",
+      "description": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
+      "markdownDescription": "This property changes how transparent the control component is. If omitted, a default value of 1 is used meaning the control is fully opaque.",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "Outer",
+      "description": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Items within this ring are arranged clockwise starting from the top of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
+      "markdownDescription": "Defines the outer ring of controls or control groups present on the outer ring of the wheel. Items within this ring are arranged clockwise starting from the top of the wheel. Each index can be either a single control or an array of controls. When an array is specified, this control group will take double the interaction space and any controls added may extend further out from the center of the wheel. In total the outer wheel has room for 8 individual controls or 4 control groups. Any controls beyond this may be removed or cause a validation rule failure. Note that the `null` control can be used at the beginning of the outer wheel array to offset control groups; when this is done, a final individual control can still be added.",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "Outer",
+      "description": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
+      "markdownDescription": "Defines the outer ring of layer controls and layer control groups on the wheel. This property behaves identically to the same named layout property except that it additionally allows the `blank` control in order to hide controls from the layer(s) underneath it. Note that if a control or control group from a layer below has a different number of items than this layer's corresponding index, all items from that layer will be hidden. Just like on the base layout wheel, a `null` can be used to skip over a control or control group.",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterWheelControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "Control Pull Action",
+      "description": "This property allows either a single action, an array of actions all at once, or one of several defined actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout. When this property is defined as an object with type `segmented`, the pull action ring is divided into equal segements starting at top of the control and progressing clockwise. Based on the exact location of where the control is being pulled, a single segment will enter the `pulled` state.",
+      "markdownDescription": "This property allows either a single action, an array of actions all at once, or one of several defined actions to be performed by the control when it is in the `pulled` state. These actions can map to gamepad inputs or to more complex actions like showing a new layer on the layout. When this property is defined as an object with type `segmented`, the pull action ring is divided into equal segements starting at top of the control and progressing clockwise. Based on the exact location of where the control is being pulled, a single segment will enter the `pulled` state.",
+      "anyOf": [
+        {
+          "properties": {
+             "type":  { 
+              "const": "segmented",
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/_ActionTypeBase"
+              },
+              "maxItems": 4,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/_ActionTypeBase"
+        }
+      ]
+    },
+    "PullIndicator": {
+      "title": "Pull Indicator Styling Component",
+      "description": "The visual styling for the indicator that control is currently being pulled. When an array is used, the type of the pull indicator must be a `segmented` pull indicator. In this case, each array element corresponds to that segment's styling.",
+      "markdownDescription": "The visual styling for the indicator that control is currently being pulled. When an array is used, the type of the pull indicator must be a `segmented` pull indicator. In this case, each array element corresponds to that segment's styling.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        [
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          null,
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          }
+        ],
+        [
+          {
+            "opacity": 0
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PullIndicatorSegment"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        }
+      ]
+    },
+    "PullIndicatorSegment": {
+      "title": "Pull Indicator Segment Styling Component",
+      "description": "The visual styling for the indicator that control is currently being pulled in the direction of this segment. The color of this can be customized to indicate the semantics of pulling the control as well as a custom face image to indicate its action semantics. By default, any single gamepad action mapped to a pull action will have its gamepad function indicated as its face image.",
+      "markdownDescription": "The visual styling for the indicator that control is currently being pulled in the direction of this segment. The color of this can be customized to indicate the semantics of pulling the control as well as a custom face image to indicate its action semantics. By default, any single gamepad action mapped to a pull action will have its gamepad function indicated as its face image.",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "Background Styling Component",
+      "description": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+      "markdownDescription": "A color used to style the background. The exact shape where the color is used depends on the component and cannot be customized.",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "Relative",
+      "description": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
+      "markdownDescription": "This property determines how interactions with the control are calculated. Interactions are calculated either relative to where the interaction began or in an absolute fashion using the control's center. If omitted, a default value of `true` is used to calculate relative to the interaction's starting point.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "Render As Button",
+      "description": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
+      "markdownDescription": "This property causes the control to appear visually as a button. If omitted, a default value of `false` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "Scale",
+      "description": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
+      "markdownDescription": "Multiplier value used to change the size of the control. This value must be between 0.5 and 2. If omitted, a default value of 1 is used.",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "Sensitivity",
+      "description": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
+      "markdownDescription": "Multiplier value used to change the sensitivity of the control. This value must be greater than 0. If omitted, a default value of 1 is used.",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "Sensor Control",
+      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
+      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. Refer to the `type` property for information on the specific control types and their purpose.",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "Layer Sensor Control",
+      "description": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "markdownDescription": "An individual invisible control that takes interactions from a device's available sensors and translates them to outputs. The `blank` control can be used to hide or turn off sensor controls from the layer(s) underneath this one.",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "Sticky",
+      "description": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
+      "markdownDescription": "This property changes if the control returns back to a neutral position when the player stops interacting with the control. Note that even when set, a sticky throttle will not remain in the `axisDown` region. This can be used, for instance, to implement a cruise control style feature. If omitted, a default value of `false` is used.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "Stroke Styling Component",
+      "description": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
+      "markdownDescription": "The visual styling for the stroke of the control component. The stroke is usually a border or outline used to show the extent of the control component.",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "Throttle Axis",
+      "description": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+      "markdownDescription": "This property defines a single mapping from a player's interactions with the control either up or down from the midpoint to the specified output.",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "Throttle Axis Styling Component",
+      "description": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+      "markdownDescription": "The visual styling of the throttle axis component. This component gives the player an indication of the range of possible inputs as well as what region the control is currently in, either up or down.",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "Control Activated Up Style",
+              "description": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
+              "markdownDescription": "Styling overrides used when the control is in the `activatedUp` state. The `activatedUp` state is when the control is being interacted with, specifically in the region above the control's center.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "Control Activated Down Style",
+              "description": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
+              "markdownDescription": "Styling overrides used when the control is in the `activatedDown` state. The `activatedDown` state is when the control is being interacted with, specifically in the region below the control's center.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "Control Disabled Style",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "Control Idle Up Style",
+              "description": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
+              "markdownDescription": "Styling overrides used when the control is in the `idleUp` state. The `idleUp` state is when the control is not being interacted with but the control's value remains in the region above the control's center. This state can only be reached when the control is `sticky`.",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "Toggle",
+      "description": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
+      "markdownDescription": "This property changes the control to be a toggle control. Instead of returning to `idle` state when no longer being interacted with, the control instead transitions to the `toggled` state where its action is still executed. After the player interacts with the control again, it will un-toggle and return to `idle` state.",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "Control Styles",
+      "description": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "markdownDescription": "Visual styling definition of the control. For each state of the control, styling can be overridden. For any elements that are not customized in a specific state, the `default` styling property or the system's defaults will be used as a basis to style the control. The system may still modify a control's visuals from the `default` style as appropriate in a specific state, for instance by reducing opacity in the `disabled` state.",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "Control Activated Style",
+              "description": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "markdownDescription": "Styling overrides used when the control is in the `activated` state. The `activated` state is when the control is being interacted with and its action is being executed.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "Control Default Style",
+              "description": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "markdownDescription": "Default styling parameters to be applied to the control. These parameters are used to override the system provided default styling for the control. The visuals can be further overridden by specifying styles for a specific state. Note that in a specific state, like `disabled`, when no specific styles are provided, the default styles will be used as a fallback though some changes may be made for that state, like decreasing the overall opacity to indicate the control is disabled.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "Control Disabled Style",
+              "description": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "markdownDescription": "Styling overrides used when the control is in the `disabled` state. In this state, the control is visually disabled even though outputs are still executed when a player interacts with the control. Unless explicitly overridden here, values provided in the `default` styling configuration will be used with a reduced overall control opacity and any interaction indicators will be hidden to show that the control is disabled.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "Control Idle Style",
+              "description": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "markdownDescription": "Styling overrides used when the control is in the `idle` state. In this state, the control is not being interacted with and is  considered neutral or resting.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "Control Moving Style",
+              "description": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+              "markdownDescription": "Styling overrides used when the control is in the `moving` state. The `moving` state is when the control is being interacted with but its action is not being executed yet. Additional styling elements may be available in this state to indicate the direction of the interaction.",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "Interval",
+      "description": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
+      "markdownDescription": "This property defines the regular interval or period, in milliseconds, at which the assigned sub-action is turned on and off while the overall action is executed.",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "type": "object"
+}

--- a/touch-adaptation-kit/schemas/zh-CN/context/v4.1/context.json
+++ b/touch-adaptation-kit/schemas/zh-CN/context/v4.1/context.json
@@ -1,0 +1,163 @@
+{
+    "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/context/v4.1/context.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "触摸适配捆绑包上下文架构",
+    "description": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+    "markdownDescription": "触摸适配捆绑包上下文是包含可由其他布局引用的全局、可重用状态和定义的文件。这允许重用公共架构片段，并使触摸控件动态响应游戏状态。有关版本之间更改的最新信息，请参阅 https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+    "$defs": {
+        "AllowedStateValues": {
+            "title": "触摸捆绑包允许的状态值",
+            "description": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
+            "markdownDescription": "使用动态状态时，此属性用于在可能值集上提供其他元数据，如不同的资产文件名。这用于验证目的，以帮助确保所有值都将导致有效的触摸布局，并且不会丢失或未使用资产等其他捆绑包文件。请注意，运行时不使用此属性，将导致布局无效的任何状态更改操作都将被忽略。因此，必须使用各种值进行测试，以确保在所有情况下都正常操作。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotForegroundImage": [
+                        "InventoryForegroundFireballSpell",
+                        "InventoryForegroundLightningBoltSpell"
+                    ],
+                    "inventorySlotBackgroundImage": {
+                        "$ref": "#/definitions/AllowedBackgroundImages"
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/StateType"
+                            }
+                        },
+                        {
+                            "$ref": "../../layout/latest/layout.json#/$defs/Reference"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ContextDefinableType": {
+            "title": "可定义类型",
+            "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+            "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+            "anyOf": [
+                {
+                    "$ref": "../../layout/latest/layout.json#/$defs/LayoutDefinableType"
+                },
+                {
+                    "$ref": "#/$defs/StateType"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/StateType"
+                    }
+                }
+            ]
+        },
+        "Definitions": {
+            "title": "定义",
+            "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+            "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+            "examples": [
+                {},
+                {
+                    "joystickAssetName": "exampleAssetName",
+                    "joystickKnob": {
+                        "default": {
+                            "knob": {
+                                "faceImage": {
+                                    "type": "asset",
+                                    "value": {
+                                        "$ref": "#/$defs/joystickAssetName"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/ContextDefinableType"
+                }
+            },
+            "type": "object"
+        },
+        "State": {
+            "title": "触摸捆绑包状态",
+            "description": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
+            "markdownDescription": "此属性用于通过指定具有基元值的自定义命名属性来包含触摸捆绑包的所有动态状态。`XGameStreamingUpdateTouchControlsState` API 可用于在运行时更新节中的值。这对于将玩家游戏的确切状态与所显示的控件匹配可能很有用，例如当玩家获取新技能或自定义其控制首选项时。触摸布局中使用基元字符串、数字或布尔类型的大多数位置都允许动态替换，将值定义为`$ref`回此状态块。",
+            "examples": [
+                {},
+                {
+                    "inventorySlotEnabled": true,
+                    "inventorySlotForegroundImage": "InventoryForeground",
+                    "inventorySlotBackgroundImage": "InventoryBackground"
+                }
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/$defs/StateType"
+                }
+            },
+            "type": "object"
+        },
+        "StateType": {
+            "title": "触摸捆绑包状态项",
+            "description": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
+            "markdownDescription": "此属性是出现在`state`配置中的单个项。其值必须是基元字符串、数字或布尔值。调用`XGameStreamingUpdateTouchControlsState`时，使用项的名称和匹配类型的值动态更新状态。",
+            "examples": [
+                "customAssetName",
+                false,
+                true,
+                1,
+                0
+            ],
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "ContextStyles": {
+            "title": "样式",
+            "description": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+            "markdownDescription": "此属性定义可重用样式，可在此触摸适配捆绑包的布局中引用这些样式以实现样式设置。如果在给定的布局文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果找到重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+            "$ref": "../../layout/latest/layout.json#/$defs/_LayoutStyles"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "definitions": {
+            "$ref": "#/$defs/Definitions"
+        },
+        "state": {
+            "$ref": "#/$defs/State"
+        },
+        "styles": {
+            "$ref": "#/$defs/ContextStyles"
+        },
+        "allowedStateValues": {
+            "$ref": "#/$defs/AllowedStateValues"
+        }
+    },
+    "additionalProperties": false
+}

--- a/touch-adaptation-kit/schemas/zh-CN/layout/v4.1/layout.json
+++ b/touch-adaptation-kit/schemas/zh-CN/layout/v4.1/layout.json
@@ -1,0 +1,5525 @@
+{
+  "$id": "https://raw.githubusercontent.com/microsoft/xbox-game-streaming-tools/main/touch-adaptation-kit/schemas/layout/v4.1/layout.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "additionalProperties": false,
+  "title": "触摸适配捆绑包布局架构",
+  "description": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+  "markdownDescription": "触摸适配捆绑包布局表示游戏场景以及允许移动或触摸游戏玩游戏所需的所有控件。有关布局版本之间更改的最新信息，请参阅https://github.com/microsoft/xbox-game-streaming-tools/releases。",
+  "$defs": {
+    "LayoutDefinableType": {
+      "title": "可定义类型",
+      "description": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "markdownDescription": "包含可在此文件的`definitions`部分中使用的所有类型的联合类型。有关详细信息，请参阅`definitions`部分",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        {
+          "$ref": "#/$defs/ActionType"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ArcadeButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/AssetReference"
+        },
+        {
+          "$ref": "#/$defs/AxisCap"
+        },
+        {
+          "$ref": "#/$defs/AxisCapColor"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        {
+          "$ref": "#/$defs/Background"
+        },
+        {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        {
+          "$ref": "#/$defs/ButtonActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonToggledStyle"
+        },
+        {
+          "$ref": "#/$defs/ButtonPulledStyle"
+        },
+        {
+          "$ref": "#/$defs/Color"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteDefaultVariant"
+        },
+        {
+          "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+        },
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/ControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneRadial"
+        },
+        {
+          "$ref": "#/$defs/DeadzoneThreshold"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+        },
+        {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        {
+          "$ref": "#/$defs/FaceImage"
+        },
+        {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        },
+        {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        {
+          "$ref": "#/$defs/FillColor"
+        },
+        {
+          "$ref": "#/$defs/Gradient"
+        },
+        {
+          "$ref": "#/$defs/Indicator"
+        },
+        {
+          "$ref": "#/$defs/InnerLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InnerLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/InputCurveRange"
+        },
+        {
+          "$ref": "#/$defs/InputCurve"
+        },
+        {
+          "$ref": "#/$defs/InputCurveType"
+        },
+        {
+          "$ref": "#/$defs/JoystickActivatedStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDefaultStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickDirectionIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickDisabledStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickIdleStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickMovingStyle"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+        },
+        {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        {
+          "$ref": "#/$defs/Knob"
+        },
+        {
+          "$ref": "#/$defs/Layer"
+        },
+        {
+          "$ref": "#/$defs/Layers"
+        },
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroupItem"
+        },
+        {
+          "$ref": "#/$defs/LayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayerLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayerSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayerUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/LayoutColors"
+        },
+        {
+          "$ref": "#/$defs/LayoutOrientation"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerArrayContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutLowerContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutSensorContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperContent"
+        },
+        {
+          "$ref": "#/$defs/LayoutUpperRightContent"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Opacity"
+        },
+        {
+          "$ref": "#/$defs/OuterLayoutControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelControlGroup"
+        },
+        {
+          "$ref": "#/$defs/OuterLayerControlWheel"
+        },
+        {
+          "$ref": "#/$defs/OuterWheelLayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/PullActionType"
+        },
+        {
+          "$ref": "#/$defs/PullIndicator"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        },
+        {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        {
+          "$ref": "#/$defs/Scale"
+        },
+        {
+          "$ref": "#/$defs/Sensitivity"
+        },
+        {
+          "$ref": "#/$defs/SensorControl"
+        },
+        {
+          "$ref": "#/$defs/Sticky"
+        },
+        {
+          "$ref": "#/$defs/Stroke"
+        },
+        {
+          "$ref": "#/$defs/LayoutStyles"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        {
+          "$ref": "#/$defs/ThrottleAxisStyle"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyleBase"
+        },
+        {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        {
+          "$ref": "#/$defs/Toggle"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyleBase"
+        },
+        {
+          "$ref": "#/$defs/TouchpadStyles"
+        }
+      ]
+    },
+    "Definitions": {
+      "title": "定义",
+      "description": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "markdownDescription": "可用于包含触摸布局的可重用组件和值的部分。这些定义稍后可以使用 JSON 引用进行引用，例如 `{ \"$ref\": \"#/definitions/joystickKnobStyle\" }。几乎布局架构的每个部分都支持 JSON 引用，使常见元素(如多个控件中使用的常用按钮背景)被分解和重复使用。请注意，上下文文件还支持`definitions`属性和`state`，以便跨布局重复使用组件。",
+      "examples": [
+        {},
+        {
+          "joystickAssetName": "exampleAssetName",
+          "joystickKnob": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "asset",
+                  "value": {
+                    "$ref": "#/definitions/joystickAssetName"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/LayoutDefinableType"
+        }
+      },
+      "type": "object"
+    },
+    "Reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
+          "markdownDescription": "对本地或附近文件中定义的值的引用，如上下文文件。有关详细信息，请参阅`definitions`布局属性。",
+          "examples": [
+            "#/definitions/layoutReusableItem",
+            "../../context.json#/state/dynamicStateValue",
+            "../../context.json#/definitions/globalReusableItem"
+          ],
+          "format": "uri-reference"
+        }
+      }
+    },
+    "_Null": {
+      "title": "Null",
+      "description": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
+      "markdownDescription": "这是一个特殊值，可用于代替控件来跳过某个位置。这在控件数组和层上特别有用，用于填充内容的位置。",
+      "examples": [
+        null
+      ],
+      "type": "null"
+    },
+    "_Accelerometer": {
+      "examples": [
+        {
+          "type": "accelerometer",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "加速计控件类型",
+          "description": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
+          "markdownDescription": "加速计控件。此控件允许从设备的动作(尤其是加速)转换为游戏输入。",
+          "const": "accelerometer",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_ActionTypeBase": {
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_SingleControlActionAssignableTypes"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "_ArcadeButtons": {
+      "examples": [
+        {
+          "type": "arcadeButtons",
+          "lightKick": {
+            "action": "gamepadA"
+          },
+          "mediumKick": {
+            "action": "gamepadB"
+          },
+          "heavyKick": {
+            "action": "gamepadX"
+          },
+          "lightPunch": {
+            "action": "gamepady"
+          },
+          "mediumPunch": {
+            "action": "rightBumper"
+          },
+          "heavyPunch": {
+            "action": "leftBumper"
+          },
+          "specialKick": {
+            "action": [
+              "gamepadA",
+              "gamepadB"
+            ]
+          },
+          "specialPunch": {
+            "action": [
+              "gamepadX",
+              "gamepadY"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "heavyKick": {
+          "title": "重踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "heavyPunch": {
+          "title": "重踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightKick": {
+          "title": "轻踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "lightPunch": {
+          "title": "轻拳按键",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumKick": {
+          "title": "中等力度踢按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "mediumPunch": {
+          "title": "中等拳击按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialKick": {
+          "title": "特殊踢出按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "specialPunch": {
+          "title": "特殊拳击按钮",
+          "$ref": "#/$defs/ArcadeButton"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeArcadeButtons"
+        }
+      },
+      "required": [
+        "type",
+        "lightKick",
+        "mediumKick",
+        "heavyKick",
+        "lightPunch",
+        "mediumPunch",
+        "heavyPunch"
+      ],
+      "type": "object"
+    },
+    "_AxisMapping2DItem": {
+      "title": "二维轴映射项",
+      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的单一映射。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping2D"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1D"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinal"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_AxisMapping3DItem": {
+      "title": "三维轴映射项",
+      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的单个映射。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisUp",
+          "output": "rightTrigger"
+        },
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        }
+      ]
+    },
+    "_BackgroundAsset": {
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageFileName"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "用于设置背景样式的自定义资产。",
+          "markdownDescription": "用于设置背景样式的自定义资产。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/BackgroundAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_BackgroundColor": {
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+          "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+          "const": "color",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/Color"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "_Blank": {
+      "examples": [
+        {
+          "type": "blank"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "空白控件类型",
+          "description": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
+          "markdownDescription": "创建使用层的布局时，空白控件类型用于替代或隐藏其下层上的现有控件或控件组。空白控件不可交互，并且没有任何可样式组件。",
+          "const": "blank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_Button": {
+      "examples": [
+        {
+          "type": "button",
+          "action": "gamepadA",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "interact"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "pullAction": {
+          "$ref": "#/$defs/PullActionType"
+        },
+        "toggle": {
+          "$ref": "#/$defs/Toggle"
+        },
+        "styles": {
+          "$ref": "#/$defs/ButtonStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeButton"
+        }
+      },
+      "required": [
+        "type",
+        "action"
+      ],
+      "type": "object"
+    },
+    "_Color": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        "colors/system_contentPrimary",
+        "colors/myColor",
+        {
+          "$ref": "#/definitions/commonAccentColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/_ColorReference"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ColorReference": {
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^colors\/(?!system_)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "enum": [
+            "colors/system_contentPrimary",
+            "colors/system_contentSecondary",
+            "colors/system_contrastPrimary",
+            "colors/system_contrastSecondary",
+            "colors/system_actionColorDefault",
+            "colors/system_actionColorA",
+            "colors/system_actionColorB",
+            "colors/system_actionColorX",
+            "colors/system_actionColorY",
+            "colors/system_accentPrimary",
+            "colors/system_accentSecondary"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "_ColorPaletteBase": {
+      "examples": [
+        {},
+        {
+          "system_contentPrimary": "#ffffffff",
+          "myColor": "#ff00ffff"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "system_contentPrimary": {
+          "$ref": "#/$defs/_SystemColorContentPrimary"
+        },
+        "system_contentSecondary": {
+          "$ref": "#/$defs/_SystemColorContentSecondary"
+        },
+        "system_contrastPrimary": {
+          "$ref": "#/$defs/_SystemColorContrastPrimary"
+        },
+        "system_contrastSecondary": {
+          "$ref": "#/$defs/_SystemColorContrastSecondary"
+        },
+        "system_actionColorDefault": {
+          "$ref": "#/$defs/_SystemColorActionColor"
+        },
+        "system_actionColorA": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorB": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorX": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_actionColorY": {
+          "$ref": "#/$defs/_SystemColorGamepadActionColor"
+        },
+        "system_accentPrimary": {
+          "$ref": "#/$defs/_SystemColorAccentPrimary"
+        },
+        "system_accentSecondary": {
+          "$ref": "#/$defs/_SystemColorAccentSecondary"
+        }
+      },
+      "patternProperties": {
+        "^(?!system_)[a-zA-Z0-9\\.\\-_]+$": {
+          "$ref": "#/$defs/_CustomColorPaletteColor"
+        }
+      },
+      "type": "object"
+    },
+    "_ColorPaletteColor": {
+      "examples": [
+        "#0099ff",
+        "#0099ffaa",
+        "#09f",
+        "#09fa",
+        {
+          "$ref": "#/definitions/myColor"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_HexColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_ControlBase": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControlTypeArcadeButtons"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeButton"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeDirectionalPad"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeJoystick"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeThrottle"
+            },
+            {
+              "$ref": "#/$defs/_ControlTypeTouchpad"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Button"
+        },
+        {
+          "$ref": "#/$defs/_Joystick"
+        },
+        {
+          "$ref": "#/$defs/_DirectionalPad"
+        },
+        {
+          "$ref": "#/$defs/_Touchpad"
+        },
+        {
+          "$ref": "#/$defs/_Throttle"
+        },
+        {
+          "$ref": "#/$defs/_ArcadeButtons"
+        }
+      ]
+    },
+    "_ControllerAction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerButtonOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalogMagnitudinalJoystickOutputType": {
+      "title": "游戏手柄模拟游戏杆输出",
+      "description": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
+      "markdownDescription": "沿指定的游戏手柄游戏杆轴将值从 0 输出到最大值。当用作`action`而不是`output`时，仅使用最大值。",
+      "enum": [
+        "leftJoystickRight",
+        "leftJoystickLeft",
+        "leftJoystickUp",
+        "leftJoystickDown",
+        "rightJoystickRight",
+        "rightJoystickLeft",
+        "rightJoystickUp",
+        "rightJoystickDown"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalogMagnitudinalOutputType": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerTriggerOutputType"
+        },
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalJoystickOutputType"
+        }
+      ]
+    },
+    "_ControllerAnalog1DOutputType": {
+      "title": "游戏手柄模拟游戏杆输出",
+      "description": "沿指定游戏手柄游戏杆轴的整个输出值。",
+      "markdownDescription": "沿指定游戏手柄游戏杆轴的整个输出值。",
+      "enum": [
+        "leftJoystickX",
+        "leftJoystickY",
+        "rightJoystickX",
+        "rightJoystickY"
+      ],
+      "type": "string"
+    },
+    "_ControllerAnalog2DOutputType": {
+      "title": "游戏手柄模拟游戏杆输出",
+      "description": "沿两个游戏手柄游戏杆轴的整个输出值。",
+      "markdownDescription": "沿两个游戏手柄游戏杆轴的整个输出值。",
+      "enum": [
+        "rightJoystick",
+        "leftJoystick"
+      ],
+      "type": "string"
+    },
+    "_ControllerButtonOutputType": {
+      "title": "游戏手柄按钮输出",
+      "description": "输出按下的游戏手柄按钮。",
+      "markdownDescription": "输出按下的游戏手柄按钮。",
+      "enum": [
+        "guide",
+        "gamepadA",
+        "gamepadB",
+        "gamepadX",
+        "gamepadY",
+        "view",
+        "menu",
+        "leftBumper",
+        "rightBumper",
+        "dPadLeft",
+        "dPadRight",
+        "dPadUp",
+        "dPadDown",
+        "leftThumb",
+        "rightThumb"
+      ],
+      "type": "string"
+    },
+    "_ControllerTriggerOutputType": {
+      "title": "游戏手柄模拟触发器输出",
+      "description": "输出映射到指定游戏手柄触发器的值。",
+      "markdownDescription": "输出映射到指定游戏手柄触发器的值。",
+      "enum": [
+        "leftTrigger",
+        "rightTrigger"
+      ],
+      "type": "string"
+    },
+    "_ControlTypeArcadeButtons": {
+      "title": "Arcade 按钮控件类型",
+      "description": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
+      "markdownDescription": "Arcade 按钮控件。此控件是根据常见的 6 或 8 按钮 Arcade 柜安排排列的一组按钮。这通常用于格斗风格游戏。通过在按钮之间触摸，玩家可以同时按多个按钮。在一行按钮上方或下方触摸将同时激活该行中的所有按钮，使执行组合更易于执行。",
+      "const": "arcadeButtons",
+      "type": "string"
+    },
+    "_ControlTypeButton": {
+      "title": "按钮控件类型",
+      "description": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
+      "markdownDescription": "按钮控件是一种简单控件类型，允许在按下控件时执行操作。若要允许某些高级功能，当交互超出控件的范围时，可以分配另一个操作，即“拉”操作。这对于第二个同时操作需要与控件的主要操作协调的情境很有用，例如在射击时出错。",
+      "const": "button",
+      "type": "string"
+    },
+    "_ControlTypeDirectionalPad": {
+      "title": "方向盘控件类型",
+      "description": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
+      "markdownDescription": "方向板控件模仿在物理游戏手柄上找到的标准四向或八向控件。此控件在 2D 平台游戏和格斗游戏中特别有用，需要精确方向才能执行某些操作。若要在四向或八向样式控件之间进行选择，请参阅`interaction`属性。",
+      "const": "directionalPad",
+      "type": "string"
+    },
+    "_ControlTypeJoystick": {
+      "title": "游戏杆控件类型",
+      "description": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
+      "markdownDescription": "一个游戏杆控件，它模仿物理控制器中的模拟游戏杆。它允许玩家根据`axis`属性在二维或一维空间中移动控件。此外，它还允许使用`action`和`actionThreshold`属性与移动一起执行同时执行的操作。此控件通常用于玩家游戏或相机控件，触控布局通常包括多个游戏杆，用于在移动或环行时可以执行的任何操作，如瞄准或射击。",
+      "const": "joystick",
+      "type": "string"
+    },
+    "_ControlTypeThrottle": {
+      "title": "限制控件类型",
+      "description": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
+      "markdownDescription": "一种限制控件，它模仿船、汽车或飞机中的物理限制。此控件具有玩家可以与之交互以向上或向下移动限制的旋钮。此控件最适用于驾驶或飞行游戏，在游戏中，通常需要随时按住气量。在样式化控件时，单独的`activatedUp`、`activatedDown`和`idleUp`状态允许在玩家使用气、制动器等时显示精确的自定义。",
+      "const": "throttle",
+      "type": "string"
+    },
+    "_ControlTypeTouchpad": {
+      "title": "触摸板控件类型",
+      "description": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
+      "markdownDescription": "模拟在笔记本电脑上找到的物理触摸板的触摸板控件。此控件最适合用于鼠标或游戏杆样式动作，如相机控件，并允许玩家通过轻扫和拖动进行精确控制。此外，可以向控件分配`action`，并且该控件可呈现为带`renderAsButton`的按钮，以便创建一个控件，该控件将移动或照相机与诸如移动或跳跃等常见操作结合在一起。",
+      "const": "touchpad",
+      "type": "string"
+    },
+    "_CustomColorPaletteColor": {
+      "title": "自定义布局颜色",
+      "description": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
+      "markdownDescription": "此属性定义可在其他地方引用的可重用颜色。可以使用“colors/”前缀，后跟可用于样式的颜色区域中的颜色名称来引用此颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_DirectionalPad": {
+      "examples": [
+        {
+          "type": "directionalPad"
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/DeadzoneDirectionalPad"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "interaction": {
+          "$ref": "#/$defs/DirectionalPadInteraction"
+        },
+        "scale": {
+          "$ref": "#/$defs/Scale"
+        },
+        "styles": {
+          "$ref": "#/$defs/DirectionalPadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeDirectionalPad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "_FaceImageAsset": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "人脸图像资产样式设置组件",
+          "description": "用作控件组件的前景图形的自定义资产。",
+          "markdownDescription": "用作控件组件的前景图形的自定义资产。",
+          "const": "asset",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageAssetValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_FaceImageIcon": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "人脸图像图标样式组件",
+          "description": "用作控件组件的前景图形的内置图标。",
+          "markdownDescription": "用作控件组件的前景图形的内置图标。",
+          "const": "icon",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/FaceImageIconValue"
+        },
+        "opacity": {
+          "$ref": "#/$defs/Opacity"
+        },
+        "label": {
+          "$ref": "#/$defs/FaceImageIconLabel"
+        }
+      },
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "_Gyroscope": {
+      "examples": [
+        {
+          "type": "gyroscope",
+          "axis": {
+            "input": "axisXY",
+            "output": "rightJoystick"
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/AxisMapping3D"
+        },
+        "type": {
+          "title": "陀螺仪控件类型",
+          "description": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
+          "markdownDescription": "陀螺仪控件。此控件允许将设备的运动，特别是轴旋转转换为游戏输入。此控件对于控制玩家的相机特别有用，因为真实的旋转自然可以旋转游戏的视角。",
+          "const": "gyroscope",
+          "type": "string"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_HexColor": {
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "_InputAxisMagnitudinal": {
+      "title": "坐标轴输入映射",
+      "description": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
+      "markdownDescription": "仅使用沿指定轴方向的输入量(向上、向下、向左或向右)转换为指定的输出。例如，根据输入当前距离控件原点的剩余距离，`axisLeft`值将从 0 映射到 1。由于这是一个基于大小的值，因此不可能有负输出。",
+      "enum": [
+        "axisRight",
+        "axisLeft",
+        "axisUp",
+        "axisDown"
+      ],
+      "type": "string"
+    },
+    "_InputAxis1D": {
+      "anyOf": [
+        {
+          "title": "X 轴输入映射",
+          "description": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "markdownDescription": "使用沿控件的 X 轴上的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "const": "axisX",
+          "type": "string"
+        },
+        {
+          "title": "Y 轴输入映射",
+          "description": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "markdownDescription": "使用沿控件的 Y 轴的正向和负方向的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+          "const": "axisY",
+          "type": "string"
+        }
+      ]
+    },
+    "_InputAxisXY": {
+      "title": "X 轴和 Y 轴输入映射",
+      "description": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "markdownDescription": "使用控件的 X 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "const": "axisXY",
+      "type": "string"
+    },
+    "_InputAxisZY": {
+      "title": "Z 轴和 Y 轴输入映射",
+      "description": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "markdownDescription": "使用控件的 Z 轴和 Y 轴中的交互转换为指定的输出。有关此映射的详细信息，请参阅`output`属性。",
+      "const": "axisZY",
+      "type": "string"
+    },
+    "_InputMapping1D": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping1DToGamepad1DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMapping1DToRelativeMouse1DOutput"
+        }
+      ]
+    },
+    "_InputMapping1DToGamepad1DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxis1D"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog1DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping1DToRelativeMouse1DOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxis1D"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouse1DOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMapping2D": {
+      "$ref": "#/$defs/_InputMappingXY"
+    },
+    "_InputMappingMagnitudinal": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingMagnitudinalToGamepadMagnitudinalOutput"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToRelativeMouseMagnitudinalOutput": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/_InputAxisMagnitudinal"
+            },
+            "output": {
+              "$ref": "#/$defs/_RelativeMouseMagnitudinalOutputType"
+            },
+            "sensitivity": {
+              "$ref": "#/$defs/Sensitivity"
+            }
+          },
+          "required": [
+            "input",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_InputMappingXY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingXYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingXYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingXYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisXY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZY": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingZYToGamepad2DOutput"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZYToMouse2DOutput"
+        }
+      ]
+    },
+    "_InputMappingZYToMouse2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_RelativeMouse2DOutputType"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMappingZYToGamepad2DOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone2D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisZY"
+        },
+        "output": {
+          "$ref": "#/$defs/_ControllerAnalog2DOutputType"
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_InputMapping3DTo2DOutput": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMappingXY"
+        },
+        {
+          "$ref": "#/$defs/_InputMappingZY"
+        }
+      ]
+    },
+    "_InputMappingMagnitudinalToGamepadMagnitudinalOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "deadzone": {
+          "$ref": "#/$defs/Deadzone1D"
+        },
+        "input": {
+          "$ref": "#/$defs/_InputAxisMagnitudinal"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+            },
+            {
+              "$ref": "#/$defs/Reference"
+            }
+          ]
+        },
+        "responseCurve": {
+          "$ref": "#/$defs/InputCurve"
+        },
+        "sensitivity": {
+          "$ref": "#/$defs/Sensitivity"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ],
+      "type": "object"
+    },
+    "_Joystick": {
+      "examples": [
+        {
+          "type": "joystick",
+          "axis": {
+            "input": "axisXY",
+            "output": "leftJoystick"
+          },
+          "styles": {
+            "default": {
+              "knob": {
+                "faceImage": {
+                  "type": "icon",
+                  "value": "walk"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "actionThreshold": {
+          "$ref": "#/$defs/ActionThreshold"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "expand": {
+          "$ref": "#/$defs/ExpandInteraction"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "styles": {
+          "$ref": "#/$defs/JoystickStyles"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeJoystick"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_LayerControlBase": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        }
+      ]
+    },
+    "_LayoutAction": {
+      "title": "布局操作",
+      "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
+      "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "layer",
+          "target": "WeaponSelectLayer"
+        }
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/LayoutActionTarget"
+        },
+        "type": {
+          "title": "布局操作",
+          "description": "触发布局更改的操作类型，例如在执行操作时应用层。",
+          "markdownDescription": "触发布局更改的操作类型，例如在执行操作时应用层。",
+          "const": "layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "target"
+      ],
+      "type": "object"
+    },
+    "_LayoutStyles": {
+      "examples": [
+        {},
+        {
+          "colors": {
+            "default": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#ff0000ff"
+            },
+            "highContrast": {
+              "system_contentPrimary": "#ffffffff",
+              "myColor": "#00ff00ff"
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "$ref": "#/$defs/LayoutColors"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_RelativeMouse1DOutputType": {
+      "title": "相对鼠标一维输出",
+      "description": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
+      "markdownDescription": "此输出类型采用一维控件输入并将它们转换为沿单个轴的相对鼠标移动。",
+      "enum": [
+        "relativeMouseX",
+        "relativeMouseY"
+      ],
+      "type": "string"
+    },
+    "_RelativeMouse2DOutputType": {
+      "title": "相对鼠标二维输出",
+      "description": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
+      "markdownDescription": "此输出类型采用二维控件输入并将它们转换为相对鼠标移动。",
+      "const": "relativeMouse",
+      "type": "string"
+    },
+    "_RelativeMouseMagnitudinalOutputType": {
+      "title": "相对鼠标方向输出",
+      "description": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
+      "markdownDescription": "此输出类型采用一个控件输入沿指定输入轴的大小，并将其映射到单个方向的相对鼠标移动。例如，如果游戏杆的 X 轴移动被映射到相对鼠标 X 轴输出，只要游戏杆在右侧保持，就会发送一系列正 X 方向的鼠标移动。",
+      "enum": [
+        "relativeMouseUp",
+        "relativeMouseDown",
+        "relativeMouseLeft",
+        "relativeMouseRight"
+      ],
+      "type": "string"
+    },
+    "_SingleControlActionAssignableTypes": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/_LayoutAction"
+        },
+        {
+          "$ref": "#/$defs/_TurboAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_StrokeBase": {
+      "examples": [
+        {
+          "type": "solid",
+          "opacity": 1,
+          "color": "#0099ff"
+        },
+        {
+          "$ref": "#/definitions/commonControlStroke"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
+              "markdownDescription": "此样式组件用于指定具有可自定义颜色和不透明度的纯粗线。",
+              "const": "solid",
+              "type": "string"
+            },
+            "color": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "_SystemColorContentPrimary": {
+      "title": "内容主系统颜色替代",
+      "description": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
+      "markdownDescription": "此属性将替代用于中划、图标和 dpad 渐变等样式组件的主要系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContentSecondary": {
+      "title": "内容辅助系统颜色替代",
+      "description": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
+      "markdownDescription": "此属性将替代用于样式组件(如背景和填充)的辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastPrimary": {
+      "title": "对比度主系统颜色替代",
+      "description": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
+      "markdownDescription": "此属性将替代用于样式对比度组件的对比度主系统颜色，如内部/外部笔划和人脸图像背景板。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorContrastSecondary": {
+      "title": "对比度辅助系统颜色替代",
+      "description": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
+      "markdownDescription": "此属性将替代用于触控板笔划等样式对比度组件的对比度辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorActionColor": {
+      "title": "操作系统颜色替代",
+      "description": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
+      "markdownDescription": "此属性将替代相应的操作系统颜色，该颜色用于在`action`字段设置为非游戏手柄操作的控件上样式组件。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorGamepadActionColor": {
+      "title": "游戏手柄操作系统颜色替代",
+      "description": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
+      "markdownDescription": "此属性将替代相应的游戏手柄操作系统颜色，用于在`action`字段设置为`gamepadA`、`gamepadB`、`gamepadX`或`gamepadY`的控件上样式组件。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentPrimary": {
+      "title": "重置主要系统颜色强调",
+      "description": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
+      "markdownDescription": "此属性将替代用于样式组件的强调主系统颜色，如 ergo-edit 内部滚轮。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_SystemColorAccentSecondary": {
+      "title": "重音次要系统颜色覆盖",
+      "description": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
+      "markdownDescription": "此属性替代用于样式设置组件(如 ergo 编辑外轮)的主题辅助系统颜色。",
+      "$ref": "#/$defs/_ColorPaletteColor"
+    },
+    "_Throttle": {
+      "examples": [
+        {
+          "type": "throttle",
+          "axisUp": "rightTrigger",
+          "axisDown": "leftTrigger",
+          "sticky": true
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axisDown": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "axisUp": {
+          "$ref": "#/$defs/ThrottleAxisOutput"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "relative": {
+          "$ref": "#/$defs/RelativeInteraction"
+        },
+        "sticky": {
+          "$ref": "#/$defs/Sticky"
+        },
+        "styles": {
+          "$ref": "#/$defs/ThrottleStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeThrottle"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axisDown",
+        "axisUp"
+      ],
+      "type": "object"
+    },
+    "_Touchpad": {
+      "examples": [
+        {
+          "type": "touchpad",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "look"
+              }
+            }
+          },
+          "axis": [
+            {
+              "input": "axisXY",
+              "output": "relativeMouse"
+            }
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ActionType"
+        },
+        "axis": {
+          "$ref": "#/$defs/AxisMapping2D"
+        },
+        "enabled": {
+          "$ref": "#/$defs/ControlEnabled"
+        },
+        "renderAsButton": {
+          "$ref": "#/$defs/RenderAsButton"
+        },
+        "styles": {
+          "$ref": "#/$defs/TouchpadStyles"
+        },
+        "type": {
+          "$ref": "#/$defs/_ControlTypeTouchpad"
+        },
+        "visible": {
+          "$ref": "#/$defs/ControlVisibility"
+        }
+      },
+      "required": [
+        "type",
+        "axis"
+      ],
+      "type": "object"
+    },
+    "_TurboAction": {
+      "title": "Turbo 操作",
+      "description": "根据时间间隔而不是连续触发的操作。",
+      "markdownDescription": "根据时间间隔而不是连续触发的操作。",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/ControllerOnlyActionType"
+        },
+        "interval": {
+          "$ref": "#/$defs/TurboActionInterval"
+        },
+        "type": {
+          "title": "Turbo 操作",
+          "description": "根据时间间隔而不是连续触发的操作。",
+          "markdownDescription": "根据时间间隔而不是连续触发的操作。",
+          "const": "turbo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "action",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ActionThreshold": {
+      "title": "操作阈值",
+      "description": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+      "markdownDescription": "此属性定义触发控件操作所需的径向规范化输入值。达到此值后，控件将执行其操作并从`moving`状态转换为`activated`状态。如果省略，则使用默认值 0，表示任何控件交互都将立即执行分配的操作。",
+      "examples": [
+        1,
+        1.5,
+        0,
+        {
+          "$ref": "../../context.json#/state/playerJoystickActionDeadzonePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ActionType": {
+      "title": "控制操作",
+      "description": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个操作或操作数组。这些操作可以映射到游戏手柄输入或更复杂的操作，例如在布局上显示新层。",
+      "$ref": "#/$defs/_ActionTypeBase"
+    },
+    "ArcadeButton": {
+      "description": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
+      "markdownDescription": "`arcadeButtons`控件类型上的单个按钮。此按钮是`button`控件类型的简化版本，可在街机按钮排列中正常工作。",
+      "examples": [
+        {
+          "action": "gamepadX",
+          "styles": {
+            "default": {
+              "faceImage": {
+                "type": "icon",
+                "value": "lightPunch"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonFightingButtons"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "$ref": "#/$defs/ActionType"
+            },
+            "enabled": {
+              "$ref": "#/$defs/ControlEnabled"
+            },
+            "styles": {
+              "$ref": "#/$defs/ArcadeButtonStyles"
+            },
+            "visible": {
+              "$ref": "#/$defs/ControlVisibility"
+            }
+          },
+          "required": [
+            "action"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyleBase": {
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomArcadeButtonBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomArcadeButtonFaceImage"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ArcadeButtonStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomDefaultArcadeButtonFaceImage"
+            }
+          },
+          "activated": {
+            "background": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomActivatedArcadeButtonFaceImage"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonArcadeButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "disabled": {
+              "title": "控件禁用样式",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/ArcadeButtonStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AssetReference": {
+      "title": "资产引用样式组件",
+      "description": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
+      "markdownDescription": "资产引用是与触控布局捆绑的自定义资产的标识符。若要引用整个文件，请使用不带文件扩展名的映像的文件名。对于 sprite 工作表资产，请使用不带扩展名的纹理文件名，后跟`/`和 sprite atlas 中的 sprite 名称。请注意，为了处理具有不同屏幕分辨率的设备，应提供每个 DPI (1.0x、1.5x、2.0x、3.0x、4.0x)的文件。根据资产使用的控件和组件，最大分辨率 1.0x 可能有所不同，但 60x60 和 120x120 是最常见的允许最大值。所有其他 DPI 分辨率应是 1.0x 资产分辨率的倍数。",
+      "examples": [
+        "JumpImage",
+        "SpitesheetTextureFileName/Jump",
+        {
+          "$ref": "#/definitions/buttonBackgroundAssetValue"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+$"
+        },
+        {
+          "type": "string",
+          "pattern": "^[^\/\\.]+\/[A-Za-z0-9_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisCap": {
+      "$ref": "#/$defs/AxisCapColor"
+    },
+    "AxisCapColor": {
+      "title": "坐标轴样式组件",
+      "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+      "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "坐标轴样式组件",
+              "description": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+              "markdownDescription": "用于描述轴控制组件限制的视觉样式。可以使用语义指示轴最大值或最小值的颜色来设置其样式。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "AxisMapping2D": {
+      "title": "二维轴映射",
+      "description": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "markdownDescription": "该属性定义了玩家通过控制器进行的二维模拟交互到一维或两维输出的映射或映射集。请注意，根据轴分配，控件的外观和感觉可能会改变。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_AxisMapping2DItem"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_AxisMapping2DItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "AxisMapping3D": {
+      "title": "三维轴映射",
+      "description": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "markdownDescription": "该属性定义了玩家在控制器上进行三维模拟交互时，将其映射为一维或二维输出的映射或映射集。对于三维交互(例如使用设备传感器)，坐标空间始终相对于游戏视频而言。换句话说，正 X 方向是视频右侧，正 Y 方向是视频顶部，正 Z 方向指向离玩家远离视频的位置。",
+      "examples": [
+        {
+          "input": "axisXY",
+          "output": "rightJoystick",
+          "sensitivity": 0.3
+        },
+        {
+          "input": "axisXY",
+          "output": "relativeMouse"
+        },
+        [
+          {
+            "input": "axisUp",
+            "output": "rightTrigger"
+          },
+          {
+            "input": "axisDown",
+            "output": "leftTrigger"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonAxisMapping"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_InputMapping3DTo2DOutput"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/_InputMapping2D"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Background": {
+      "title": "背景样式组件",
+      "description": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+      "markdownDescription": "控件组件背景的视觉样式。背景可以是`color`或`asset`。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/_BackgroundAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "BackgroundAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "ButtonStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "interact"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ButtonDefaultStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/ButtonIdleStyle"
+            },
+            "activated": {
+              "$ref": "#/$defs/ButtonActivatedStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/ButtonDisabledStyle"
+            },
+            "toggled": {
+              "$ref": "#/$defs/ButtonToggledStyle"
+            },
+            "pulled": {
+              "$ref": "#/$defs/ButtonPulledStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonActivatedStyle": {
+      "title": "控件激活样式",
+      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDefaultStyle": {
+      "title": "控件默认样式",
+      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonDisabledStyle": {
+      "title": "控件禁用样式",
+      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonIdleStyle": {
+      "title": "控制空闲样式",
+      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
+      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的背景和拉动指示器一起使用，以显示控件空闲且未与之交互。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonToggledStyle": {
+      "title": "控件切换样式",
+      "description": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
+      "markdownDescription": "控件处于`toggled`状态时使用的样式替代。`toggled`状态是未与控件交互，但正在执行其操作，因为它当前处于切换状态。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ButtonPulledStyle": {
+      "title": "控件拉取样式",
+      "description": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+      "markdownDescription": "控件处于`pulled`状态时使用的样式替代。`pulled`状态是当控件与控件交互并使用时超出控件的范围，从而导致执行其他操作。",
+      "examples": [
+        {},
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "interact"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonButtonStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "pullIndicator": {
+              "$ref": "#/$defs/PullIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Color": {
+      "title": "颜色",
+      "description": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "markdownDescription": "此属性使用字符串表示形式定义颜色。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "$ref": "#/$defs/_Color"
+    },
+    "ColorPaletteDefaultVariant": {
+      "title": "默认颜色",
+      "description": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "markdownDescription": "此属性定义可在其他位置引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于未在特定变量中定义或没有特定变量的活动颜色，相应的颜色引用将回退到此处定义的颜色。如果未指定给定的系统颜色替代，则颜色引用将回退到系统的默认颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "ColorPaletteHighContrastVariant": {
+      "title": "高对比度颜色",
+      "description": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "markdownDescription": "此属性定义在启用高对比度模式时可在其他地方引用的可重用颜色的集合。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。对于此处或禁用高对比度模式时未定义的任何颜色，相应的颜色引用将回退到`default`中定义的颜色。可以使用`colors/`前缀，后跟可用于样式的颜色区域中的颜色名称来引用颜色。",
+      "$ref": "#/$defs/_ColorPaletteBase"
+    },
+    "Control": {
+      "title": "触摸布局控件",
+      "description": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "markdownDescription": "玩家可以与其交互以执行某些翻译操作的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlEnabled": {
+      "title": "已启用",
+      "description": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
+      "markdownDescription": "用于确定控件是否处于`disabled`状态的属性。此属性在与上下文文件一起使用时最为有用，`state`允许根据游戏状态动态启用和禁用控件。如果省略，则使用默认值`true`。禁用后，该控件可见，并且仍沿输出向前，但没有处于活动状态的外观。请注意，此行为仅适用于具有外观并在屏幕上呈现的控件。传感器控件在处于禁用状态时不转发输出，因为它们没有外观。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroup": {
+      "title": "触摸布局控制组",
+      "description": "一组 1 到 4 个控件排列在一个组中。此组中的项目按系统排列，通常从可用区域的顶部顺时针进行。只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null` 的特殊值可用于跳过排列中的控件。",
+      "markdownDescription": "一组 1 到 4 个控件排列在一个组中。此组中的项目按系统排列，通常从可用区域的顶部顺时针进行。只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，`null` 的特殊值可用于跳过排列中的控件。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "gamepadX"
+          },
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonControlGroup"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ControlGroupItem"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlGroupItem": {
+      "title": "触摸布局控件组项",
+      "description": "控制组中的单个项。使用`null`跳过排列中的控件。",
+      "markdownDescription": "控制组中的单个项。使用`null`跳过排列中的控件。",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControllerOnlyActionType": {
+      "title": "游戏手柄操作",
+      "description": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
+      "markdownDescription": "此属性允许控件在处于`activated`状态时执行单个游戏手柄操作或游戏板操作数组。",
+      "examples": [
+        "gamepadB",
+        {
+          "$ref": "../../context.json#/state/jumpControllerMapping"
+        },
+        [
+          "gamepadA",
+          "leftTrigger"
+        ]
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAction"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ControlVisibility": {
+      "title": "可见",
+      "description": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+      "markdownDescription": "确定控件是否显示。此属性在与上下文文件一起使用时最为有用`state`允许根据游戏状态动态显示和隐藏控件。如果省略，则使用默认值`true`。如果不可见，则无法激活控件，并且即使玩家正在触摸控件否则将显示的位置，也不会执行任何操作。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/hasSpellEquipped"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone1D": {
+      "title": "一维死区",
+      "description": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
+      "markdownDescription": "控件生成的规范化的最小输出值。这对于应对已编程到游戏中的死区非常有用。如果省略，则不使用死区。",
+      "examples": [
+        {
+          "threshold": 0
+        },
+        {
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Deadzone2D": {
+      "title": "二维死区",
+      "description": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
+      "markdownDescription": "控件生成的规范化最小输出值。这对于应对已编程到游戏中的死区很有用。如果`radial`设置为 true，则将按照径向组件一维计算死区。否则，使用阈值单独计算每个轴。如果省略，则不使用任何死区。",
+      "examples": [
+        {
+          "radial": true,
+          "threshold": 0
+        },
+        {
+          "radial": false,
+          "threshold": 0.1
+        },
+        {
+          "$ref": "#/definitions/commonDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "radial": {
+              "$ref": "#/$defs/DeadzoneRadial"
+            },
+            "threshold": {
+              "$ref": "#/$defs/DeadzoneThreshold"
+            }
+          },
+          "required": [
+            "threshold",
+            "radial"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneDirectionalPad": {
+      "title": "方向板死区",
+      "description": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
+      "markdownDescription": "将忽略输入的方向板区域的规范化半径。这对于避免方向靠近方向板中心的方向进行不需要的更改非常有用，小的输入更改可能会显著更改激活的方向。如果省略，则使用值 0.25。请注意，对此值的更改将更改方向板的呈现方式，以向玩家显示此大小的指示。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/dpadDeadzone"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneThreshold": {
+      "title": "阈值",
+      "description": "生成输出值所需的规范化输入值。",
+      "markdownDescription": "生成输出值所需的规范化输入值。",
+      "examples": [
+        0.5,
+        1,
+        0,
+        {
+          "$ref": "#/definitions/commonDeadzoneThreshold"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DeadzoneRadial": {
+      "title": "径向",
+      "description": "是否沿径向输入组件或每个轴单独计算死区阈值。",
+      "markdownDescription": "是否沿径向输入组件或每个轴单独计算死区阈值。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/radialConfig"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "DirectionalPadDefaultStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "gradient": {
+              "$ref": "#/$defs/Gradient"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadIdleStyle": {
+      "examples": [
+        {},
+        {
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          },
+          "gradient": {
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "fill": {
+              "$ref": "#/$defs/FillColor"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteraction": {
+      "title": "交互",
+      "description": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
+      "markdownDescription": "此属性确定玩家如何与控件进行交互。有关详细信息，请参阅`activationType`属性。",
+      "examples": [
+        {
+          "activationType": "exclusive"
+        },
+        {
+          "activationType": "allowNeighboring"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonDPadInteraction"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activationType": {
+              "$ref": "#/$defs/DirectionalPadInteractionActivationType"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadInteractionActivationType": {
+      "title": "激活类型",
+      "description": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
+      "markdownDescription": "此属性确定如何激活控件及其子组件以响应玩家交互。激活类型可以是`exclusive`或`allowNeighboring`。设置为`exclusive`时，一次只激活控件的单个子组件。如果设置`allowNeighboring`，则可以根据玩家与控件交互的位置同时激活该控件的多个子组件。如果省略，则使用默认值`allowNeighboring`。",
+      "examples": [
+        "exclusive",
+        "allowNeighboring",
+        {
+          "$ref": "../../context.json#/state/playerDpadInteractionPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "exclusive",
+            "allowNeighboring"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "DirectionalPadStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            },
+            "gradient": {
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonDPadStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/DirectionalPadDefaultStyle"
+            },
+            "disabled": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，并且是控件的中性或静态状态。除非在此处显式重写，否则`default`样式配置中提供的值将与完全透明的渐变一起使用，以显示控件空闲且未与之交互。",
+              "$ref": "#/$defs/DirectionalPadIdleStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ExpandInteraction": {
+      "title": "展开",
+      "description": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
+      "markdownDescription": "此属性确定控件是否应展开其可交互区域以填充可用空间。这对于玩家可以自定义区域大小的`inner`滚轮容器特别有用。如果设置为 \"false\"，则该控件锁定为其默认或最小交互大小。如果省略，则使用默认值`true`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerExpandControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImage": {
+      "title": "人脸图像样式设置组件",
+      "description": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+      "markdownDescription": "表示控件组件前景的视觉样式。这通常用于显示与其交互的语义。人脸图像可以是`icon`或`asset`类型。图标是内置图形，可表达各种控件操作，而资产允许控件使用与布局捆绑的自定义图像。",
+      "examples": [
+        {
+          "type": "asset",
+          "value": "CustomImageForJumpButtonFace"
+        },
+        {
+          "type": "icon",
+          "value": "interact"
+        },
+        {
+          "$ref": "#/definitions/commonFaceImageStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_FaceImageIcon"
+        },
+        {
+          "$ref": "#/$defs/_FaceImageAsset"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageAssetValue": {
+      "$ref": "#/$defs/AssetReference"
+    },
+    "FaceImageIconLabel": {
+      "title": "人脸图像图标标签样式组件",
+      "description": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
+      "markdownDescription": "此属性确定标签在人脸图像图标上的显示方式。使用语义图像提醒玩家在游戏提示和图像与语义图标不完全匹配的情况下，`action`类型非常有用。若要隐藏这些附加标签，可以使用`none`类型。如果省略，则使用默认值`action`。",
+      "examples": [
+        {
+          "type": "action"
+        },
+        {
+          "type": "none"
+        },
+        {
+          "$ref": "../../context.json#/state/playerShowButtonLabelsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "action",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FaceImageIconValue": {
+      "title": "人脸图像图标",
+      "description": "此属性用于选择要用于此组件的内置图标。",
+      "markdownDescription": "此属性用于选择要用于此组件的内置图标。",
+      "examples": [
+        "heavyPunch",
+        {
+          "$ref": "../../context.json#/definitions/commonIconForPunch"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "ability",
+            "ability2",
+            "ability3",
+            "abilityPowerPunch",
+            "abilityPowerUp",
+            "accept",
+            "add",
+            "aim",
+            "armor",
+            "arrow",
+            "arrowReload",
+            "attackBehind",
+            "barrel",
+            "block",
+            "bomb",
+            "book",
+            "bow",
+            "brakePedal",
+            "brightness",
+            "capture",
+            "character",
+            "characterSelect",
+            "characterSelect2",
+            "chat",
+            "climbStairs",
+            "close",
+            "compass",
+            "cover",
+            "crouch",
+            "cursor",
+            "dPad",
+            "dash",
+            "defendByShield",
+            "dodge",
+            "downArrow",
+            "downArrow2",
+            "downChevron",
+            "emotes",
+            "enterCar",
+            "enterDoor",
+            "exit",
+            "exitCar",
+            "exitDoor",
+            "fastForward",
+            "fire",
+            "firePunch",
+            "flag",
+            "gasPedal",
+            "glide",
+            "golf",
+            "grab",
+            "grenade",
+            "gyroscope",
+            "handbrake",
+            "handbrake2",
+            "health",
+            "heavyKick",
+            "heavyKick2",
+            "heavyKick3",
+            "heavyKick4",
+            "heavyPunch",
+            "heavyPunch2",
+            "heavyPunch3",
+            "heavySword",
+            "heavySword2",
+            "help",
+            "horn",
+            "hourglass",
+            "interact",
+            "internet",
+            "inventory",
+            "jump",
+            "kick",
+            "largeGridView",
+            "leftArrow",
+            "leftArrow2",
+            "leftChevron",
+            "leftRightArrows",
+            "lightKick",
+            "lightKick2",
+            "lightKick3",
+            "lightKick4",
+            "lightPunch",
+            "lightPunch2",
+            "lightPunch3",
+            "lightSword",
+            "lightSword2",
+            "look",
+            "lookBehind",
+            "lookBehind2",
+            "lookByHand",
+            "map",
+            "map2",
+            "medical",
+            "meditate",
+            "mediumKick",
+            "mediumKick2",
+            "mediumKick3",
+            "mediumKick4",
+            "mediumPunch",
+            "mediumPunch2",
+            "mediumPunch3",
+            "mediumSword",
+            "mediumSword2",
+            "microphone",
+            "mirror",
+            "moreActions",
+            "move",
+            "move2",
+            "notebook",
+            "parameters",
+            "pause",
+            "phone",
+            "pickAxe",
+            "placeholder",
+            "plane",
+            "planeFast",
+            "planeSlow",
+            "punch",
+            "punch2",
+            "radialMenu",
+            "radialMenu2",
+            "radio",
+            "ram",
+            "redo",
+            "reload",
+            "repeatRefresh",
+            "reset",
+            "rewind",
+            "rightArrow",
+            "rightArrow2",
+            "rightChevron",
+            "roll",
+            "run",
+            "select",
+            "selectAll",
+            "selectionWheel",
+            "sit",
+            "skateboard",
+            "skateboardGrab",
+            "skateboardGrind",
+            "skateboardJump",
+            "skateboardOllie",
+            "skateboardRampOver",
+            "slide",
+            "smallGridView",
+            "speaker",
+            "specialAbility",
+            "sprint",
+            "stealth",
+            "steering",
+            "stopwatch",
+            "subtract",
+            "surf",
+            "switchCamera",
+            "sword",
+            "sword2",
+            "sync",
+            "targetLock",
+            "team",
+            "teamAttack",
+            "throw",
+            "titleMenu",
+            "touch",
+            "undo",
+            "upArrow",
+            "upArrow2",
+            "upChevron",
+            "walk",
+            "waypoint",
+            "weaponSelect",
+            "zoomIn",
+            "zoomOut"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "FillColor": {
+      "title": "填充",
+      "description": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "markdownDescription": "此属性更改用于填充控件组件的颜色。如果省略，则使用最透明的白色填充。颜色必须按照`hex-color` CSS 规范指定为十六进制值，或者通过使用以`colors/`开头、后跟颜色名称的字符串来引用已知的系统颜色或布局颜色。有关详细信息，请参阅 https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color。",
+      "$ref": "#/$defs/_Color"
+    },
+    "Gradient": {
+      "title": "渐变",
+      "description": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
+      "markdownDescription": "渐变是一种从一种颜色到另一种颜色的混合。目前，仅允许从完全透明到提供的颜色值的渐变。",
+      "examples": [
+        {
+          "color": "#0099ffaa"
+        },
+        {
+          "color": {
+            "$ref": "#/definitions/commonColor"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonColorGradient"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "$ref": "#/$defs/Color"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Indicator": {
+      "title": "指示器样式组件",
+      "description": "用于指示控件的当前值或位置的笔划的视觉样式。",
+      "markdownDescription": "用于指示控件的当前值或位置的笔划的视觉样式。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "InnerLayoutControlWheel": {
+      "title": "内部",
+      "description": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件，通常通过从空间顶部开始并顺时针进行排列。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
+      "markdownDescription": "一组 1 到 4 个控件排列在控制轮内部段的组中。系统确定如何在可用空间内最佳地排列组中的控件，通常通过从空间顶部开始并顺时针进行排列。请注意，整个内部段的交互区域将在分配的控件之间平均划分。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "joystick",
+            "axis": {
+              "input": "axisXY",
+              "output": "leftJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Control"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InnerLayerControlWheel": {
+      "title": "内部",
+      "description": "一组 1 到 4 层控件，包括 `blank` 控件，用于在下方() 层隐藏控件，这些控件排列在控制轮内段的组中。系统确定如何在可用空间内最佳地排列组中的控件，通常通过从空间顶部开始并顺时针进行排列。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
+      "markdownDescription": "一组 1 到 4 层控件，包括 `blank` 控件，用于在下方() 层隐藏控件，这些控件排列在控制轮内段的组中。系统确定如何在可用空间内最佳地排列组中的控件，通常通过从空间顶部开始并顺时针进行排列。请注意，整个内部段的交互区域将在分配的控件之间平均划分。另请注意，如果来自下层的控件组的项数与此控制组的项数不同，则该层中的所有项都将被隐藏。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLeftInnerWheelForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LayerControl"
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveRange": {
+      "deprecated": true,
+      "title": "[已弃用]输入曲线范围",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义最小值和最大值。所有值均已规范化，因此必须介于 -1 和 1 之间。",
+      "examples": [
+        [
+          0,
+          0.33
+        ],
+        [
+          0,
+          1
+        ],
+        {
+          "$ref": "#/definitions/commonJoystickInputRange"
+        },
+        [
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMin"
+          },
+          {
+            "$ref": "#/definitions/commonJoystickInputRangeMax"
+          }
+        ]
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": -1,
+                "maximum": 1
+              },
+              {
+                "$ref": "#/$defs/Reference"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurve": {
+      "deprecated": true,
+      "title": "[已弃用]输入响应曲线",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中移除。此属性可定义输入如何映射到输出值的曲线或函数。一种类型的 `circular` 或 `circular-inverse` 可用于映射具有分别匹配右下象限或左上象限形状的圆形曲线的输入。如果省略此属性，则使用默认的线性映射。",
+      "examples": [
+        {
+          "type": "circular",
+          "range": [
+            0,
+            0.33
+          ]
+        },
+        {
+          "type": "circular-inverse",
+          "range": [
+            0,
+            1
+          ]
+        },
+        {
+          "$ref": "#/$defs/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/InputCurveRange"
+            },
+            "type": {
+              "$ref": "#/$defs/InputCurveType"
+            }
+          },
+          "required": [
+            "range",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "InputCurveType": {
+      "deprecated": true,
+      "title": "[已弃用]输入响应曲线类型",
+      "description": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。",
+      "markdownDescription": "⚠️ 已弃用: 此属性可能会更改行为或在将来的版本中删除。此属性定义要使用的曲线类型。`circular`类型可用于映射具有与圆的右下象限形状匹配的圆形曲线的输入。值`circular-inverse`可用于映射具有与圆的左上象限形状匹配的圆形曲线的输入。",
+      "examples": [
+        "circular",
+        "circular-inverse",
+        {
+          "$ref": "#/definitions/commonJoystickResponseCurve"
+        }
+      ],
+      "anyOf": [
+        {
+          "enum": [
+            "circular",
+            "circular-inverse"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickActivatedStyle": {
+      "title": "控件激活样式",
+      "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDefaultStyle": {
+      "title": "控件默认样式",
+      "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDirectionIndicator": {
+      "title": "方向指示器样式设置组件",
+      "description": "指示交互方向的视觉样式",
+      "markdownDescription": "指示交互方向的视觉样式",
+      "examples": [
+        {
+          "type": "color",
+          "value": "#0099ffaa"
+        },
+        {
+          "$ref": "#/definitions/commonIndicatorStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
+              "markdownDescription": "用于指定方向指示器是可以自定义其值的颜色类型的属性。",
+              "const": "color",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/Color"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickDisabledStyle": {
+      "title": "控件禁用样式",
+      "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickIdleStyle": {
+      "title": "控制空闲样式",
+      "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+      "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithoutIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickMovingStyle": {
+      "title": "控件移动样式",
+      "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+      "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+      "examples": [
+        {},
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomJoystickBackgroundImage"
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyle"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "outline": {
+              "$ref": "#/$defs/JoystickOutlineWithIndicator"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithIndicator": {
+      "title": "大纲样式组件",
+      "description": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+      "markdownDescription": "具有交互方向指示器的控件轮廓的视觉样式。处于其他状态的此属性可能不包括样式指示器的功能，因为未在这些状态下与控件进行交互。",
+      "examples": [
+        {
+          "indicator": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "indicator": {
+              "$ref": "#/$defs/JoystickDirectionIndicator"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickOutlineWithoutIndicator": {
+      "title": "大纲样式组件",
+      "description": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
+      "markdownDescription": "控件轮廓的视觉样式。在控件正在与之交互的其他状态下，此属性还可以包括为交互方向设置指示器样式的功能。",
+      "examples": [
+        {
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonOutlineStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "JoystickStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "background": {
+              "type": "asset",
+              "value": "CustomJoystickBackgroundImage"
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonJoystickStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "$ref": "#/$defs/JoystickActivatedStyle"
+            },
+            "default": {
+              "$ref": "#/$defs/JoystickDefaultStyle"
+            },
+            "disabled": {
+              "$ref": "#/$defs/JoystickDisabledStyle"
+            },
+            "idle": {
+              "$ref": "#/$defs/JoystickIdleStyle"
+            },
+            "moving": {
+              "$ref": "#/$defs/JoystickMovingStyle"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Knob": {
+      "title": "Knob 样式设置组件",
+      "description": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
+      "markdownDescription": "控件旋钮的视觉样式。旋钮是控件的交互点，它模仿实例的游戏杆顶部。",
+      "examples": [
+        {
+          "background": {
+            "type": "asset",
+            "value": "CustomKnobBackgroundImage"
+          },
+          "faceImage": {
+            "type": "asset",
+            "value": "CustomKnobFaceImage"
+          },
+          "stroke": {
+            "type": "solid",
+            "color": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonControlKnobStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layer": {
+      "title": "触摸布局层",
+      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "examples": [
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "throttle",
+                "axisUp": "rightTrigger",
+                "axisDown": "leftTrigger",
+                "sticky": true
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "left": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayerLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayerControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayerUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Layers": {
+      "title": "触摸布局层",
+      "description": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "markdownDescription": "此属性允许定义可用于控件`action`覆盖其他控件或更改布局内容以响应另一个控件上的玩家操作的自定义控件层。",
+      "examples": [
+        {
+          "AdvancedDrivingLayer": {
+            "left": {
+              "inner": [
+                {
+                  "type": "throttle",
+                  "axisUp": "rightTrigger",
+                  "axisDown": "leftTrigger",
+                  "sticky": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayersForDrivingLayouts"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$": {
+              "$ref": "#/$defs/Layer"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControl": {
+      "title": "触摸布局层控件",
+      "description": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
+      "markdownDescription": "玩家可以与其交互以执行一些翻译操作的当前层中的单个控件。有关特定控件类型及其用途的信息，请参阅`type`属性。图层添加特殊`blank`控件类型，以隐藏此控件下层的任何控件。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlGroup": {
+      "title": "触摸布局层控制组",
+      "description": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
+      "markdownDescription": "一组 1 到 4 层控件，包括`blank` 控件，用于隐藏下层中的控件，这些控件排列在一个组中。系统确定如何在可用空间内最好地排列组中的控件; 只有一个控件的组不同于未分组的控件，因为该组可能包含更大的总交互区域。请注意，特殊值 `null` 可用于跳过索引。另请注意，如果下层中的控件组具有与此控件组不同的项数，则该层中的所有项都将隐藏。",
+      "examples": [
+        [],
+        [
+          null,
+          {
+            "type": "blank"
+          },
+          null
+        ]
+      ],
+      "items": {
+        "$ref": "#/$defs/LayerControlGroupItem"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "LayerControlGroupItem": {
+      "title": "触摸布局层控件组项",
+      "description": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
+      "markdownDescription": "层控制组中的单个项。使用`null`跳过排列中的控件，或`blank`从下面的层隐藏控件。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonLayerButtonControl"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_LayerControlBase"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerControlWheel": {
+      "title": "触摸布局层控制轮",
+      "description": "一组以圆圈或滚轮形状组织的层控件。",
+      "markdownDescription": "一组以圆圈或滚轮形状组织的层控件。",
+      "examples": [
+        {
+          "inner": [
+            null,
+            {
+              "type": "blank"
+            }
+          ],
+          "outer": [
+            {
+              "type": "blank"
+            },
+            [
+              null,
+              {
+                "type": "blank"
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonWheelDefinitions"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayerControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayerControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerArrayContent": {
+      "title": "下层数组内容",
+      "description": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "markdownDescription": "此属性定义层的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerLowerContent": {
+      "title": "下层内容",
+      "description": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
+      "markdownDescription": "此属性定义固定到可用显示空间底部边缘的层的内容。此属性与布局内容的同一命名属性相同，只不过此属性还允许使用`blank`控件从此属性下的层隐藏控件。",
+      "examples": [
+        {
+          "center": {
+            "type": "blank"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "blank"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "blank"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayerLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/LayerControl"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayerLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerSensorContent": {
+      "title": "传感器层内容",
+      "description": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的层内容容器。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayerSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorLayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperContent": {
+      "title": "上层内容",
+      "description": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的层内容。此属性镜像主布局的上部区域，只不过它允许使用`blank`控件类型隐藏此图层下层的控件。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "blank"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayerUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayerUpperRightContent": {
+      "title": "上层右侧内容",
+      "description": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
+      "markdownDescription": "此属性定义固定到可用显示空间右上角的层内容。此属性镜像主布局的右上角区域，但允许使用`blank`控件类型隐藏此图层下层中的控件。",
+      "examples": [
+        [
+          {
+            "type": "blank"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightLayerControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LayerControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutActionTarget": {
+      "title": "布局操作目标",
+      "description": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
+      "markdownDescription": "此属性指定执行操作时要应用的层。此名称必须出现在布局内容的`layers`属性中。",
+      "examples": [
+        "WeaponSelectLayer",
+        "AdvancedDrivingLayer",
+        {
+          "$ref": "../../context.json#/state/playerAdvancedDrivingControlsPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?!__proto__)[a-zA-Z0-9\\.\\-_]+$"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutColors": {
+      "title": "颜色",
+      "description": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
+      "markdownDescription": "此属性定义由可在其他地方引用的颜色定义组成的调色板集合。对于每个样式变体，可以定义调色板。对于未在特定变量中定义的任何颜色，将使用`default`调色板或系统的默认值。颜色定义可以特定于布局的内容或覆盖系统的默认颜色。系统颜色以保留`system_`关键字为前缀。可以使用`colors/`前缀，后跟可用于样式的区域中的颜色名称来引用颜色。",
+      "examples": [
+        {},
+        {
+          "default": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#ff0000ff"
+          },
+          "highContrast": {
+            "system_contentPrimary": "#ffffffff",
+            "myColor": "#00ff00ff"
+          }
+        },
+        {
+          "$ref": "#/definitions/myColors"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ColorPaletteDefaultVariant"
+            },
+            "highContrast": {
+              "$ref": "#/$defs/ColorPaletteHighContrastVariant"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutContent": {
+      "title": "布局内容",
+      "description": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
+      "markdownDescription": "此属性定义布局的实际内容。布局中的内容根据显示位置组织到容器中，如`lower`显示。`left`和`right`区域是特殊位置，因为它们旨在位于玩家的拇指下方，并且可以由玩家移动和自定义，以便最适合他们的设备和首选播放方式。在每个容器控件中，如按钮，可以根据命名属性或子阵列直接指定或放置到子容器中。",
+      "examples": [
+        {},
+        {
+          "left": {
+            "inner": [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick"
+                }
+              }
+            ]
+          },
+          "right": {
+            "outer": [
+              {
+                "type": "button",
+                "action": "gamepadY"
+              }
+            ]
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "deprecated": true,
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "layers": {
+              "$ref": "#/$defs/Layers"
+            },
+            "left": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "lower": {
+              "$ref": "#/$defs/LayoutLowerContent"
+            },
+            "right": {
+              "$ref": "#/$defs/LayoutControlWheel"
+            },
+            "sensors": {
+              "$ref": "#/$defs/LayerSensorContent"
+            },
+            "upper": {
+              "$ref": "#/$defs/LayoutUpperContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutControlWheel": {
+      "title": "触摸布局控制轮",
+      "description": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
+      "markdownDescription": "以圆圈或滚轮形状组织起来的一组控件。默认情况下，这些滚轮控件位于屏幕右侧或左侧播放机的拇指下方，具体取决于布局内容中是否使用`right`或`left`属性。滚轮由一组内部控件以及一个控件外环组成。",
+      "examples": [
+        {},
+        {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadX"
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/commonControlWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "inner": {
+              "$ref": "#/$defs/InnerLayoutControlWheel"
+            },
+            "outer": {
+              "$ref": "#/$defs/OuterLayoutControlWheel"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutOrientation": {
+      "deprecated": true,
+      "title": "[已弃用]布局方向",
+      "description": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
+      "markdownDescription": "⚠️ 已弃用: 不再支持此属性。其值被忽略，所有布局都使用等效于`landscape`。",
+      "enum": [
+        "landscape-left",
+        "landscape-right",
+        "landscape",
+        "portrait-up",
+        "portrait"
+      ],
+      "type": "string"
+    },
+    "LayoutLowerArrayContent": {
+      "title": "下层布局数组内容",
+      "description": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "markdownDescription": "此属性定义布局的内容，该层是从可用显示区域的底部中心向外增长的数组。此属性与布局内容的同一命名属性相同，但此属性还允许使用`blank`控件从此内容下方层隐藏控件。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "dPadLeft"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerLeftCenterContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutLowerContent": {
+      "title": "下层布局内容",
+      "description": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
+      "markdownDescription": "此属性定义固定到可用显示空间的下边缘的布局的内容。沿下边缘的内容居中，向左边缘和右边缘向外增长。由于此内容位于显示中心，因此大型设备可能难以访问。因此，建议在此空间中放置较少使用的控件，例如切换相机模式或其他模式交换。",
+      "examples": [
+        {
+          "center": {
+            "type": "button",
+            "action": "dPadDown"
+          }
+        },
+        {
+          "leftCenter": [
+            {
+              "type": "button",
+              "action": "dPadLeft"
+            }
+          ],
+          "rightCenter": [
+            {
+              "type": "button",
+              "action": "dPadRight"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonLayoutLowerContent"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "center": {
+              "$ref": "#/$defs/Control"
+            },
+            "leftCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            },
+            "rightCenter": {
+              "$ref": "#/$defs/LayoutLowerArrayContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutSensorContent": {
+      "title": "传感器布局内容",
+      "description": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
+      "markdownDescription": "此属性定义使用设备的传感器输入作为交互的布局内容容器。",
+      "examples": [
+        [
+          {
+            "type": "gyroscope",
+            "axis": {
+              "input": "axisXY",
+              "output": "rightJoystick"
+            }
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonSensors"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SensorControl"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 4,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutStyles": {
+      "title": "布局样式",
+      "description": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "markdownDescription": "此属性定义可重用样式，这些样式可在整个布局中引用以用于样式。如果上下文文件中定义了等效的`styles`属性，则将合并每个属性的内容。如果发现重复的定义，则首选布局中的定义，覆盖上下文文件中的定义。",
+      "$ref": "#/$defs/_LayoutStyles"
+    },
+    "LayoutUpperContent": {
+      "title": "上层布局内容",
+      "description": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
+      "markdownDescription": "此属性定义固定到可用显示空间的上边缘的布局内容。目前，只有右上角空间可用于添加控件，因为左上角是为系统快速访问菜单保留的。由于右上角的内容在大型设备上无法轻松访问，因此此空间最适合用于仅需要间歇访问而非游戏过程中的控件，例如拉取暂停菜单或跳过电影时刻。",
+      "examples": [
+        {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonUpperControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "right": {
+              "$ref": "#/$defs/LayoutUpperRightContent"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "LayoutUpperRightContent": {
+      "title": "右上角布局内容",
+      "description": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
+      "markdownDescription": "此属性定义固定到可用显示空间右上角的布局内容。添加到此容器的控件从角开始，然后向内增长到屏幕顶部中心。",
+      "examples": [
+        [
+          {
+            "type": "button",
+            "action": "menu"
+          },
+          {
+            "type": "button",
+            "action": "view"
+          }
+        ],
+        {
+          "$ref": "../../context.json#/definitions/commonUpperRightControls"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Control"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "type": "array",
+          "maxItems": 5,
+          "minItems": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Opacity": {
+      "title": "不透明度",
+      "description": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
+      "markdownDescription": "此属性更改控件组件的透明性。如果省略，则使用默认值 1，表示控件完全不透明。",
+      "examples": [
+        1,
+        0.5,
+        0,
+        {
+          "$ref": "#/definitions/buttonOpacity"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayoutControlWheel": {
+      "title": "外部​​",
+      "description": "定义滚轮外环上存在的控件或控件组的外部环。此环中的项目按顺时针排列，从滚轮顶部开始。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
+      "markdownDescription": "定义滚轮外环上存在的控件或控件组的外部环。此环中的项目按顺时针排列，从滚轮顶部开始。每个索引可以是单个控件或控件数组。指定数组时，此控制组的交互空间将增加一倍，添加的任何控件都可能从滚轮中心向外扩展。外部轮总共有 8 个单个控件或 4 个控制组的空间。此项之外的任何控件都可能会被删除或导致验证规则失败。请注意，可以在外轮数组的开头使用 “null” 控件来偏移控制组;完成此操作后，仍可添加最终的单个控件。",
+      "examples": [
+        [],
+        [
+          null,
+          [
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ],
+          {
+            "type": "button",
+            "action": "gamepadY"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterLayerControlWheel": {
+      "title": "外部​​",
+      "description": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
+      "markdownDescription": "定义滚轮上的层控件和层控制组的外部环。此属性的行为与同一命名布局属性相同，但另外还允许`blank`控件在该属性下方层中隐藏控件。请注意，如果下层中的控件或控制组的项数与此层的相应索引的项数不同，则该层中的所有项都将被隐藏。就像在基本布局滚轮上一样，`null`可用于跳过控件或控制组。",
+      "examples": [
+        [],
+        [
+          {
+            "type": "blank"
+          },
+          [
+            null,
+            {
+              "type": "blank"
+            },
+            null
+          ],
+          {
+            "type": "button",
+            "action": "gamepadX"
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonLayerOuterWheel"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/OuterWheelLayerControlGroup"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "OuterWheelControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Control"
+        },
+        {
+          "$ref": "#/$defs/ControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "OuterWheelLayerControlGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LayerControl"
+        },
+        {
+          "$ref": "#/$defs/LayerControlGroup"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        }
+      ]
+    },
+    "PullActionType": {
+      "title": "控制拉取操作",
+      "description": "此属性允许单个操作、一个操作的数组同时执行，或在控件处于 `pulled` 状态时由该控件执行的多个已定义操作之一。这些操作可以映射到游戏板输入或更复杂的操作，例如在布局上显示新层。当此属性定义为类型为 `segmented` 的对象时，拉取操作环将划分为从控件顶部开始的相等序列，并顺时针进行。根据要拉取控件的确切位置，单个段将进入 `pulled` 状态。",
+      "markdownDescription": "此属性允许单个操作、一个操作的数组同时执行，或在控件处于 `pulled` 状态时由该控件执行的多个已定义操作之一。这些操作可以映射到游戏板输入或更复杂的操作，例如在布局上显示新层。当此属性定义为类型为 `segmented` 的对象时，拉取操作环将划分为从控件顶部开始的相等序列，并顺时针进行。根据要拉取控件的确切位置，单个段将进入 `pulled` 状态。",
+      "anyOf": [
+        {
+          "properties": {
+             "type":  { 
+              "const": "segmented",
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/_ActionTypeBase"
+              },
+              "maxItems": 4,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/_ActionTypeBase"
+        }
+      ]
+    },
+    "PullIndicator": {
+      "title": "拉动指示器样式组件",
+      "description": "当前正在拉取控件指示器的视觉样式。使用数组时，拉取指示器的类型必须是“分段”拉取指示器。在这种情况下，每个数组元素都与该段的样式相对应。",
+      "markdownDescription": "当前正在拉取控件指示器的视觉样式。使用数组时，拉取指示器的类型必须是“分段”拉取指示器。在这种情况下，每个数组元素都与该段的样式相对应。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        [
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          },
+          null,
+          {
+            "background": {
+              "type": "color",
+              "value": "#0099ffaa"
+            }
+          }
+        ],
+        [
+          {
+            "opacity": 0
+          }
+        ],
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PullIndicatorSegment"
+              },
+              {
+                "$ref": "#/$defs/_Null"
+              }
+            ]
+          },
+          "maxItems": 4,
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/PullIndicatorSegment"
+        }
+      ]
+    },
+    "PullIndicatorSegment": {
+      "title": "请求指示器字段样式设置组件",
+      "description": "该控件当前正按此段的方向拉取的指示器的视觉样式。可以自定义此内容的颜色，以指示拉取控件的语义以及自定义人脸图像以指示其操作语义。默认情况下，映射到拉取操作的任何一个游戏板操作都将将其游戏板函数指示为其人脸图像。",
+      "markdownDescription": "该控件当前正按此段的方向拉取的指示器的视觉样式。可以自定义此内容的颜色，以指示拉取控件的语义以及自定义人脸图像以指示其操作语义。默认情况下，映射到拉取操作的任何一个游戏板操作都将将其游戏板函数指示为其人脸图像。",
+      "examples": [
+        {
+          "background": {
+            "type": "color",
+            "value": "#0099ffaa"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonPullIndicator"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/PullIndicatorBackground"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "PullIndicatorBackground": {
+      "title": "背景样式组件",
+      "description": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+      "markdownDescription": "用于设置背景样式的颜色。使用颜色的确切形状取决于组件，因此无法进行自定义。",
+      "examples": [
+        {
+          "$ref": "#/definitions/commonPullIndicatorBackground"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_BackgroundColor"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RelativeInteraction": {
+      "title": "亲属",
+      "description": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
+      "markdownDescription": "此属性确定如何计算与控件的交互。交互是相对于交互开始的位置计算的，也可以是使用控件的中心以绝对方式计算。如果省略，则使用`true`的默认值来计算相对于交互起点的值。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerRelativeControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "RenderAsButton": {
+      "title": "呈现为按钮",
+      "description": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
+      "markdownDescription": "此属性导致控件以直观方式显示为按钮。如果省略，则使用默认值 `false`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "#/definitions/commonRenderAsButton"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Scale": {
+      "title": "扩展",
+      "description": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
+      "markdownDescription": "用于更改控件大小的乘数值。此值必须介于 0.5 和 2 之间。如果省略，则使用默认值 1。",
+      "examples": [
+        1,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerControlSizePreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sensitivity": {
+      "title": "灵敏度",
+      "description": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
+      "markdownDescription": "用于更改控件灵敏度的乘数值。此值必须大于 0。如果省略，则使用默认值 1。",
+      "examples": [
+        10,
+        1.5,
+        0.5,
+        {
+          "$ref": "../../context.json#/state/playerSensitivityPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorControl": {
+      "title": "传感器控件",
+      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。有关特定控件类型及其用途的信息，请参阅`type`属性。",
+      "examples": [
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "SensorLayerControl": {
+      "title": "层传感器控件",
+      "description": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "markdownDescription": "从设备的可用传感器进行交互并将其转换为输出的单个不可见控件。`blank`控件可用于从此控件下方层隐藏或关闭传感器控件。",
+      "examples": [
+        {
+          "type": "blank"
+        },
+        {
+          "$ref": "../../context.json#/definitions/commonGyroscopeControl"
+        }
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "accelerometer",
+            "gyroscope",
+            "blank"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_Accelerometer"
+        },
+        {
+          "$ref": "#/$defs/_Gyroscope"
+        },
+        {
+          "$ref": "#/$defs/_Blank"
+        },
+        {
+          "$ref": "#/$defs/_Null"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Sticky": {
+      "title": "精华",
+      "description": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
+      "markdownDescription": "当玩家停止与控件交互时，如果控件返回到中性位置，则此属性将发生更改。请注意，即使设置，粘滞限制也不会保留在`axisDown`区域中。例如，可以使用它来实现航海控制样式功能。如果省略，则使用默认值 `false`。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerCruiseControlPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Stroke": {
+      "title": "笔划样式组件",
+      "description": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
+      "markdownDescription": "控件组件笔划的视觉样式。笔划通常是用于显示控件部分范围的边框或轮廓。",
+      "$ref": "#/$defs/_StrokeBase"
+    },
+    "ThrottleAxisOutput": {
+      "title": "限制轴",
+      "description": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+      "markdownDescription": "此属性定义从玩家与控件的交互到指定输出的从中点到指定输出的单个映射。",
+      "examples": [
+        "rightTrigger",
+        "leftJoystickUp",
+        {
+          "$ref": "#/definitions/commonThrottleAxis"
+        }
+      ],
+      "anyOf": [
+        {
+          "$ref": "#/$defs/_ControllerAnalogMagnitudinalOutputType"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleAxisStyle": {
+      "title": "限制轴样式组件",
+      "description": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+      "markdownDescription": "限制轴组件的视觉样式。此组件向玩家显示可能输入的范围以及控件当前所在的区域，无论是向上还是向下。",
+      "examples": [
+        {
+          "cap": {
+            "type": "color",
+            "value": "#0099ffaa"
+          },
+          "stroke": {
+            "type": "solid",
+            "opacity": 1,
+            "color": "#0099ff"
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cap": {
+              "$ref": "#/$defs/AxisCap"
+            },
+            "stroke": {
+              "$ref": "#/$defs/Stroke"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyleBase": {
+      "examples": [
+        {
+          "axisUp": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "axisDown": {
+            "cap": {
+              "type": "color",
+              "value": "#0099ffaa"
+            },
+            "stroke": {
+              "type": "solid",
+              "opacity": 1,
+              "color": "#0099ff"
+            }
+          },
+          "knob": {
+            "background": {
+              "type": "asset",
+              "value": "CustomKnobBackgroundImage"
+            },
+            "faceImage": {
+              "type": "asset",
+              "value": "CustomKnobFaceImage"
+            },
+            "stroke": {
+              "type": "solid",
+              "color": "#0099ffaa"
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "axisUp": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "axisDown": {
+              "$ref": "#/$defs/ThrottleAxisStyle"
+            },
+            "indicator": {
+              "$ref": "#/$defs/Indicator"
+            },
+            "knob": {
+              "$ref": "#/$defs/Knob"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "ThrottleStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "axisUp": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "axisDown": {
+              "cap": {
+                "type": "color",
+                "value": "#0099ffaa"
+              },
+              "stroke": {
+                "type": "solid",
+                "opacity": 1,
+                "color": "#0099ff"
+              }
+            },
+            "knob": {
+              "background": {
+                "type": "asset",
+                "value": "CustomKnobBackgroundImage"
+              },
+              "faceImage": {
+                "type": "asset",
+                "value": "CustomKnobFaceImage"
+              },
+              "stroke": {
+                "type": "solid",
+                "color": "#0099ffaa"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonThrottleStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedUp": {
+              "title": "控件已激活向上样式",
+              "description": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
+              "markdownDescription": "控件处于`activatedUp`状态时使用的样式替代。`activatedUp`状态为与控件进行交互时，特别是在控件中心上方的区域中。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "activatedDown": {
+              "title": "控件已激活向下样式",
+              "description": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
+              "markdownDescription": "控件处于`activatedDown`状态时使用的样式替代。`activatedDown`状态为与控件进行交互时，特别是在控件中心下方的区域中。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "disabled": {
+              "title": "控件禁用样式",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            },
+            "idleUp": {
+              "title": "控制空闲向上样式",
+              "description": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
+              "markdownDescription": "控件处于`idleUp`状态时使用的样式替代。`idleUp`状态是未与控件交互，但控件的值仍保留在控件中心上方的区域中。仅当控件`sticky`时，才能达到此状态。",
+              "$ref": "#/$defs/ThrottleStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "Toggle": {
+      "title": "切换",
+      "description": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
+      "markdownDescription": "此属性将控件更改为切换控件。控件不再与之交互时不返回`idle`状态，而是转换为仍执行其操作的`toggled`状态。玩家再次与控件交互后，该控件将取消切换并返回到`idle`状态。",
+      "examples": [
+        true,
+        false,
+        {
+          "$ref": "../../context.json#/state/playerToggleCrouchPreference"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyleBase": {
+      "examples": [
+        {
+          "faceImage": {
+            "type": "icon",
+            "value": "look"
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadStyling"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "background": {
+              "$ref": "#/$defs/Background"
+            },
+            "faceImage": {
+              "$ref": "#/$defs/FaceImage"
+            },
+            "opacity": {
+              "$ref": "#/$defs/Opacity"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TouchpadStyles": {
+      "title": "控件样式",
+      "description": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "markdownDescription": "控件的视觉样式定义。对于控件的每个状态，可以重写样式。对于未在特定状态下自定义的任何元素，将使用`default`样式属性或系统的默认值作为控件样式的基础。系统仍可在特定状态下根据`default`样式修改控件的视觉对象，例如减少`disabled`状态的不透明度。",
+      "examples": [
+        {
+          "default": {
+            "faceImage": {
+              "type": "icon",
+              "value": "look"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/commonTouchpadControlStyles"
+        }
+      ],
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "activated": {
+              "title": "控件激活样式",
+              "description": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "markdownDescription": "控件处于`activated`状态时使用的样式替代。`activated`状态是与控件交互并且正在执行其操作的时间。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "default": {
+              "title": "控件默认样式",
+              "description": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "markdownDescription": "要应用于控件的默认样式参数。这些参数用于替代系统为控件提供的默认样式。通过指定特定状态的样式，可进一步重写视觉对象。请注意，在特定状态，如`disabled`，如果未提供特定样式，默认样式将用作回退，尽管可能会对该状态进行一些更改，例如减少整体不透明度以指示控件已禁用。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "disabled": {
+              "title": "控件禁用样式",
+              "description": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "markdownDescription": "控件处于`disabled`状态时使用的样式替代。在此状态下，即使玩家与控件交互时仍执行输出，控件仍可直观禁用。除非在此处显式重写，否则`default`样式配置中提供的值将用于减少整体控制不透明度，并且将隐藏任何交互指示器以显示控件已禁用。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "idle": {
+              "title": "控制空闲样式",
+              "description": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "markdownDescription": "控件处于`idle`状态时使用的样式替代。在此状态下，控件未与之交互，被视为中性或静态。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            },
+            "moving": {
+              "title": "控件移动样式",
+              "description": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+              "markdownDescription": "控件处于`moving`状态时使用的样式替代。`moving`状态是当控件正在交互，但尚未执行其操作时。在此状态下可以提供其他样式元素以指示交互的方向。",
+              "$ref": "#/$defs/TouchpadStyleBase"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Reference"
+        }
+      ]
+    },
+    "TurboActionInterval": {
+      "title": "间隔",
+      "description": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
+      "markdownDescription": "此属性以毫秒为单位定义在执行整体操作时打开和关闭分配的子操作的常规间隔或时间段。",
+      "examples": [
+        500,
+        1000
+      ],
+      "type": "number",
+      "exclusiveMinimum": 0
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "content": {
+      "$ref": "#/$defs/LayoutContent"
+    },
+    "styles": {
+      "$ref": "#/$defs/LayoutStyles"
+    },
+    "orientation": {
+      "$ref": "#/$defs/LayoutOrientation"
+    },
+    "definitions": {
+      "$ref": "#/$defs/Definitions"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
This change adds the layout and context v4.1 schemas that introduce a new type of pull button known as the 'segmented' pull action type. This type of button allows creators to create a button in which an action is triggered when pressed and up to 4 other actions are able to be added in when the player slides or drags to the edge of the button. Each pull action gets its own segment (piece of a donut) which can be styled to help inform players what will happen when pulling to that segment.